### PR TITLE
Refactor menu entities

### DIFF
--- a/app/DoctrineMigrations/Version20171007174720.php
+++ b/app/DoctrineMigrations/Version20171007174720.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171007174720 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE TABLE menu_category (id SERIAL NOT NULL, description VARCHAR(255) DEFAULT NULL, name VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('INSERT INTO menu_category (id, name) SELECT id, name FROM menu_section_base');
+
+        $this->addSql('ALTER TABLE menu_section DROP CONSTRAINT fk_a5a86751f98e57a8');
+        $this->addSql('DROP SEQUENCE menu_section_base_id_seq CASCADE');
+        $this->addSql('DROP TABLE menu_section_base');
+        $this->addSql('DROP INDEX idx_a5a86751f98e57a8');
+        $this->addSql('ALTER TABLE menu_section RENAME COLUMN menu_section_id TO menu_category_id');
+        $this->addSql('ALTER TABLE menu_section ADD CONSTRAINT FK_A5A867517ABA83AE FOREIGN KEY (menu_category_id) REFERENCES menu_category (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_A5A867517ABA83AE ON menu_section (menu_category_id)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE menu_section DROP CONSTRAINT FK_A5A867517ABA83AE');
+        $this->addSql('CREATE SEQUENCE menu_section_base_id_seq INCREMENT BY 1 MINVALUE 1 START 1');
+        $this->addSql('CREATE TABLE menu_section_base (id SERIAL NOT NULL, description VARCHAR(255) DEFAULT NULL, name VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('DROP TABLE menu_category');
+        $this->addSql('DROP INDEX IDX_A5A867517ABA83AE');
+        $this->addSql('ALTER TABLE menu_section RENAME COLUMN menu_category_id TO menu_section_id');
+        $this->addSql('ALTER TABLE menu_section ADD CONSTRAINT fk_a5a86751f98e57a8 FOREIGN KEY (menu_section_id) REFERENCES menu_section_base (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX idx_a5a86751f98e57a8 ON menu_section (menu_section_id)');
+    }
+}

--- a/app/DoctrineMigrations/Version20171009105937.php
+++ b/app/DoctrineMigrations/Version20171009105937.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171009105937 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE menu_section ADD name VARCHAR(255) DEFAULT NULL');
+        $this->addSql('UPDATE menu_section SET name = menu_category.name FROM menu_category WHERE menu_category.id = menu_section.menu_category_id');
+
+        $this->addSql('ALTER TABLE menu_section DROP CONSTRAINT fk_a5a867517aba83ae');
+        $this->addSql('DROP INDEX idx_a5a867517aba83ae');
+        $this->addSql('ALTER TABLE menu_section DROP menu_category_id');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE menu_section ADD menu_category_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE menu_section DROP name');
+        $this->addSql('ALTER TABLE menu_section ADD CONSTRAINT fk_a5a867517aba83ae FOREIGN KEY (menu_category_id) REFERENCES menu_category (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX idx_a5a867517aba83ae ON menu_section (menu_category_id)');
+    }
+}

--- a/features/fixtures/ORM/restaurants.yml
+++ b/features/fixtures/ORM/restaurants.yml
@@ -6,14 +6,6 @@ AppBundle\Entity\Base\GeoCoordinates:
   geo_3:
     __construct: [ "48.878658", "2.341055" ]
 
-AppBundle\Entity\MenuSection:
-  menu_section_appetizers:
-    name: Appetizers
-  menu_section_dishes:
-    name: Dishes
-  menu_section_desserts:
-    name: Desserts
-
 AppBundle\Entity\Menu\MenuItem:
   menu_item_{1..9}:
     name: <name()>
@@ -21,16 +13,16 @@ AppBundle\Entity\Menu\MenuItem:
 
 AppBundle\Entity\Menu\MenuSection:
   menu_section_1:
-    menuSection: "@menu_section_appetizers"
+    name: "Appetizers"
     items: [ "@menu_item_1", "@menu_item_2" ]
   menu_section_2:
-    menuSection: "@menu_section_dishes"
+    name: "Dishes"
     items: [ "@menu_item_3", "@menu_item_4" ]
   menu_section_3:
-    menuSection: "@menu_section_appetizers"
+    name: "Appetizers"
     items: [ "@menu_item_5", "@menu_item_6" ]
   menu_section_4:
