### PR TITLE
Introduce delivery pricing

### DIFF
--- a/app/DoctrineMigrations/Version20171203210138.php
+++ b/app/DoctrineMigrations/Version20171203210138.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171203210138 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE TABLE pricing_rule (id SERIAL NOT NULL, expression VARCHAR(255) NOT NULL, price DOUBLE PRECISION NOT NULL, position INT DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('ALTER TABLE delivery ADD weight INT DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('DROP TABLE pricing_rule');
+        $this->addSql('ALTER TABLE delivery DROP weight');
+    }
+}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -66,6 +66,15 @@ services:
       - "@sylius.tax_rate_resolver"
       - "@sylius.tax_calculator"
       - "@sylius.repository.tax_category"
+      - "@coopcycle.delivery.manager"
+
+  coopcycle.delivery.manager:
+    class: AppBundle\Service\DeliveryManager
+    arguments:
+      - "@coopcycle.repository.delivery.pricing_rule"
+      - "@sylius.tax_rate_resolver"
+      - "@sylius.tax_calculator"
+      - "@sylius.repository.tax_category"
       - 'tva_livraison' # TODO Load from settings
 
   delivery.entity_listener:
@@ -137,6 +146,12 @@ services:
     factory: ['@doctrine.orm.default_entity_manager', getRepository]
     arguments:
       - AppBundle\Entity\Delivery
+
+  coopcycle.repository.delivery.pricing_rule:
+    class: Doctrine\ORM\EntityRepository
+    factory: ['@doctrine.orm.default_entity_manager', getRepository]
+    arguments:
+      - AppBundle\Entity\Delivery\PricingRule
 
   delivery_service.default:
     class: AppBundle\Service\DeliveryService\Core

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -493,6 +493,34 @@ form[name="menu"] {
     }
 }
 
