### PR TITLE
Prop for widget development setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+WEBPACK_BASE_DIR=web/

--- a/README.md
+++ b/README.md
@@ -128,6 +128,16 @@ docker-compose run php bin/console doctrine:migrations:migrate'
 
 ```
 
+How to develop the widget
+--------------
+
+With Docker
+```
+WEBPACK_BASE_DIR=widget-demo/ docker-compose up webpack
+```
+
+The widget demo will be accessible at `http://<docker_machine>:8080`
+
 Testing
 -------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     volumes:
       - './:/srv/coopcycle'
       - 'node_modules:/srv/coopcycle/node_modules'
+    environment:
+      WEBPACK_BASE_DIR: "${WEBPACK_BASE_DIR}"
 
   osrm:
     build: './docker/osrm'

--- a/docker/webpack/start.sh
+++ b/docker/webpack/start.sh
@@ -2,4 +2,4 @@
 
 cd /srv/coopcycle
 npm install
-webpack-dev-server --watch-poll --host 0.0.0.0 --content-base=web/
+webpack-dev-server --watch-poll --host 0.0.0.0 --content-base=$WEBPACK_BASE_DIR

--- a/js/widget/index.jsx
+++ b/js/widget/index.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDom from 'react-dom';
+
+class Widget extends React.Component {
+    render() {
+        return (<h1>Hello World</h1>);
+    };
+}
+
+var widget = {
+        render: (domElement, args) => {
+            ReactDom.render(<Widget />, domElement);
+        }
+    }
+
+export { widget };
+

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "beautifymarker": "git+https://git@github.com/alexsegura/BeautifyMarker.git",
     "card": "^2.1.1",
     "chart.js": "^2.4.0",
+    "coopcycle-js": "git+https://git@github.com/coopcycle/coopcycle-js.git",
     "deepmerge": "^1.3.2",
     "font-awesome": "^4.7.0",
     "fontawesome-markers": "^4.6.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,41 @@ else {
       cssFilename = "[name].css";
 }
 
+var loaders = [
+  {
+    test: /\.scss$/,
+    loader: ExtractTextPlugin.extract({
+      fallback: 'style-loader',
+      use: ['css-loader', 'sass-loader']
+    })
+  },
+  {
+    test: /\.css$/,
+    loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' })
+  },
+  {
+    test: /\.(eot|ttf|woff|woff2)$/,
+    loader: 'file-loader?name=css/fonts/[name].[ext]'
+  },
+  {
+    test: /\.(svg|png)$/,
+    loader: 'file-loader?name=css/images/[name].[ext]'
+  },
+  {
+    test: /\.jsx?/,
+    include: __dirname + '/js',
+    loader: "babel-loader"
+  }
+];
+
+var devServerConfig = {
+  headers: { "Access-Control-Allow-Origin": "*" },
+  contentBase: __dirname + '/web',
+  stats: 'minimal',
+  compress: true,
+  public: '192.168.99.100:8080'
+};
+
 var webpackConfig = {
   entry: {
     'css/styles': './assets/css/main.scss',
@@ -40,32 +75,7 @@ var webpackConfig = {
     }
   },
   module: {
-    loaders: [
-      {
-          test: /\.scss$/,
-          loader: ExtractTextPlugin.extract({
-            fallback: 'style-loader',
-            use: ['css-loader', 'sass-loader']
-          })
-      },
-      {
-          test: /\.css$/,
-          loader: ExtractTextPlugin.extract({ fallback: 'style-loader', use: 'css-loader' })
-      },
-      {
-          test: /\.(eot|ttf|woff|woff2)$/,
-          loader: 'file-loader?name=css/fonts/[name].[ext]'
-      },
-      {
-          test: /\.(svg|png)$/,
-          loader: 'file-loader?name=css/images/[name].[ext]'
-      },
-      {
-        test: /\.jsx?/,
-        include: __dirname + '/js',
-        loader: "babel-loader"
-      }
-    ]
+    loaders: loaders
   },
   // Use the plugin to specify the resulting filename (and add needed behavior to the compiler)
   plugins: [
@@ -75,13 +85,7 @@ var webpackConfig = {
         jQuery: "jquery"
       })
   ],
-  devServer: {
-      headers: { "Access-Control-Allow-Origin": "*" },
-      contentBase: __dirname + '/web',
-      stats: 'minimal',
-      compress: true,
-      public: '192.168.99.100:8080'
-  }
+  devServer: devServerConfig
 };
 
 if (process.env.NODE_ENV === 'production') {
@@ -90,4 +94,28 @@ if (process.env.NODE_ENV === 'production') {
   }));
 }
 
-module.exports = webpackConfig;
+var widgetConfig = {
+  entry: {
+    'js/widget': './js/widget/index.jsx'
+  },
+  output: {
+    library: 'CoopcycleWidget',
+    libraryTarget: 'umd',
+    publicPath: "/",
+    path: __dirname + '/web',
+    filename: 'js/widget.js'
+  },
+  module: {
+    loaders: loaders
+  },
+  plugins: [
+      new ExtractTextPlugin({filename: 'css/widget.css', allChunks: true}),
+  ],
+  devServer: devServerConfig
+};
+
+if (process.env.NODE_ENV === 'development') {
+  widgetConfig.output.path = __dirname + '/widget-demo';
+}
+
+module.exports = [webpackConfig, widgetConfig];

--- a/widget-demo/index.html
+++ b/widget-demo/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+</head>
+<body>
+    <h1>Coopcycle Widget Demo</h1>
+    <div id="widget-demo"></div>
+</body>
+    <script src="js/widget.js"></script>
+    <script>
+        CoopcycleWidget.widget.render(document.querySelector('#widget-demo'));
+    </script>
+</html>


### PR DESCRIPTION
Hey,

A proposal to develop the widget for external integration. I am not sure of all of the requirements and if it's the best solution.

In development:
 - `js/widget/index.jsx` is built in `widget-demo`
 - webpack-dev-server root is located at `./widget-demo`
 - we can test the widget by opening `<dev_ip>:8080`

In production:
 - `js/widget/index.jsx` is built in `js/widget.js`
 - we don't want to apply the `WebpackAssetsManifest` plugin to it (so our customers don't need to change the URL).

@alexsegura what do you think of this setup ?