-    menuSection: "@menu_section_dishes"
+    name: "Dishes"
     items: [ "@menu_item_7", "@menu_item_8" ]
 
 AppBundle\Entity\Menu:

--- a/features/restaurants.feature
+++ b/features/restaurants.feature
@@ -86,14 +86,12 @@ Feature: Manage restaurants
             "@id":"@string@.startsWith('/api/menu_sections')",
             "@type":"http://schema.org/MenuSection",
             "hasMenuItem":@array@,
-            "description":null,
             "name":@string@
           },
           {
             "@id":"@string@.startsWith('/api/menu_sections')",
             "@type":"http://schema.org/MenuSection",
             "hasMenuItem":@array@,
-            "description":null,
             "name":@string@
           }
         ],

--- a/src/AppBundle/Command/InitDemoCommand.php
+++ b/src/AppBundle/Command/InitDemoCommand.php
@@ -18,7 +18,6 @@ class InitDemoCommand extends ContainerAwareCommand
     private $doctrine;
     private $faker;
     private $fixturesLoader;
-    private $menuSections = [];
     private $client;
     private $redis;
 
@@ -110,19 +109,18 @@ class InitDemoCommand extends ContainerAwareCommand
         $this->userManipulator->addRole($username, 'ROLE_COURIER');
     }
 
-    private function createMenuSection($name)
+    private function createMenuCategory($name)
     {
-        $menuSection = new Entity\MenuSection();
-        $menuSection->setName($name);
+        $category = new Entity\Menu\MenuCategory();
+        $category->setName($name);
 
-        $this->doctrine->getManagerForClass(Entity\MenuSection::class)->persist($menuSection);
+        $this->doctrine->getManagerForClass(Entity\Menu\MenuCategory::class)->persist($category);
 
-        return $menuSection;
+        return $category;
     }
 
     private function createMenu()
     {
-        $this->fixturesLoader->setReferences($this->menuSections);
         $objects = $this->fixturesLoader->load(__DIR__ . '/Resources/menu.yml');
 
         return $objects['menu'];
@@ -142,11 +140,10 @@ class InitDemoCommand extends ContainerAwareCommand
 
     private function createRestaurants(OutputInterface $output)
     {
-        $this->menuSections = [
-            'menu_section_appetizers' => $this->createMenuSection('Entrées'),
-            'menu_section_dishes' => $this->createMenuSection('Plats'),
-            'menu_section_desserts' => $this->createMenuSection('Desserts'),
-        ];
+        foreach (['Entrées', 'Plats', 'Desserts'] as $name) {
+            $this->createMenuCategory($name);
+        }
+        $this->doctrine->getManagerForClass(Entity\Menu\MenuCategory::class)->flush();
 
         for ($i = 0; $i < 100; $i++) {
             $restaurant = $this->createRestaurant($this->faker->randomAddress);

--- a/src/AppBundle/Command/Resources/menu.yml
+++ b/src/AppBundle/Command/Resources/menu.yml
@@ -12,13 +12,13 @@ AppBundle\Entity\Menu\MenuItem:
 
 AppBundle\Entity\Menu\MenuSection:
   menu_section_1:
-    menuSection: "@menu_section_appetizers"
+    name: "Entrées"
     items: [ "@appetizers_1", "@appetizers_2", "@appetizers_3", "@appetizers_4", "@appetizers_5" ]
   menu_section_2:
-    menuSection: "@menu_section_dishes"
+    name: "Plats"
     items: [ "@dishes_1", "@dishes_2", "@dishes_3", "@dishes_4", "@dishes_5" ]
   menu_section_3:
-    menuSection: "@menu_section_desserts"
+    name: "Desserts"
     items: [ "@desserts_1", "@desserts_2", "@desserts_3", "@desserts_4", "@desserts_5" ]
 
 AppBundle\Entity\Menu:

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -3,11 +3,13 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Utils\Cart;
-use AppBundle\Entity\Delivery;
 use AppBundle\Entity\Base\GeoCoordinates;
+use AppBundle\Entity\Delivery;
+use AppBundle\Entity\Menu;
 use AppBundle\Entity\Order;
 use AppBundle\Entity\Restaurant;
 use AppBundle\Form\DeliveryType;
+use AppBundle\Form\MenuCategoryType;
 use AppBundle\Form\RestaurantMenuType;
 use AppBundle\Form\RestaurantType;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -346,5 +348,44 @@ class AdminController extends Controller
         if ($request->isMethod('POST')) {
             return $this->cancelOrder($id, 'admin_orders');
         }
+    }
+
+    /**
+     * @Route("/admin/menu/categories", name="admin_menu_categories")
+     * @Template
+     */
+    public function menuCategoriesAction(Request $request)
+    {
+        $categories = $this->getDoctrine()
+            ->getRepository(Menu\MenuCategory::class)
+            ->findBy([], ['name' => 'ASC']);
+
+        return [
+            'categories' => $categories,
+        ];
+    }
+
+    /**
+     * @Route("/admin/menu/categories/new", name="admin_menu_category_new")
+     * @Template
+     */
+    public function newMenuCategoryAction(Request $request)
+    {
+        $category = new Menu\MenuCategory();
+
+        $form = $this->createForm(MenuCategoryType::class, $category);
+
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $category = $form->getData();
+            $this->getDoctrine()->getManagerForClass(Menu\MenuCategory::class)->persist($category);
+            $this->getDoctrine()->getManagerForClass(Menu\MenuCategory::class)->flush();
+
+            return $this->redirectToRoute('admin_menu_categories');
+        }
+
+        return [
+            'form' => $form->createView(),
+        ];
     }
 }