+.delivery-pricing-ruleset {
+  padding-left: 0;
+  &__rule {
+    display: flex;
+    align-items: center;
+    margin-bottom: 30px;
+    &__handle {
+      flex: 1;
+      text-align: center;
+      cursor: pointer;
+      padding-top: 22px;
+    }
+    &__expression {
+      flex: 8;
+      padding-right: 15px;
+    }
+    &__price {
+      flex: 4;
+    }
+    &__remove {
+      flex: 1;
+      text-align: right;
+      padding-top: 22px;
+      padding-right: 15px;
+    }
+  }
+}
+
 .react-autosuggest__suggestions-container--open {
   display: block;
   border: 1px solid #aaa;
@@ -513,4 +541,8 @@ form[name="menu"] {
 
 .react-autosuggest__suggestion--highlighted {
   background-color: #eee;
+}
+
+.text-monospace {
+  font-family: "Courier New", Courier, "Lucida Sans Typewriter", "Lucida Typewriter", monospace;
 }

--- a/js/app/autocomplete.jsx
+++ b/js/app/autocomplete.jsx
@@ -5,9 +5,7 @@ const options = {
   }
 };
 
-let placeChangedListener;
-
-module.exports = (form) => {
+module.exports = (form, onPlaceChanged) => {
 
   if (!window.google) {
     return;
@@ -26,14 +24,15 @@ module.exports = (form) => {
     locality: form + '_addressLocality'
   };
 
-  if (placeChangedListener) {
-    google.maps.event.removeListener(placeChangedListener);
-  }
-
+  google.maps.event.clearListeners(addressInput, 'place_changed');
   const autocomplete = new google.maps.places.Autocomplete(addressInput, options);
 
-  placeChangedListener = autocomplete.addListener('place_changed', function() {
-    var place = autocomplete.getPlace();
+  autocomplete.addListener('place_changed', function() {
+    const place = autocomplete.getPlace();
+    if (!place.geometry) {
+      return;
+    }
+
     latitudeInput.value = place.geometry.location.lat();
     longitudeInput.value = place.geometry.location.lng();
     for (var i = 0; i < place.address_components.length; i++) {
@@ -42,6 +41,10 @@ module.exports = (form) => {
       if (inputMap[addressType]) {
         $('#' + inputMap[addressType]).val(value);
       }
+    }
+
+    if (typeof onPlaceChanged !== 'undefined' && typeof onPlaceChanged === 'function') {
+      onPlaceChanged(place);
     }
   });
 };

--- a/js/app/delivery/pricing-rules.jsx
+++ b/js/app/delivery/pricing-rules.jsx
@@ -1,0 +1,42 @@
+import { Sortable } from '@shopify/draggable'
+
+const ruleSet = $('#rule-set')
+const warning = $('form[name="pricing_rule_set"] .alert-warning')
+
+const onListChange = () => {
+  if ($('.delivery-pricing-ruleset > li').length === 0) {
+    warning.removeClass('hidden')
+  } else {
+    warning.addClass('hidden')
+  }
+
+  $('.delivery-pricing-ruleset > li').each((index, el) => {
+    $(el).find('.delivery-pricing-ruleset__rule__position').val(index)
+  })
+}
+
+$('#add-pricing-rule').on('click', function(e) {
+  e.preventDefault();
+
+  var newRule = ruleSet.attr('data-prototype')
+  newRule = newRule.replace(/__name__/g, ruleSet.find('li').length)
+
+  var newLi = $('<li></li>').addClass('delivery-pricing-ruleset__rule').html(newRule)
+  newLi.appendTo(ruleSet)
+
+  onListChange()
+})
+
+$(document).on('click', '.delivery-pricing-ruleset__rule__remove > a', function(e) {
+  e.preventDefault()
+  $(e.target).closest('li').remove()
+
+  onListChange()
+})
+
+const sortable = new Sortable(document.querySelector('.delivery-pricing-ruleset'), {
+  draggable: '.delivery-pricing-ruleset__rule',
+  handle:    '.delivery-pricing-ruleset__rule__handle',
+})
+
+sortable.on('mirror:destroy', () => onListChange())

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,11 @@
       "resolved": "https://registry.npmjs.org/@mapbox/polyline/-/polyline-0.2.0.tgz",
       "integrity": "sha1-biWYB0SqIjMflLZFpULALT/P7pc="
     },
+    "@shopify/draggable": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@shopify/draggable/-/draggable-1.0.0-beta.3.tgz",
+      "integrity": "sha512-YkXPv1ecnr+1l+CMNkqd7aqTbJ4XjKe28/PqQ5r2YZvVf+tZxmn88l6B2BVoNJszZqinpfK4rcTk2bYMQDoDrQ=="
+    },
     "@tweenjs/tween.js": {
       "version": "16.11.0",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-16.11.0.tgz",
@@ -1591,6 +1596,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3266,6 +3272,910 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.6.2",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "@mapbox/polyline": "^0.2.0",
+    "@shopify/draggable": "^1.0.0-beta.3",
     "@tweenjs/tween.js": "^16.3.5",
     "antd": "^3.0.0",
     "async": "^2.1.4",

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -16,6 +16,7 @@ use AppBundle\Form\PricingRuleSetType;
 use AppBundle\Form\RestaurantMenuType;
 use AppBundle\Form\RestaurantType;
 use AppBundle\Form\UpdateProfileType;
+use AppBundle\Service\DeliveryPricingManager;
 use AppBundle\Utils\PricingRuleSet;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
@@ -324,22 +325,9 @@ class AdminController extends Controller
             }
 
             if ($form->isValid()) {
-                $originLat = $form->get('originAddress')->get('latitude')->getData();
-                $originLng = $form->get('originAddress')->get('longitude')->getData();
 
-                $deliveryLat = $form->get('deliveryAddress')->get('latitude')->getData();
-                $deliveryLng = $form->get('deliveryAddress')->get('longitude')->getData();
-
-                $data = $this->container->get('routing_service')->getRawResponse(
-                    new GeoCoordinates($originLat, $originLng),
-                    new GeoCoordinates($deliveryLat, $deliveryLng)
-                );
-
-                $delivery->setDistance((int) $data['routes'][0]['distance']);
-                $delivery->setDuration((int) $data['routes'][0]['duration']);
-
-                $delivery->getOriginAddress()->setGeo(new GeoCoordinates($originLat, $originLng));
-                $delivery->getDeliveryAddress()->setGeo(new GeoCoordinates($deliveryLat, $deliveryLng));
+                $this->get('delivery_service.default')->calculate($delivery);
+                $this->get('coopcycle.delivery.manager')->applyTaxes($delivery);
 
                 $em->persist($delivery);
                 $em->flush();
@@ -549,5 +537,19 @@ class AdminController extends Controller
         return [
             'form' => $form->createView(),
         ];
+    }
+
+    /**
+     * @Route("/admin/deliveries/pricing/calculate", name="admin_deliveries_pricing_calculate")
+     * @Template
+     */
+    public function deliveriesPricingCalculateAction(Request $request)
+    {
+        $deliveryManager = $this->get('coopcycle.delivery.manager');
+
+        $delivery = new Delivery();
+        $delivery->setDistance($request->query->get('distance'));
+
+        return new JsonResponse($deliveryManager->getPrice($delivery));
     }
 }

--- a/src/AppBundle/Entity/Delivery.php
+++ b/src/AppBundle/Entity/Delivery.php
@@ -143,6 +143,11 @@ class Delivery extends Intangible implements TaxableInterface
      */
     private $taxCategory;
 
+    /**
+     * @ORM\Column(type="integer", nullable=true)
+     */
+    private $weight;
+
     public function __construct(Order $order = null)
     {
         $this->status = self::STATUS_WAITING;
@@ -339,6 +344,20 @@ class Delivery extends Intangible implements TaxableInterface
     public function setTaxCategory(TaxCategoryInterface $taxCategory)
     {
         $this->taxCategory = $taxCategory;
+
+        return $this;
+    }
+
+    public function getWeight()
+    {
+        return $this->weight;
+    }
+
+    public function setWeight($weight)
+    {
+        $this->weight = $weight;
+
+        return $this;
     }
 
     public function getActualDuration()

--- a/src/AppBundle/Entity/Delivery/PricingRule.php
+++ b/src/AppBundle/Entity/Delivery/PricingRule.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace AppBundle\Entity\Delivery;
+
+use AppBundle\Entity\Delivery;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="pricing_rule")
+ */
+class PricingRule
+{
+    /**
+     * @var int
+     *
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(type="string")
+     * @Assert\Type(type="string")
+     */
+    protected $expression;
+
+    /**
+     * @ORM\Column(type="float")
+     * @Assert\Type(type="float")
+     */
+    protected $price;
+
+    /**
+     * @ORM\Column(type="integer", nullable=true)
+     */
+    protected $position;
+
+    /**
+     * Gets id.
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getExpression()
+    {
+        return $this->expression;
+    }
+
+    public function setExpression($expression)
+    {
+        $this->expression = $expression;
+
+        return $this;
+    }
+
+    public function getPrice()
+    {
+        return $this->price;
+    }
+
+    public function setPrice($price)
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    public function setPosition($position)
+    {
+        $this->position = $position;
+
+        return $this;
+    }
+
+    public function matches(Delivery $delivery)
+    {
+        $language = new ExpressionLanguage();
+
+        return $language->evaluate($this->getExpression(), [
+            'distance' => $delivery->getDistance(),
+            'weight' => $delivery->getWeight(),
+        ]);
+    }
+}

--- a/src/AppBundle/Form/AddressType.php
+++ b/src/AppBundle/Form/AddressType.php
@@ -22,18 +22,18 @@ class AddressType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('floor', TextType::class, [
-                'required' => false,
-                'label' => 'Floor (optional)'
-            ])
             ->add('streetAddress', TextType::class, [
                 'label' => 'Street address'
+            ])
+            ->add('addressLocality', TextType::class, [
+                'label' => 'City'
             ])
             ->add('postalCode', TextType::class, [
                 'label' => 'Postal code'
             ])
-            ->add('addressLocality', TextType::class, [
-                'label' => 'City'
+            ->add('floor', TextType::class, [
+                'required' => false,
+                'label' => 'Floor (optional)'
             ])
             ->add('description', TextareaType::class, [
                 'required' => false,

--- a/src/AppBundle/Form/DeliveryType.php
+++ b/src/AppBundle/Form/DeliveryType.php
@@ -5,6 +5,7 @@ namespace AppBundle\Form;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Validation;
@@ -18,12 +19,14 @@ class DeliveryType extends AbstractType
         $builder
             ->add('originAddress', AddressType::class)
             ->add('deliveryAddress', AddressType::class)
-            ->add('distance', NumberType::class, ['mapped' => false])
-            ->add('duration', NumberType::class, ['mapped' => false])
+            ->add('weight', NumberType::class, ['required' => false])
             ->add('date', DateType::class, [
                 'widget' => 'single_text',
                 'format' => 'yyyy-MM-dd HH:mm:ss'
-            ]);
+            ])
+            ->add('price', MoneyType::class)
+            ->add('distance', NumberType::class, ['mapped' => false])
+            ->add('duration', NumberType::class, ['mapped' => false]);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/AppBundle/Form/PricingRuleSetType.php
+++ b/src/AppBundle/Form/PricingRuleSetType.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Utils\PricingRuleSet;
+use Doctrine\ORM\EntityRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PricingRuleSetType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('rules', CollectionType::class, array(
+                'entry_type' => PricingRuleType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'prototype' => true,
+            ));
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => PricingRuleSet::class,
+        ));
+    }
+}

--- a/src/AppBundle/Form/PricingRuleType.php
+++ b/src/AppBundle/Form/PricingRuleType.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Entity\Delivery\PricingRule;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class PricingRuleType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('expression', TextType::class)
+            ->add('price', MoneyType::class)
+            ->add('position', HiddenType::class, [
+                'required' => false
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => PricingRule::class,
+        ));
+    }
+}

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -37,6 +37,23 @@ delivery.status.DISPATCHED: Dispatched
 delivery.status.PICKED: Picked
 delivery.status.DELIVERED: Delivered
 
+delivery.pricing_rules.help: >
+  You can define rules for deliveries pricing:
+  each rule defines an « expression » and an associated price.
+  <br>
+  The rules are traversed in order, and the first one whose expression is evaluated to true is applied.
+  <br>
+  Available variables: <code>distance</code>, <code>weight</code>
+  <br>
+  <br>
+  <strong>Examples:</strong>
+  <br>
+  <code>distance in 0..3000</code> : the distance is between 0 and 3000 meters
+  <br>
+  <code>weight > 1000</code> : the weight is greater than 1000 grams
+  <br><br>
+  <a target="_blank" href="http://symfony.com/doc/3.4/components/expression_language/syntax.html">Expression syntax</a>
+
 demo.disclaimer: <i class="fa fa-bullhorn"></i>  Welcome on the demo of the <a target="_blank" href="https://coopcycle.org">CoopCycle</a> platform.
 demo.disclaimer.subtitle: <a target="_blank" href="https://coopcycle.org/en/help/how-to-use-the-demo/"><i class="fa fa-info-circle"></i>  How to use this demo?</a>
 

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -124,6 +124,9 @@ Pricing: Tarification
 Add rule: Ajouter une règle
 No pricing rule found: Pas de règle de tarification pour le moment
 Enter an expression: Entrez une expression
+Origin address: Adresse de départ
+Delivery address: Adresse de livraison
+Weight: Poids
 
 profile.addresses.breadcrumb: Addresses
 profile.addresses.empty: Pas d'adresse sauvegardée pour le moment!

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -120,6 +120,10 @@ Invoice: Facture
 Total excluding tax: Total HT
 Total tax: Total TVA
 Total including tax: Total TTC
+Pricing: Tarification
+Add rule: Ajouter une règle
+No pricing rule found: Pas de règle de tarification pour le moment
+Enter an expression: Entrez une expression
 
 profile.addresses.breadcrumb: Addresses
 profile.addresses.empty: Pas d'adresse sauvegardée pour le moment!
@@ -161,13 +165,30 @@ order.status.ACCEPTED: Acceptée
 order.status.REFUSED: Refusée
 order.status.READY: Prête
 order.status.CANCELED: Annulée
-order.status.PAYMENT_ERROR: Erreur de payement
+order.status.PAYMENT_ERROR: Erreur de paiement
 
 delivery.status.WAITING: En attente
 delivery.status.DISPATCHED: Acceptée
 delivery.status.PICKED: Récupérée
 delivery.status.DELIVERED: Livrée
 delivery.status.CANCELED: Annulée
+
+delivery.pricing_rules.help: >
+  Vous pouvez définir des règles pour la tarification des livraisons :
+  chaque règle permet de définir une « expression » et un prix associé.
+  <br>
+  Les règles sont parcourues dans l'ordre, et la première dont l'expression est évaluée comme vraie est appliquée.
+  <br>
+  Variables disponibles : <code>distance</code>, <code>weight</code>
+  <br>
+  <br>
+  <strong>Exemples :</strong>
+  <br>
+  <code>distance in 0..3000</code> : la distance est comprise entre 0 et 3000 mètres
+  <br>
+  <code>weight > 1000</code> : le poids est supérieur à 1000 grammes
+  <br><br>
+  <a target="_blank" href="http://symfony.com/doc/3.4/components/expression_language/syntax.html">Syntaxe des expressions</a>
 
 demo.disclaimer: <i class="fa fa-bullhorn"></i>  Bienvenue sur la démo de la plateforme <a target="_blank" href="https://coopcycle.org">CoopCycle</a>
 demo.disclaimer.subtitle: <a target="_blank" href="https://coopcycle.org/fr/aide/comment-utiliser-la-demo/"><i class="fa fa-info-circle"></i>  Comment utiliser cette démo ?</a>

--- a/src/AppBundle/Resources/views/Admin/deliveries.html.twig
+++ b/src/AppBundle/Resources/views/Admin/deliveries.html.twig
@@ -24,5 +24,5 @@
     </tr>
   {% endfor %}
   </table>
-  <a href="{{ path('admin_deliveries_new') }}" class="btn btn-success"><i class="fa fa-plus"></i> Add</a>
+  <a href="{{ path('admin_deliveries_new') }}" class="btn btn-success"><i class="fa fa-plus"></i> {% trans %}Add{% endtrans %}</a>
 {% endblock %}

--- a/src/AppBundle/Resources/views/Admin/deliveriesPricing.html.twig
+++ b/src/AppBundle/Resources/views/Admin/deliveriesPricing.html.twig
@@ -1,0 +1,53 @@
+{% extends "AppBundle::admin.html.twig" %}
+{% form_theme form 'AppBundle:Form:pricingRuleSet.html.twig' %}
+
+{% block breadcrumb %}
+<li>{% trans %}Deliveries{% endtrans %}</li>
+<li>{% trans %}Pricing{% endtrans %}</li>
+{% endblock %}
+
+{% block content %}
+
+  <div class="alert alert-info">
+    <i class="fa fa-info-circle" aria-hidden="true"></i> {% trans %}delivery.pricing_rules.help{% endtrans %}
+  </div>
+
+  <hr>
+
+  {{ form_start(form) }}
+
+    <div class="alert alert-warning {% if form.rules|length > 0 %}hidden{% endif %}">
+      {% trans %}No pricing rule found{% endtrans %}
+    </div>
+
+    {% if form.rules|length == 0 %}
+      {% do form.rules.setRendered %}
+    {% endif %}
+
+    <ul id="rule-set" class="delivery-pricing-ruleset"
+      data-prototype="{{ form_widget(form.rules.vars.prototype)|e }}">
+      {% for rule in form.rules %}
+      <li class="delivery-pricing-ruleset__rule">
+        {{ form_errors(rule) }}
+        {{ form_widget(rule) }}
+      </li>
+      {% endfor %}
+    </ul>
+
+    <div class="form-group text-right">
+      <button type="button" id="add-pricing-rule" class="btn btn-success">
+        <i class="fa fa-plus"></i> {% trans %}Add rule{% endtrans %}
+      </button>
+    </div>
+
+    <button type="submit" class="btn btn-block btn-primary">
+      {% trans %}Save{% endtrans %}
+    </button>
+
+  {{ form_end(form) }}
+
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ asset('js/delivery-pricing-rules.js') }}"></script>
+{% endblock %}

--- a/src/AppBundle/Resources/views/Admin/newDelivery.html.twig
+++ b/src/AppBundle/Resources/views/Admin/newDelivery.html.twig
@@ -3,44 +3,38 @@
 {% form_theme form 'AppBundle:Form:delivery.html.twig' %}
 
 {% block breadcrumb %}
-<li>{% trans %}Deliveries{% endtrans %}</li>
+<li><a href="{{ path('admin_deliveries') }}">{% trans %}Deliveries{% endtrans %}</a></li>
 <li>{% trans %}Create delivery{% endtrans %}</li>
 {% endblock %}
 
 {% block content %}
 {{ form_start(form) }}
 
-  {{ form_row(form.originAddress) }}
-  {{ form_row(form.deliveryAddress) }}
+  <div class="row">
+    <div class="col-sm-7">
 
-  <div class="form-group">
-    <div class="col-sm-offset-2 col-sm-10">
-      <div class="row">
-        <div class="col-sm-6">
-          {{ form_row(form.distance) }}
-        </div>
-        <div class="col-sm-6">
-          {{ form_row(form.duration) }}
-        </div>
-      </div>
+      {{ form_row(form.date) }}
+      {{ form_row(form.weight) }}
+
+      <div class="well well-sm"><label>{% trans %}Origin address{% endtrans %}</label></div>
+      {{ form_widget(form.originAddress) }}
+
+      <div class="well well-sm"><label>{% trans %}Delivery address{% endtrans %}</label></div>
+      {{ form_widget(form.deliveryAddress) }}
+
     </div>
-  </div>
-
-  {{ form_row(form.date) }}
-
-  <div class="form-group">
-    <div class="col-sm-offset-2 col-sm-10">
-      <button type="submit" class="btn btn-block btn-primary">{% trans %}Save{% endtrans %}</button>
-    </div>
-  </div>
-
-  <hr>
-
-  <div class="form-group">
-    <div class="col-sm-offset-2 col-sm-10">
-      <div class="embed-responsive embed-responsive-16by9">
+    <div class="col-sm-5">
+      <div class="embed-responsive embed-responsive-4by3">
         <div class="embed-responsive-item" id="map"></div>
       </div>
+      <hr>
+      <div class="form-horizontal">
+        {{ form_row(form.distance) }}
+        {{ form_row(form.duration) }}
+        {{ form_row(form.price) }}
+      </div>
+      <hr>
+      <button type="submit" class="btn btn-block btn-lg btn-primary">{% trans %}Save{% endtrans %}</button>
     </div>
   </div>
 
@@ -48,6 +42,9 @@
 {% endblock %}
 
 {% block scripts %}
+<script>
+window.__deliveries_pricing_calculate_url = "{{ path('admin_deliveries_pricing_calculate') }}"
+</script>
 <script src="{{ asset('js/delivery-form.js') }}"></script>
 <script src="https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}&libraries=places&callback=initMap"
   async defer></script>

--- a/src/AppBundle/Resources/views/Form/delivery.html.twig
+++ b/src/AppBundle/Resources/views/Form/delivery.html.twig
@@ -2,10 +2,12 @@
 
 {% block _delivery_originAddress_streetAddress_row %}
 {% spaceless %}
-  <div class="form-row {% if not form.vars.valid %}has-error{% endif %}">
-    <div class="input-group">
-      <div class="input-group-addon"><i class="fa fa-cube"></i></div>
-      {{ form_widget(form) }}
+  <div class="form-group {% if not form.vars.valid %}has-error{% endif %}">
+    <div class="col-sm-10 col-md-offset-2">
+      <div class="input-group">
+        <div class="input-group-addon"><i class="fa fa-cube"></i></div>
+        {{ form_widget(form) }}
+      </div>
     </div>
     {% if not form.vars.valid %}{{ form_errors(form) }}{% endif %}
   </div>
@@ -14,12 +16,14 @@
 
 {% block _delivery_deliveryAddress_streetAddress_row %}
 {% spaceless %}
-  <div class="form-row {% if not form.vars.valid %}has-error{% endif %}">
-    <div class="input-group">
-      <div class="input-group-addon"><i class="fa fa-flag"></i></div>
-      {{ form_widget(form) }}
+  <div class="form-group {% if not form.vars.valid %}has-error{% endif %}">
+    <div class="col-sm-10 col-md-offset-2">
+      <div class="input-group">
+        <div class="input-group-addon"><i class="fa fa-flag"></i></div>
+        {{ form_widget(form) }}
+      </div>
+      {% if not form.vars.valid %}{{ form_errors(form) }}{% endif %}
     </div>
-    {% if not form.vars.valid %}{{ form_errors(form) }}{% endif %}
   </div>
 {% endspaceless %}
 {% endblock %}
@@ -39,14 +43,22 @@
 
 {% block _delivery_distance_row %}
 {% spaceless %}
-  <label class="control-label">{{ translation_domain is same as(false) ? 'Distance' : 'Distance'|trans({}, translation_domain) }}</label>
-  <p class="form-control-static"><span id="delivery_distance"></span></p>
+  <div class="form-group">
+    {{ form_label(form, 'Distance'|trans({}, 'messages')) }}
+    <div class="col-sm-10">
+      <p class="form-control-static"><span id="delivery_distance"></span></p>
+    </div>
+  </div>
 {% endspaceless %}
 {% endblock %}
 
 {% block _delivery_duration_row %}
 {% spaceless %}
-  <label class="control-label">{{ translation_domain is same as(false) ? 'Duration' : 'Duration'|trans({}, translation_domain) }}</label>
-  <p class="form-control-static"><span id="delivery_duration"></span></p>
+  <div class="form-group">
+    {{ form_label(form, 'Duration'|trans({}, 'messages')) }}
+    <div class="col-sm-10">
+      <p class="form-control-static"><span id="delivery_duration"></span></p>
+    </div>
+  </div>
 {% endspaceless %}
 {% endblock %}

--- a/src/AppBundle/Resources/views/Form/pricingRuleSet.html.twig
+++ b/src/AppBundle/Resources/views/Form/pricingRuleSet.html.twig
@@ -1,0 +1,19 @@
+{% extends 'bootstrap_3_layout.html.twig' %}
+
+{% block _pricing_rule_set_rules_entry_widget %}
+  <div class="delivery-pricing-ruleset__rule__handle">
+    <i class="fa fa-arrows"></i>
+    {{ form_widget(form.position, { attr: { class: 'delivery-pricing-ruleset__rule__position' } }) }}
+  </div>
+  <div class="delivery-pricing-ruleset__rule__expression">
+    {{ form_label(form.expression) }}
+    {{ form_widget(form.expression, { attr: { placeholder: 'Enter an expression'|trans([], 'messages'), class: 'text-monospace' } }) }}
+  </div>
+  <div class="delivery-pricing-ruleset__rule__price">
+    {{ form_label(form.price) }}
+    {{ form_widget(form.price) }}
+  </div>
+  <div class="delivery-pricing-ruleset__rule__remove">
+    <a href="#"><i class="fa fa-trash"></i></a>
+  </div>
+{% endblock %}

--- a/src/AppBundle/Resources/views/admin.html.twig
+++ b/src/AppBundle/Resources/views/admin.html.twig
@@ -30,6 +30,8 @@
             <ul class="dropdown-menu">
               <li><a href="{{ path('admin_menu_categories') }}">{% trans %}Menu categories{% endtrans %}</a></li>
               <li><a href="{{ path('admin_taxation_settings') }}">{% trans %}Taxation{% endtrans %}</a></li>
+              <li class="dropdown-header">{% trans %}Deliveries{% endtrans %}</li>
+              <li><a href="{{ path('admin_deliveries_pricing') }}">{% trans %}Pricing{% endtrans %}</a></li>
             </ul>
           </li>
           {% endif %}

--- a/src/AppBundle/Service/DeliveryManager.php
+++ b/src/AppBundle/Service/DeliveryManager.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace AppBundle\Service;
+
+use AppBundle\Entity\Delivery;
+use Doctrine\ORM\EntityRepository;
+use Sylius\Component\Taxation\Calculator\CalculatorInterface;
+use Sylius\Component\Taxation\Repository\TaxCategoryRepositoryInterface;
+use Sylius\Component\Taxation\Resolver\TaxRateResolverInterface;
+
+class DeliveryManager
+{
+    private $pricingRuleRepository;
+    private $taxRateResolver;
+    private $calculator;
+    private $taxCategoryRepository;
+    private $taxCategoryCode;
+
+    public function __construct(EntityRepository $pricingRuleRepository,
+        TaxRateResolverInterface $taxRateResolver, CalculatorInterface $calculator,
+        TaxCategoryRepositoryInterface $taxCategoryRepository, $taxCategoryCode)
+    {
+        $this->pricingRuleRepository = $pricingRuleRepository;
+        $this->taxRateResolver = $taxRateResolver;
+        $this->calculator = $calculator;
+        $this->taxCategoryRepository = $taxCategoryRepository;
+        $this->taxCategoryCode = $taxCategoryCode;
+    }
+
+    public function applyTaxes(Delivery $delivery)
+    {
+        $taxCategory = $this->taxCategoryRepository->findOneBy(['code' => $this->taxCategoryCode]);
+
+        $delivery->setTaxCategory($taxCategory);
+
+        $taxRate = $this->taxRateResolver->resolve($delivery);
+
+        $totalIncludingTax = $delivery->getPrice();
+        $totalTax = $this->calculator->calculate($totalIncludingTax, $taxRate);
+        $totalExcludingTax = $totalIncludingTax - $totalTax;
+
+        $delivery->setTotalExcludingTax($totalExcludingTax);
+        $delivery->setTotalTax($totalTax);
+        $delivery->setTotalIncludingTax($totalIncludingTax);
+    }
+
+    public function getPrice(Delivery $delivery)
+    {
+        $rules = $this->pricingRuleRepository->findBy([], ['position' => 'ASC']);
+
+        foreach ($rules as $rule) {
+            if ($rule->matches($delivery)) {
+                return $rule->getPrice();
+            }
+        }
+    }
+}

--- a/src/AppBundle/Tests/Action/TestCase.php
+++ b/src/AppBundle/Tests/Action/TestCase.php
@@ -5,6 +5,7 @@ namespace AppBundle\Tests\Action;
 use AppBundle\Action\Order\Accept;
 use AppBundle\Entity;
 use AppBundle\Service\DeliveryService\Factory as DeliveryServiceFactory;
+use AppBundle\Service\DeliveryManager;
 use AppBundle\Service\DeliveryServiceInterface;
 use AppBundle\Service\OrderManager;
 use AppBundle\Service\PaymentService;
@@ -42,6 +43,7 @@ class TestCase extends BaseTestCase
         $taxRateResolver = $this->prophesize(TaxRateResolverInterface::class);
         $calculator = $this->prophesize(CalculatorInterface::class);
         $taxCategoryRepository = $this->prophesize(TaxCategoryRepositoryInterface::class);
+        $deliveryManager = $this->prophesize(DeliveryManager::class);
 
         $deliveryServiceFactory = new DeliveryServiceFactory([], $deliveryService->reveal());
 
@@ -60,7 +62,7 @@ class TestCase extends BaseTestCase
             $taxRateResolver->reveal(),
             $calculator->reveal(),
             $taxCategoryRepository->reveal(),
-            'foo'
+            $deliveryManager->reveal()
         );
 
         $this->action = new $this->actionClass(

--- a/src/AppBundle/Utils/PricingRuleSet.php
+++ b/src/AppBundle/Utils/PricingRuleSet.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AppBundle\Utils;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+class PricingRuleSet extends ArrayCollection
+{
+    public function setRules(array $rules)
+    {
+        $this->clear();
+        foreach ($rules as $rule) {
+            $this->add($rule);
+        }
+
+        return $this;
+    }
+
+    public function getRules()
+    {
+        return $this->toArray();
+    }
+}

--- a/tests/AppBundle/Entity/Delivery/PricingRuleTest.php
+++ b/tests/AppBundle/Entity/Delivery/PricingRuleTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace AppBundle\Entity\Delivery;
+
+use AppBundle\Entity\Delivery;
+use AppBundle\Entity\Delivery\PricingRule;
+use PHPUnit\Framework\TestCase;
+
+class PricingRuleTest extends TestCase
+{
+    public function testMatches()
+    {
+        $rule = new PricingRule();
+        $rule->setExpression('distance in 0..3000 and weight in 0..1000');
+
+        $delivery = new Delivery();
+
+        $delivery->setDistance(1500);
+        $delivery->setWeight(500);
+        $this->assertTrue($rule->matches($delivery));
+
+        $delivery->setDistance(3500);
+        $delivery->setWeight(500);
+        $this->assertFalse($rule->matches($delivery));
+
+        $delivery->setDistance(1500);
+        $delivery->setWeight(1500);
+        $this->assertFalse($rule->matches($delivery));
+    }
+
+    public function testNullVariable()
+    {
+        $rule = new PricingRule();
+        $rule->setExpression('distance in 500..3000');
+
+        $delivery = new Delivery();
+        $delivery->setDistance(null);
+
+        $this->assertFalse($rule->matches($delivery));
+    }
+
+    /**
+     * @expectedException Symfony\Component\ExpressionLanguage\SyntaxError
+     */
+    public function testUnknownVariable()
+    {
+        $rule = new PricingRule();
+        $rule->setExpression('foo == 1');
+
+        $delivery = new Delivery();
+        $delivery->setDistance(null);
+
+        $this->assertFalse($rule->matches($delivery));
+    }
+}

--- a/tests/AppBundle/Service/DeliveryManagerTest.php
+++ b/tests/AppBundle/Service/DeliveryManagerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace AppBundle\Service;
+
+use AppBundle\BaseTest;
+use AppBundle\Entity\Delivery;
+use AppBundle\Entity\Delivery\PricingRule;
+use AppBundle\Service\DeliveryManager;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\EntityRepository;
+use Prophecy\Argument;
+
+class DeliveryManagerTest extends BaseTest
+{
+    private $taxRateResolver;
+    private $calculator;
+    private $taxCategoryRepository;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->taxRateResolver = static::$kernel->getContainer()->get('sylius.tax_rate_resolver');
+        $this->calculator = static::$kernel->getContainer()->get('sylius.tax_calculator');
+        $this->taxCategoryRepository = static::$kernel->getContainer()->get('sylius.repository.tax_category');
+    }
+
+    public function testGetPrice()
+    {
+        $pricingRuleRepository = $this->prophesize(EntityRepository::class);
+
+        $rule1 = new PricingRule();
+        $rule1->setExpression('distance in 0..3000');
+        $rule1->setPrice(5.99);
+
+        $rule2 = new PricingRule();
+        $rule2->setExpression('distance in 3000..5000');
+        $rule2->setPrice(6.99);
+
+        $rule3 = new PricingRule();
+        $rule3->setExpression('distance in 5000..7500');
+        $rule3->setPrice(8.99);
+
+        $rules = new ArrayCollection([
+            $rule1,
+            $rule2,
+            $rule3,
+        ]);
+
+        $pricingRuleRepository
+            ->findBy(Argument::type('array'), Argument::type('array'))
+            ->willReturn($rules);
+
+        $deliveryManager = new DeliveryManager(
+            $pricingRuleRepository->reveal(),
+            $this->taxRateResolver,
+            $this->calculator,
+            $this->taxCategoryRepository,
+            'tva_livraison'
+        );
+
+        $delivery = new Delivery();
+        $delivery->setDistance(1500);
+
+        $this->assertEquals(5.99, $deliveryManager->getPrice($delivery));
+    }
+
+    public function testApplyTaxes()
+    {
+        $this->createTaxCategory('TVA livraison', 'tva_livraison', 'TVA 20%', 'tva_20', 0.20, 'float');
+
+        $pricingRuleRepository = $this->prophesize(EntityRepository::class);
+
+        $deliveryManager = new DeliveryManager(
+            $pricingRuleRepository->reveal(),
+            $this->taxRateResolver,
+            $this->calculator,
+            $this->taxCategoryRepository,
+            'tva_livraison'
+        );
+
+        // 3.5 - (3.5 / (1 + 0.20)) = 0.58
+        $delivery = new Delivery();
+        $delivery->setPrice(3.50);
+
+        $deliveryManager->applyTaxes($delivery);
+
+        $this->assertEquals(02.92, $delivery->getTotalExcludingTax());
+        $this->assertEquals(00.58, $delivery->getTotalTax());
+        $this->assertEquals(03.50, $delivery->getTotalIncludingTax());
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ var webpackConfig = {
     'js/order-tracking': './js/app/order/tracking.jsx',
     'js/profile-deliveries': './js/app/profile/deliveries.js',
     'js/delivery-form': './js/app/delivery/form.jsx',
+    'js/delivery-pricing-rules': './js/app/delivery/pricing-rules.jsx',
     'js/restaurant-form': './js/app/restaurant/form.jsx',
     'js/restaurant-menu': './js/app/restaurant/menu.jsx',
     'js/restaurant-panel': './js/app/restaurant/panel.jsx',


### PR DESCRIPTION
Here is the first draft to introduce delivery pricing calculation based on configurable rules 🚀

![coopcycle_delivery_new](https://user-images.githubusercontent.com/1162230/33296430-f0d2f4cc-d3db-11e7-9438-b5d2f47b2726.gif)

Rules are simple [expressions](https://symfony.com/doc/current/components/expression_language.html) stored in database. To calculate the delivery price, the `DeliveryPriceManager` loops on rules and applies the first one that matches.

**TODO**

- [x] Allow reordering rules
- [x] Store price in database
- [x] Add help message about expressions

I think we can merge this early before introducing vehicles. 