### PR TITLE
Disable restaurant + restaurant checkup validation

### DIFF
--- a/app/DoctrineMigrations/Version20171201132329.php
+++ b/app/DoctrineMigrations/Version20171201132329.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171201132329 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE restaurant ADD enabled BOOLEAN DEFAULT \'false\' NOT NULL');
+        $this->addSql('UPDATE restaurant SET enabled = true');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE restaurant DROP enabled');
+    }
+}

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -430,6 +430,10 @@ $order-follow--number-width: 26px;
     margin-left: 10px;
 }
 
+.restaurant-availability-errors {
+  list-style: initial;
+}
+
 form[name="menu"] {
     #menu_sections .switch {
         padding-top: 26px;

--- a/assets/css/utils.scss
+++ b/assets/css/utils.scss
@@ -3,6 +3,10 @@
   flex-wrap: wrap;
 }
 
+.display-inline-block {
+  display: inline-block;
+}
+
 .margin-top-s {
   margin-top: $base-margin-s;
 }

--- a/assets/css/utils.scss
+++ b/assets/css/utils.scss
@@ -11,6 +11,10 @@
   margin-top: $base-margin-s;
 }
 
+.margin-left-l {
+  margin-left: $base-margin-l;
+}
+
 .margin-bottom-md {
   margin-bottom: $base-margin;
 }

--- a/assets/css/vars.scss
+++ b/assets/css/vars.scss
@@ -22,6 +22,7 @@ $bs-base-margin: 20px;
 $screen-md-min: 768px;
 
 // Length
+$base-margin-l: $bs-base-margin * 2;
 $base-margin: $bs-base-margin;
 $base-margin-s: $base-margin / 2;
 $base-margin-xs: $base-margin-s / 2;

--- a/features/fixtures/ORM/restaurants.yml
+++ b/features/fixtures/ORM/restaurants.yml
@@ -73,16 +73,19 @@ AppBundle\Entity\Restaurant:
     address: "@address_1"
     hasMenu: "@menu_1"
     openingHours: ['Mo-Sa 11:30-14:30']
+    enabled: true
   restaurant_2:
     name: 'Café Barjot'
     address: "@address_2"
     hasMenu: "@menu_2"
     openingHours: ['Mo-Sa 11:30-14:30']
+    enabled: true
   restaurant_3:
     name: 'La Cantina Clandestina'
     address: "@address_3"
     hasMenu: "@menu_3"
     openingHours: ['Mo-Sa 11:30-14:30']
+    enabled: true
 
 AppBundle\Entity\Contract:
   contract_1:

--- a/features/restaurants.feature
+++ b/features/restaurants.feature
@@ -42,6 +42,7 @@ Feature: Manage restaurants
           "@id":"/api/restaurants/2",
           "@type":"http://schema.org/Restaurant",
           "servesCuisine":@array@,
+          "enabled":true,
           "address":@...@,
           "name":"Café Barjot",
           "hasMenu":@...@
@@ -59,6 +60,7 @@ Feature: Manage restaurants
     When I add "Accept" header equal to "application/ld+json"
     And I send a "GET" request to "/api/restaurants/1"
     Then the response status code should be 200