--- a/src/AppBundle/Controller/RestaurantTrait.php
+++ b/src/AppBundle/Controller/RestaurantTrait.php
@@ -4,7 +4,6 @@ namespace AppBundle\Controller;
 
 use AppBundle\Entity\Restaurant;
 use AppBundle\Entity\Menu;
-use AppBundle\Entity\MenuSection;
 use AppBundle\Form\RestaurantMenuType;
 use AppBundle\Form\MenuType;
 use AppBundle\Form\RestaurantType;
@@ -69,7 +68,7 @@ trait RestaurantTrait
         ];
     }
 
-    private function createMenuForm(Menu $menu, MenuSection $sectionAdded = null)
+    private function createMenuForm(Menu $menu, Menu\MenuSection $sectionAdded = null)
     {
         $form = $this->createForm(MenuType::class, $menu, [
             'section_added' => $sectionAdded,
@@ -107,7 +106,8 @@ trait RestaurantTrait
         $sectionAdded = null;
 
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)->find($id);
+            ->getRepository(Restaurant::class)
+            ->find($id);
 
         $this->checkAccess($restaurant);
 
@@ -136,10 +136,11 @@ trait RestaurantTrait
             $menu = $form->getData();
 
             if ($addMenuSection) {
-                $sectionAdded = $form->get('addSection')->getData();
+                $sectionAdded = new Menu\MenuSection();
+                $sectionAdded->setName($form->get('addSection')->getData());
+
                 $menu->addSection($sectionAdded);
 
-                $form = $this->createMenuForm($menu, $sectionAdded);
             } else {
 
                 // Make sure sections & items are mapped
@@ -198,7 +199,10 @@ trait RestaurantTrait
                 $this->get('translator')->trans('Your changes were saved.')
             );
 
-            if (!$addMenuSection) {
+            if ($addMenuSection) {
+                $em->refresh($menu);
+                $form = $this->createMenuForm($menu, $sectionAdded);
+            } else {
                 return $this->redirectToRoute($routes['success'], ['id' => $restaurant->getId()]);
             }
         }

--- a/src/AppBundle/Entity/Base/MenuItem.php
+++ b/src/AppBundle/Entity/Base/MenuItem.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Entity;
+namespace AppBundle\Entity\Base;
 
 use AppBundle\Entity\Base\Thing;
 use Doctrine\ORM\Mapping as ORM;
@@ -73,6 +73,4 @@ abstract class MenuItem extends Thing
     {
         return $this->price;
     }
-
-
 }

--- a/src/AppBundle/Entity/Menu/MenuCategory.php
+++ b/src/AppBundle/Entity/Menu/MenuCategory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Entity;
+namespace AppBundle\Entity\Menu;
 
 use AppBundle\Entity\Base\CreativeWork;
 use Doctrine\ORM\Mapping as ORM;
@@ -12,15 +12,10 @@ use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Validator\Constraints as Assert;
 
 /**
- * A sub-grouping of food or drink items in a menu. E.g. courses (such as 'Dinner', 'Breakfast', etc.), specific type of dishes (such as 'Meat', 'Vegan', 'Drinks', etc.), or some other classification made by the menu provider.
- *
- * @see http://schema.org/MenuSection Documentation on Schema.org
- *
  * @ORM\Entity
- * @ORM\Table(name="menu_section_base")
+ * @ORM\Table(name="menu_category")
  * @ApiResource(
- *  shortName="MenuSectionBase",
- *  iri="http://schema.org/MenuSection",
+ *  shortName="MenuCategory",
  *  attributes={
  *    "normalization_context"={"groups"={"restaurant"}}
  *  },
@@ -29,7 +24,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  *    "get"={"method"="GET"}
  *  })
  */
-class MenuSection extends CreativeWork
+class MenuCategory extends CreativeWork
 {
     /**
      * @var int

--- a/src/AppBundle/Entity/Menu/MenuItem.php
+++ b/src/AppBundle/Entity/Menu/MenuItem.php
@@ -4,7 +4,7 @@ namespace AppBundle\Entity\Menu;
 
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
-use AppBundle\Entity\MenuItem as BaseMenuItem;
+use AppBundle\Entity\Base\MenuItem as BaseMenuItem;
 use AppBundle\Entity\Menu\MenuItemModifier;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;

--- a/src/AppBundle/Entity/Menu/MenuSection.php
+++ b/src/AppBundle/Entity/Menu/MenuSection.php
@@ -4,7 +4,7 @@ namespace AppBundle\Entity\Menu;
 
 use AppBundle\Entity\Base\CreativeWork;
 use AppBundle\Entity\Menu;
-use AppBundle\Entity\MenuItem;
+use AppBundle\Entity\Base\MenuItem;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;

--- a/src/AppBundle/Entity/Menu/MenuSection.php
+++ b/src/AppBundle/Entity/Menu/MenuSection.php
@@ -5,15 +5,20 @@ namespace AppBundle\Entity\Menu;
 use AppBundle\Entity\Base\CreativeWork;
 use AppBundle\Entity\Menu;
 use AppBundle\Entity\Base\MenuItem;
+use AppBundle\Entity\Model\Name\MethodsTrait as NameMethods;
 use Doctrine\ORM\Mapping as ORM;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Criteria;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use Symfony\Component\Serializer\Annotation\Groups;
-use Symfony\Component\Validator\Constraints as Assert;
 
 /**
+ * A sub-grouping of food or drink items in a menu. E.g. courses (such as 'Dinner', 'Breakfast', etc.),
+ * specific type of dishes (such as 'Meat', 'Vegan', 'Drinks', etc.), or some other classification made by the menu provider.
+ *
+ * @see http://schema.org/MenuSection Documentation on Schema.org
+ *
  * @ORM\Entity
  * @ORM\Table(name="menu_section")
  * @ApiResource(
@@ -39,18 +44,21 @@ class MenuSection
     private $id;
 
     /**
+     * @var string The name of the section
+     *
+     * @ORM\Column(nullable=true)
+     * @ApiProperty(iri="http://schema.org/name")
+     * @Groups({"restaurant"})
+     */
+    protected $name;
+
+    use NameMethods;
+
+    /**
      * @ORM\ManyToOne(targetEntity="AppBundle\Entity\Menu", inversedBy="sections")
      * @ORM\JoinColumn(name="menu_id", referencedColumnName="id")
      */
     private $menu;
-
-    /**
-     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\MenuSection")
-     * @ORM\JoinColumn(name="menu_section_id", referencedColumnName="id")
-     * @ApiProperty(iri="https://schema.org/MenuSection")
-     * @Groups({"restaurant"})
-     */
-    private $menuSection;
 
     /**
      * @ORM\OneToMany(targetEntity="AppBundle\Entity\Menu\MenuItem", mappedBy="section", cascade={"all"})
@@ -72,11 +80,6 @@ class MenuSection
     public function getId()
     {
         return $this->id;
-    }
-
-    public function getName()
-    {
-        return isset($this->menuSection) ? $this->menuSection->getName() : null;
     }
 
     public function getItems()
@@ -106,18 +109,6 @@ class MenuSection
     public function setMenu(Menu $menu = null)
     {
         $this->menu = $menu;
-
-        return $this;
-    }
-
-    public function getMenuSection()
-    {
-        return $this->menuSection;
-    }
-
-    public function setMenuSection($menuSection)
-    {
-        $this->menuSection = $menuSection;
 
         return $this;
     }

--- a/src/AppBundle/Entity/Menu/Modifier.php
+++ b/src/AppBundle/Entity/Menu/Modifier.php
@@ -3,7 +3,7 @@
 
 namespace AppBundle\Entity\Menu;
 use ApiPlatform\Core\Annotation\ApiResource;
-use AppBundle\Entity\MenuItem as BaseMenuItem;
+use AppBundle\Entity\Base\MenuItem as BaseMenuItem;
 use Doctrine\ORM\Mapping as ORM;
 
 

--- a/src/AppBundle/Entity/Model/Name/MethodsTrait.php
+++ b/src/AppBundle/Entity/Model/Name/MethodsTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AppBundle\Entity\Model\Name;
+
+trait MethodsTrait
+{
+    /**
+     * Sets name.
+     *
+     * @param string $name
+     *
+     * @return $this
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Gets name.
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+}

--- a/src/AppBundle/Entity/Order.php
+++ b/src/AppBundle/Entity/Order.php
@@ -2,8 +2,8 @@
 
 namespace AppBundle\Entity;
 
-
 use AppBundle\Entity\Menu\Modifier;
+use AppBundle\Entity\Base\MenuItem;
 use AppBundle\Utils\CartItem;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;

--- a/src/AppBundle/Form/MenuCategoryType.php
+++ b/src/AppBundle/Form/MenuCategoryType.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Entity\Menu;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class MenuCategoryType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name', TextType::class)
+            ->add('description', TextareaType::class, ['required' => false])
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => Menu\MenuCategory::class,
+        ));
+    }
+}

--- a/src/AppBundle/Form/MenuType.php
+++ b/src/AppBundle/Form/MenuType.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Form;
 
 use AppBundle\Entity\Menu;
-use AppBundle\Entity\MenuSection;
 use AppBundle\Form\MenuType\MenuSectionType;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
@@ -13,6 +12,7 @@ use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class MenuType extends AbstractType
@@ -20,7 +20,21 @@ class MenuType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('sections', CollectionType::class, [
+            ->add('addSection', TextType::class, array(
+                'mapped' => false,
+                'required' => false,
+            ))
+            ->add('suggestions', EntityType::class, array(
+                'mapped' => false,
+                'class' => Menu\MenuCategory::class,
+                'choice_label' => 'name',
+                'query_builder' => function (EntityRepository $er) {
+                    return $er->createQueryBuilder('s')->orderBy('s.name', 'ASC');
+                }
+            ));
+
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($options) {
+            $event->getForm()->add('sections', CollectionType::class, [
                 'entry_type' => MenuSectionType::class,
                 'allow_add' => true,
                 'allow_delete' => true,
@@ -30,29 +44,6 @@ class MenuType extends AbstractType
                     'data-section-added' => $options['section_added'] ? $options['section_added']->getId() : ''
                 ],
             ]);
-
-        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) use ($options) {
-            $menu = $event->getData();
-            $form = $event->getForm();
-
-            $menuSectionIds = [];
-            foreach ($menu->getSections() as $section) {
-                $menuSectionIds[] = $section->getMenuSection()->getId();
-            }
-
-            $form->add('addSection', EntityType::class, array(
-                'mapped' => false,
-                'class' => 'AppBundle:MenuSection',
-                'choice_label' => 'name',
-                'query_builder' => function (EntityRepository $er) use ($menuSectionIds) {
-                    $qb = $er->createQueryBuilder('s');
-                    if (count($menuSectionIds) > 0) {
-                        $qb->where($qb->expr()->notIn('s.id', $menuSectionIds));
-                    }
-
-                    return $qb->orderBy('s.name', 'ASC');
-                }
-            ));
         });
     }
 
@@ -60,7 +51,7 @@ class MenuType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => Menu::class,
-            'section_added' => null
+            'section_added' => null,
         ));
     }
 }

--- a/src/AppBundle/Form/MenuType.php
+++ b/src/AppBundle/Form/MenuType.php
@@ -4,7 +4,6 @@ namespace AppBundle\Form;
 
 use AppBundle\Entity\Menu;
 use AppBundle\Entity\MenuSection;
-use AppBundle\Entity\MenuItem;
 use AppBundle\Form\MenuType\MenuSectionType;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;

--- a/src/AppBundle/Resources/config/serialization.yml
+++ b/src/AppBundle/Resources/config/serialization.yml
@@ -7,7 +7,7 @@ AppBundle\Entity\ApiUser:
     addresses:
       groups: ['user']
 
-AppBundle\Entity\MenuItem:
+AppBundle\Entity\Base\MenuItem:
   attributes:
     offers:
       groups: ['restaurant']

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -78,6 +78,7 @@ Accept: Accepter
 Delivery service: Service de livraison
 Waiting: En attente
 No orders yet: Pas de commande pour le moment
+Appetizers, Dishes…: Entrées, Plats…
 
 delivery_service.applicolis: AppliColis
 

--- a/src/AppBundle/Resources/views/Admin/menuCategories.html.twig
+++ b/src/AppBundle/Resources/views/Admin/menuCategories.html.twig
@@ -1,0 +1,23 @@
+{% extends "AppBundle::admin.html.twig" %}
+
+{% block breadcrumb %}
+<li>{% trans %}Menu{% endtrans %}</li>
+<li>{% trans %}Categories{% endtrans %}</li>
+{% endblock %}
+
+{% block content %}
+<table class="table">
+<tbody>
+{% for category in categories %}
+<tr>
+  <td>#{{ category.id }}</td>
+  <td>{{ category.name }}</td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+<a href="{{ path('admin_menu_category_new') }}" class="btn btn-success">{% trans %}Add category{% endtrans %}</a>
+{% endblock %}
+
+{% block scripts %}
+{% endblock %}

--- a/src/AppBundle/Resources/views/Admin/newDelivery.html.twig
+++ b/src/AppBundle/Resources/views/Admin/newDelivery.html.twig
@@ -30,7 +30,7 @@
 
   <div class="form-group">
     <div class="col-sm-offset-2 col-sm-10">
-      <button type="submit" class="btn btn-block btn-primary">Valider</button>
+      <button type="submit" class="btn btn-block btn-primary">{% trans %}Save{% endtrans %}</button>
     </div>
   </div>
 

--- a/src/AppBundle/Resources/views/Admin/newMenuCategory.html.twig
+++ b/src/AppBundle/Resources/views/Admin/newMenuCategory.html.twig
@@ -1,0 +1,19 @@
+{% extends "AppBundle::admin.html.twig" %}
+{% form_theme form 'bootstrap_3_layout.html.twig' %}
+
+{% block breadcrumb %}
+<li>{% trans %}Menu{% endtrans %}</li>
+<li>{% trans %}Categories{% endtrans %}</li>
+<li>{% trans %}Add{% endtrans %}</li>
+{% endblock %}
+
+{% block content %}
+{{ form_start(form) }}
+  {{ form_row(form.name) }}
+  {{ form_row(form.description) }}
+  <button type="submit" class="btn btn-block btn-primary">{% trans %}Save{% endtrans %}</button>
+{{ form_end(form) }}
+{% endblock %}
+
+{% block scripts %}
+{% endblock %}

--- a/src/AppBundle/Resources/views/Form/menu.html.twig
+++ b/src/AppBundle/Resources/views/Form/menu.html.twig
@@ -1,15 +1,25 @@
 {% extends 'bootstrap_3_layout.html.twig' %}
 
 {% block _menu_addSection_row %}
-{% if form.vars.choices|length > 0 %}
 <div class="form-group row">
   <div class="col-sm-9">
-    {{ form_widget(form) }}
+    {{ form_widget(form, { attr: { placeholder: 'Appetizers, Dishes…'|trans([], 'messages') } }) }}
   </div>
   <div class="col-sm-3">
     <button type="button" class="btn btn-success pull-right" id="add-menu-section">
       {% trans from 'messages' %}Add section{% endtrans %}
     </button>
+  </div>
+</div>
+{% endblock %}
+
+{% block _menu_suggestions_row %}
+{% if form.vars.choices|length > 0 %}
+<div id="{{ form.vars.id }}" class="form-group row">
+  <div class="col-sm-12">
+    <label>Suggestions</label>   {% for choice in form.vars.choices %}
+      <a class="btn btn-xs btn-default" href="#">{{ choice.data.name }}</a>
+    {% endfor %}
   </div>
 </div>
 {% endif %}
@@ -21,7 +31,7 @@
   {% set headingSelector = form.vars.id ~ '_heading' %}
   {% set collapseSelector = form.vars.id ~ '_collapse' %}
 
-  <div id="{{ form.vars.id }}" class="panel panel-default" data-menu-section-id="{{ form.vars.value.menuSection.id }}">
+  <div id="{{ form.vars.id }}" class="panel panel-default" data-section-id="{{ form.vars.value.id }}">
 
     <div class="panel-heading" role="tab" id="{{ headingSelector }}">
       <h4 class="panel-title">

--- a/src/AppBundle/Resources/views/Restaurant/form-menu.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/form-menu.html.twig
@@ -24,9 +24,9 @@
 </div>
 
 {{ form_start(form) }}
-  <div id="add-section-wrapper">
   {{ form_row(form.addSection) }}
-  </div>
+  {{ form_row(form.suggestions) }}
+  <hr>
   {{ form_row(form.sections, { attr: {
     class: 'panel-group',
     role: 'tablist'
@@ -132,6 +132,11 @@ $(function() {
     });
   });
 
+  $('#menu_suggestions a').on('click', function(e) {
+    e.preventDefault();
+    $('#menu_addSection').val($(this).text());
+  });
+
   $(document).on('show.bs.collapse', '[role="tabpanel"] .list-group-item .collapse', function () {
     $(this).closest('.list-group-item').find('.show-description').remove();
   });
@@ -157,16 +162,14 @@ $(function() {
       $('#menu_sections').replaceWith(
         $(html).find('#menu_sections')
       );
-      $('#add-section-wrapper').replaceWith(
-        $(html).find('#add-section-wrapper')
-      );
       autoDismissMessages();
 
       var sectionAdded = $('#menu_sections').data('section-added');
       if (sectionAdded) {
-        var $el = $('[data-menu-section-id="' + sectionAdded + '"]');
+        var $el = $('[data-section-id="' + sectionAdded + '"]');
         addForm($('#' + $el.attr('id') + '_items'));
-        $('#menu_sections').removeAttr('data-section-added')
+        $('#menu_sections').removeAttr('data-section-added');
+        $('#menu_addSection').val('');
       }
     })
     .catch(function(e) {

--- a/src/AppBundle/Resources/views/Restaurant/form.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/form.html.twig
@@ -27,7 +27,7 @@
       <div class="nav navbar-nav navbar-right">
         {% if restaurant.id is not empty %}
         <a href="{{ path(menu_route, { id: restaurant.id }) }}" class="btn btn-default navbar-btn">
-          <i class="fa fa-cutlery"></i>  {% trans %}Edit menu{% endtrans %}
+          <i class="fa fa-cutlery"></i>  {% trans %}Menu{% endtrans %}
         </a>
         <a href="{{ path(orders_route, { id: restaurant.id }) }}" class="btn btn-default navbar-btn">
           <i class="fa fa-cube"></i>  {% trans %}Orders{% endtrans %}

--- a/src/AppBundle/Resources/views/admin.html.twig
+++ b/src/AppBundle/Resources/views/admin.html.twig
@@ -22,6 +22,17 @@
           <li><a href="{{ path('admin_deliveries') }}"><i class="fa fa-bicycle"></i>  {% trans %}Deliveries{% endtrans %}</a></li>
           <li><a href="{{ path('admin_restaurants') }}"><i class="fa fa-cutlery"></i>  {% trans %}Restaurants{% endtrans %}</a></li>
           <li><a href="{{ path('admin_users') }}"><i class="fa fa-user"></i>  {% trans %}Users{% endtrans %}</a></li>
+          {% if is_granted('ROLE_ADMIN') %}
+          <li class="dropdown">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+              <i class="fa fa-cog"></i>  {% trans %}Settings{% endtrans %} <span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu">
+              <li class="dropdown-header">Menu</li>
+              <li><a href="{{ path('admin_menu_categories') }}">{% trans %}Categories{% endtrans %}</a></li>
+            </ul>
+          </li>
+          {% endif %}
         </ul>
       </div>
     </div>

--- a/src/AppBundle/Serializer/MenuSectionNormalizer.php
+++ b/src/AppBundle/Serializer/MenuSectionNormalizer.php
@@ -23,10 +23,6 @@ class MenuSectionNormalizer implements NormalizerInterface, DenormalizerInterfac
         $data['hasMenuItem'] = $data['items'];
         unset($data['items']);
 
-        $data['name'] = $data['menuSection']['name'];
-        $data['description'] = $data['menuSection']['description'];
-        unset($data['menuSection']);
-
         return $data;
     }
 


### PR DESCRIPTION
Naming things is hard 🙂

All menu subclasses have been moved to the `Entity\Menu` namespace. 
Now `Entity\MenuSection` is `Entity\Menu\MenuCategory`, which makes more sense.

Fixes #84 
Fixes #57