+    Then print last response
     And the response should be in JSON
     And the JSON should match:
     """
@@ -67,6 +69,7 @@ Feature: Manage restaurants
       "@id":"/api/restaurants/1",
       "@type":"http://schema.org/Restaurant",
       "servesCuisine":@array@,
+      "enabled":true,
       "name":"Nodaiwa",
       "address":{
         "@id":"@string@.startsWith('/api/addresses')",

--- a/js/app/restaurant/form.jsx
+++ b/js/app/restaurant/form.jsx
@@ -71,7 +71,8 @@ function renderSwitch($input) {
   $parent.prepend($switch)
   $parent.prepend($hidden)
 
-  const checked = $input.is(':checked')
+  const checked = $input.is(':checked'),
+        disabled = $('.restaurant-availability-errors').is(':visible')
 
   $input.closest('div.checkbox').remove()
 
@@ -84,7 +85,9 @@ function renderSwitch($input) {
               } else {
                 $hidden.remove()
               }
-            }} />,
+            }}
+            disabled={disabled}
+        />,
     $switch.get(0)
   );
 

--- a/js/app/restaurant/form.jsx
+++ b/js/app/restaurant/form.jsx
@@ -1,17 +1,17 @@
 import OpeningHours from './OpeningHours.jsx'
-import React from 'react';
-import { render } from 'react-dom';
-import moment from 'moment';
-import _ from 'underscore';
+import React from 'react'
+import { render } from 'react-dom'
+import _ from 'underscore'
 import autocomplete from '../autocomplete.jsx'
+import { Switch } from 'antd'
 
-window.initMap = () => autocomplete('restaurant_address');
+window.initMap = () => autocomplete('restaurant_address')
 
-var entriesCount = $('input[name^="restaurant[openingHours]"]').length;
+var entriesCount = $('input[name^="restaurant[openingHours]"]').length
 
 function onRowAdd() {
   // grab the prototype template
-  var newWidget = $('#restaurant_openingHours').attr('data-prototype');
+  var newWidget = $('#restaurant_openingHours').attr('data-prototype')
   // replace the "__name__" used in the id and name of the prototype
   // with a number that's unique to your emails
   // end name attribute looks like name="contact[emails][2]"
@@ -22,7 +22,7 @@ function onRowAdd() {
 }
 
 function onRowRemove(index) {
-  $('#restaurant_openingHours_' + index).remove();
+  $('#restaurant_openingHours_' + index).remove()
   $('#opening-hours-text > p').get(index).remove()
 }
 
@@ -31,13 +31,13 @@ $('input[name^="restaurant[openingHours]"]').each((index, el) => {
   defaultValue.push($(el).val())
 });
 
-var $deliveryService = $('#restaurant_deliveryService_type');
+var $deliveryService = $('#restaurant_deliveryService_type')
 $deliveryService.change(function() {
   // ... retrieve the corresponding form.
-  var $form = $(this).closest('form');
+  var $form = $(this).closest('form')
   // Simulate form data, but only include the selected sport value.
-  var data = {};
-  data[$deliveryService.attr('name')] = $deliveryService.val();
+  var data = {}
+  data[$deliveryService.attr('name')] = $deliveryService.val()
   // Submit data via AJAX to the form's action path.
   $.ajax({
     url : $form.attr('action'),
@@ -54,19 +54,62 @@ $deliveryService.change(function() {
 });
 
 
-const openingHoursValue = $('#restaurant_openingHours').val();
+function renderSwitch($input) {
 
-render(<OpeningHours
-  value={defaultValue}
-  onChange={(rows) => {
-    $('#opening-hours-text').empty();
-    _.each(rows, (value, key) => {
-      $('#restaurant_openingHours_' + key).val(value);
-      const $text = $('<p>').addClass('help-block').text(value);
-      $('#opening-hours-text').append($text)
-    })
-  }}
-  onRowAdd={onRowAdd}
-  onRowRemove={onRowRemove} />,
-  document.getElementById('opening-hours')
-);
+  const $parent = $input.closest('div.checkbox').parent()
+
+  const $switch = $('<div class="display-inline-block">')
+  const $hidden = $('<input>')
+
+  $switch.addClass('switch')
+
+  $hidden
+    .attr('type', 'hidden')
+    .attr('name', $input.attr('name'))
+    .attr('value', $input.attr('value'))
+
+  $parent.prepend($switch)
+  $parent.prepend($hidden)
+
+  const checked = $input.is(':checked')
+
+  $input.closest('div.checkbox').remove()
+
+  render(
+    <Switch defaultChecked={ checked }
+            checkedChildren={ window.AppData.__i18n['Enabled'] } unCheckedChildren={ window.AppData.__i18n['Disabled'] }
+            onChange={(checked) => {
+              if (checked) {
+                $parent.append($hidden)
+              } else {
+                $hidden.remove()
+              }
+            }} />,
+    $switch.get(0)
+  );
+
+}
+
+
+$(function() {
+  render(<OpeningHours
+      value={defaultValue}
+      onChange={(rows) => {
+        $('#opening-hours-text').empty()
+        _.each(rows, (value, key) => {
+          $('#restaurant_openingHours_' + key).val(value)
+          const $text = $('<p>').addClass('help-block').text(value)
+          $('#opening-hours-text').append($text)
+        })
+      }}
+      onRowAdd={onRowAdd}
+      onRowRemove={onRowRemove} />,
+    document.getElementById('opening-hours')
+  );
+
+  let $form = $('form[name="restaurant"]');
+
+  // Render Switch on page load
+  $form.find('.switch').each((index, el) => renderSwitch($(el)))
+
+})

--- a/src/AppBundle/Command/InitDemoCommand.php
+++ b/src/AppBundle/Command/InitDemoCommand.php
@@ -175,6 +175,7 @@ class InitDemoCommand extends ContainerAwareCommand
 
         $restaurant = new Entity\Restaurant();
 
+        $restaurant->setEnabled(true);
         $restaurant->setAddress($address);
         $restaurant->setMenu($this->createMenu($taxCategory));
         $restaurant->setName($this->faker->restaurantName);

--- a/src/AppBundle/Controller/RestaurantTrait.php
+++ b/src/AppBundle/Controller/RestaurantTrait.php
@@ -7,13 +7,16 @@ use AppBundle\Entity\Menu;
 use AppBundle\Form\RestaurantMenuType;
 use AppBundle\Form\MenuType;
 use AppBundle\Form\RestaurantType;
+use AppBundle\Utils\ValidationUtils;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\Validator\Validation;
 
 trait RestaurantTrait
 {
+
     protected function checkAccess(Restaurant $restaurant)
     {
         if ($this->getUser()->hasRole('ROLE_ADMIN')) {
@@ -44,6 +47,10 @@ trait RestaurantTrait
 
         $form->handleRequest($request);
 
+        $validator = Validation::createValidatorBuilder()->enableAnnotationMapping()->getValidator();
+        $activationErrors = $validator->validate($restaurant, null, ['activable']);
+        $activationErrors = ValidationUtils::serializeValidationErrors($activationErrors);
+
         if ($form->isSubmitted() && $form->isValid()) {
             $restaurant = $form->getData();
 
@@ -64,6 +71,7 @@ trait RestaurantTrait
 
         return [
             'restaurant' => $restaurant,
+            'activationErrors' => $activationErrors,
             'form' => $form->createView(),
             'layout' => $layout,
             'menu_route' => $routes['menu'],

--- a/src/AppBundle/Entity/Restaurant.php
+++ b/src/AppBundle/Entity/Restaurant.php
@@ -96,6 +96,16 @@ class Restaurant extends FoodEstablishment
     protected $servesCuisine;
 
     /**
+     * @var boolean Is the restaurant enabled?
+     *
+     * A disable restaurant is not shown to visitors, either on search page or on its detail page.
+     *
+     * @ORM\Column(type="boolean", options={"default": false})
+     * @Groups({"restaurant"})
+     */
+    protected $enabled;
+
+    /**
      * @Vich\UploadableField(mapping="restaurant_image", fileNameProperty="imageName")
      * @Assert\File(maxSize = "1024k")
      * @var File
@@ -212,6 +222,22 @@ class Restaurant extends FoodEstablishment
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return $this->enabled;
+    }
+
+    /**
+     * @param bool $enabled
+     */
+    public function setEnabled(bool $enabled)
+    {
+        $this->enabled = $enabled;
     }
 
     public function getWebsite()

--- a/src/AppBundle/Entity/RestaurantRepository.php
+++ b/src/AppBundle/Entity/RestaurantRepository.php
@@ -14,6 +14,11 @@ class RestaurantRepository extends EntityRepository
 
         self::addNearbyQueryClause($qb, $latitude, $longitude, $distance);
 
+        $qb->add('where', $qb->expr()->eq(
+            'r.enabled',
+            $qb->expr()->literal(true)
+        ));
+
         return $qb;
     }
 

--- a/src/AppBundle/Form/RestaurantType.php
+++ b/src/AppBundle/Form/RestaurantType.php
@@ -7,6 +7,7 @@ use AppBundle\Entity\DeliveryService;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
@@ -28,6 +29,10 @@ class RestaurantType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
+            ->add('enabled', CheckboxType::class, [
+                'label' => 'restaurant.form.enabled.label',
+                'required' => false
+            ])
             ->add('name', TextType::class)
             ->add('website', UrlType::class, ['required' => false])
             ->add('address', AddressType::class)

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -1,5 +1,10 @@
 norestaurantfound: No restaurant open at this time!<br>Try a different delivery time.
 
+restaurant.disabledWarning: |
+  This restaurant is disabled so the site visitors can't see this page. If you want to, you can <a target="_blank" href="%restaurantEditUrl%">activate it in the admin</a>.
+restaurant.form.enabled.label: Activated restaurant?
+restaurant.form.enabled.tooltip: |
+  When disabled, a restaurant is not visible on the website. It doesn't show in search results and its own page is not accessible by visitors.
 restaurant.contract.title: Contract
 restaurant.contract.minimumCartAmount.label: Minimum cart amount
 restaurant.contract.flatDeliveryPrice.label: Fixed delivery price

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -11,6 +11,13 @@ restaurant.contract.flatDeliveryPrice.label: Fixed delivery price
 restaurant.contract.onlyAdmin: Only an administrator can edit contract details.
 restaurant.contract.noContract: No contract details. Please contact an administrator.
 
+restaurant.notActivable: "You can't enable this restaurant yet :"
+restaurant.openingHours.notBlank: Select at least one opened schedule
+restaurant.deliveryService.notBlank: Select a delivery service
+restaurant.telephone.notBlank: Enter your phone number
+restaurant.name.notBlank: Enter your restaurant's name
+restaurant.contract.notBlank: Enter the delivery contract terms (require admin privileges)
+
 profile.addresses.breadcrumb: Adresses
 profile.addresses.empty: No address saved yet!
 profile.orders.empty: No order yet!

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -126,6 +126,13 @@ restaurant.contract.flatDeliveryPrice.label: Prix fixe de la course
 restaurant.contract.onlyAdmin: Éditer les conditions contractuelles est réservé aux administrateurs.
 restaurant.contract.noContract: Pas de conditions contractuelles sauvegardées. Veuillez contacter un administrateur.
 
+restaurant.notActivable: "Vous ne pouvez pas encore activer ce restaurant :"
+restaurant.openingHours.notBlank: Sélectionnez au moins un créneau d'ouverture
+restaurant.deliveryService.notBlank: Sélectionnez un service de livraison
+restaurant.telephone.notBlank: Entrez votre numéro de téléphone
+restaurant.name.notBlank: Entrez le nom de votre restaurant
+restaurant.contract.notBlank: Entrez le contrat de livraison pour ce restaurant (nécessite d'être admin)
+
 menu.modifier.STRATEGY_FREE: Gratuit
 menu.modifier.STRATEGY_ADD_MODIFIER_PRICE: Prix du produit
 menu.modifier.STRATEGY_ADD_MENUITEM_PRICE: Supplément

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -109,11 +109,17 @@ Search restaurant…: Rechercher un restaurant…
 Add a restaurant: Ajouter un restaurant
 Restaurants managed by user: Restaurants gérés par l'utilisateur
 VAT: TVA
+Your changes were saved.: Vos changements ont été sauvegardés.
 
 profile.addresses.breadcrumb: Addresses
 profile.addresses.empty: Pas d'adresse sauvegardée pour le moment!
 profile.orders.empty: Pas de commande pour l'instant!
 
+restaurant.disabledWarning: |
+  Ce restaurant n'est pas activé et n'est donc pas visible des visiteurs du site. Si vous le désirez vous pouvez <a target="_blank" href="%restaurantEditUrl%">l'activer dans l'admin</a>.
+restaurant.form.enabled.label: Restaurant activé?
+restaurant.form.enabled.tooltip: |
+  Un restaurant activé n'est ni visible ni référencé sur le site. Il n'apparaît pas dans les résultats de recherche. Sa page dédiée n'est pas accessible par les visiteurs.
 restaurant.contract.title: Contrat
 restaurant.contract.minimumCartAmount.label: Montant minimum du panier
 restaurant.contract.flatDeliveryPrice.label: Prix fixe de la course

--- a/src/AppBundle/Resources/views/Restaurant/form.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/form.html.twig
@@ -52,6 +52,12 @@
     </div>
     <div class="col-sm-8">
       {{ form_row(form.name) }}
+      <div class="switch-wrapper margin-bottom-md">
+        {{ form_label(form.enabled) }} {{ form_widget(form.enabled, { attr: { class: 'checkbox switch' }}) }}&nbsp;
+        <a data-toggle="tooltip" data-placement="top" data-html="true" title="{{ "restaurant.form.enabled.tooltip" | trans | raw }}">
+          <i class="fa fa-info-circle"></i>
+        </a>
+      </div>
       {{ form_row(form.website) }}
       {{ form_row(form.telephone) }}
     </div>
@@ -134,33 +140,38 @@
 {% block scripts %}
 <script type="text/javascript">
 
-function addForm($container) {
-  var prototype = $container.data('prototype');
-  var index = $container
-    .find('select')
-    .filter(function() {
-      return this.name.match(/^restaurant\[servesCuisine\]/);
-    })
-    .length;
+  window.AppData = window.AppData || {};
+  window.AppData.__i18n = window.AppData.__i18n || {};
+  window.AppData.__i18n['Enabled'] = 'Enabled';
+  window.AppData.__i18n['Disabled'] = 'Disabled';
 
-  var form = prototype.replace(/__name__/g, index);
+  function addForm($container) {
+    var prototype = $container.data('prototype');
+    var index = $container
+      .find('select')
+      .filter(function() {
+        return this.name.match(/^restaurant\[servesCuisine\]/);
+      })
+      .length;
 
-  $container.append(form);
-}
+    var form = prototype.replace(/__name__/g, index);
 
-$(function() {
-  $(document).on('click', '[data-remove]', function(e) {
-    e.preventDefault();
-    $(e.target).closest('.form-group').remove();
+    $container.append(form);
+  }
+
+  $(function() {
+    $(document).on('click', '[data-remove]', function(e) {
+      e.preventDefault();
+      $(e.target).closest('.form-group').remove();
+    });
+
+    $('[data-toggle="add-cuisine"]').on('click', function(e) {
+      e.preventDefault();
+      var selector = $(e.target).data('target');
+      var $target = $(selector);
+      addForm($target);
+    });
   });
-
-  $('[data-toggle="add-cuisine"]').on('click', function(e) {
-    e.preventDefault();
-    var selector = $(e.target).data('target');
-    var $target = $(selector);
-    addForm($target);
-  });
-});
 </script>
 <script src="{{ asset('js/restaurant-form.js') }}"></script>
 <script src="https://maps.googleapis.com/maps/api/js?key={{ google_api_key }}&libraries=places&callback=initMap" async defer></script>

--- a/src/AppBundle/Resources/views/Restaurant/form.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/form.html.twig
@@ -44,6 +44,24 @@
   </div>
 {% endfor %}
 
+{% if activationErrors is not empty %}
+  <div class="row margin-bottom-md">
+    <div class="col-sm-6 col-md-offset-3">
+      <div class="alert alert-warning">
+        {% trans %}restaurant.notActivable{% endtrans %}
+        <ul class="restaurant-availability-errors">
+          {% for field, errors in activationErrors %}
+            <li class="margin-left-l">
+              {%  set error = errors[0] %}
+              {{ error | trans }}
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+{% endif  %}
+
 {{ form_start(form) }}
 
   <div class="row">

--- a/src/AppBundle/Resources/views/Restaurant/index.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/index.html.twig
@@ -1,7 +1,17 @@
 {% extends "AppBundle::base.html.twig" %}
+{% set restaurant_edit_route = is_granted('ROLE_ADMIN') ? 'admin_restaurant' : 'profile_restaurant' %}
+{% set restaurant_edit_url = path(restaurant_edit_route, { id: restaurant.id }) %}
 
 {% block body %}
 <div class="container">
+
+  {%  if not restaurant.enabled %}
+    <div class="row">
+      <div class="col-md-6 col-md-offset-3 alert alert-danger">
+        {{ "restaurant.disabledWarning" | trans({'%restaurantEditUrl%': restaurant_edit_url}) | raw }}
+      </div>
+    </div>
+  {%  endif %}
 
   <div class="page-header restaurant-header">
     <h1>{{ restaurant.name }}</h1>

--- a/tests/AppBundle/Entity/RestaurantTest.php
+++ b/tests/AppBundle/Entity/RestaurantTest.php
@@ -144,10 +144,10 @@ class RestaurantTest extends TestCase
 
         $errors = $this->validator->validate($restaurant, null, ['activable']);
         $errors = ValidationUtils::serializeValidationErrors($errors);
-        $this->assertEquals($errors['name'][0], 'restaurant.openingHours.notBlank');
-        $this->assertEquals($errors['telephone'][0], 'restaurant.deliveryService.notBlank');
-        $this->assertEquals($errors['openingHours'][0], 'restaurant.telephone.notBlank');
-        $this->assertEquals($errors['deliveryService'][0], 'restaurant.name.notBlank');
+        $this->assertEquals($errors['name'][0], 'restaurant.name.notBlank');
+        $this->assertEquals($errors['telephone'][0], 'restaurant.telephone.notBlank');
+        $this->assertEquals($errors['openingHours'][0], 'restaurant.openingHours.notBlank');
+        $this->assertEquals($errors['deliveryService'][0], 'restaurant.deliveryService.notBlank');
         $this->assertEquals($errors['contract'][0], 'restaurant.contract.notBlank');
 
     }

--- a/tests/AppBundle/Entity/RestaurantTest.php
+++ b/tests/AppBundle/Entity/RestaurantTest.php
@@ -3,10 +3,19 @@
 namespace Tests\AppBundle\Entity;
 
 use AppBundle\Entity\Restaurant;
+use AppBundle\Utils\ValidationUtils;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Validation;
 
 class RestaurantTest extends TestCase
 {
+    private $validator;
+
+    public function setUp()
+    {
+        $this->validator = Validation::createValidatorBuilder()->enableAnnotationMapping()->getValidator();
+    }
+
     public function testGetAvailabilities() {
         $restaurant = new Restaurant();
         $restaurant->setOpeningHours(["Mo-Sa 10:00-19:00"]);
@@ -127,6 +136,28 @@ class RestaurantTest extends TestCase
         $availabilities = $restaurant->getAvailabilities($date);
 
         $this->assertEquals([], $availabilities);
+
+    }
+
+    public function testValidationErrors() {
+        $restaurant = new Restaurant();
+
+        $errors = $this->validator->validate($restaurant, null, ['activable']);
+        $errors = ValidationUtils::serializeValidationErrors($errors);
+        $this->assertEquals($errors['name'][0], 'restaurant.openingHours.notBlank');
+        $this->assertEquals($errors['telephone'][0], 'restaurant.deliveryService.notBlank');
+        $this->assertEquals($errors['openingHours'][0], 'restaurant.telephone.notBlank');
+        $this->assertEquals($errors['deliveryService'][0], 'restaurant.name.notBlank');
+        $this->assertEquals($errors['contract'][0], 'restaurant.contract.notBlank');
+
+    }
+
+    public function testCannotEnableRestaurant() {
+        $restaurant = new Restaurant();
+        $restaurant->setEnabled(true);
+
+        $errors = $this->validator->validate($restaurant, null);
+        $this->assertEquals(ValidationUtils::serializeValidationErrors($errors)['enabled'][0], 'Unable to activate restaurant.');
 
     }
 }


### PR DESCRIPTION
Almost there still have an issue on error translations. I followed [this](http://symfony.com/doc/current/validation/translations.html) but it doesn't seem to work in the unit tests. If you have an idea @alexsegura.. (?)

PR add:
 - possibility to disable/enable a restaurant
 - admin and restaurant owner only can see the restaurant when disable (preview mode)
 - restaurant is disabled by default at creation, there is a checkup before possibility to activate

<img width="1392" alt="capture d ecran 2017-12-01 a 18 59 35" src="https://user-images.githubusercontent.com/4426585/33496257-d25d84c6-d6c9-11e7-87f3-4f1d5fc564c0.png">

