### PR TITLE
Introduce taxation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ addons:
 
 language: php
 php:
-  - '7.0.19'
-  - '7.1.5'
+  - '7.1.12'
+  - '7.2.0RC6'
 
 env:
   - SYMFONY_ENV=test COOPCYCLE_BASE_URL=http://localhost:8080

--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -13,11 +13,14 @@ class AppKernel extends Kernel
             new Symfony\Bundle\TwigBundle\TwigBundle(),
             new Symfony\Bundle\MonologBundle\MonologBundle(),
             new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
+            new Sylius\Bundle\TaxationBundle\SyliusTaxationBundle(),
+            new Sylius\Bundle\ResourceBundle\SyliusResourceBundle(),
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Dunglas\ActionBundle\DunglasActionBundle(),
             new ApiPlatform\Core\Bridge\Symfony\Bundle\ApiPlatformBundle(),
             new Nelmio\CorsBundle\NelmioCorsBundle(),
+            new FOS\RestBundle\FOSRestBundle(),
             new FOS\UserBundle\FOSUserBundle(),
             new Lexik\Bundle\JWTAuthenticationBundle\LexikJWTAuthenticationBundle(),
             new Gesdinet\JWTRefreshTokenBundle\GesdinetJWTRefreshTokenBundle(),
@@ -29,7 +32,8 @@ class AppKernel extends Kernel
             new Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle(),
             new AppBundle\AppBundle(),
             new Csa\Bundle\GuzzleBundle\CsaGuzzleBundle(),
-            new Misd\PhoneNumberBundle\MisdPhoneNumberBundle()
+            new Misd\PhoneNumberBundle\MisdPhoneNumberBundle(),
+            new winzou\Bundle\StateMachineBundle\winzouStateMachineBundle(),
         ];
 
         if (in_array($this->getEnvironment(), ['dev', 'test'], true)) {

--- a/app/DoctrineMigrations/Version20171130230406.php
+++ b/app/DoctrineMigrations/Version20171130230406.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171130230406 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE TABLE sylius_tax_category (id SERIAL NOT NULL, code VARCHAR(255) NOT NULL, name VARCHAR(255) NOT NULL, description TEXT DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_221EB0BE77153098 ON sylius_tax_category (code)');
+        $this->addSql('CREATE TABLE sylius_tax_rate (id SERIAL NOT NULL, category_id INT NOT NULL, code VARCHAR(255) NOT NULL, name VARCHAR(255) NOT NULL, amount NUMERIC(10, 5) NOT NULL, included_in_price BOOLEAN NOT NULL, calculator VARCHAR(255) NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE DEFAULT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_3CD86B2E77153098 ON sylius_tax_rate (code)');
+        $this->addSql('CREATE INDEX IDX_3CD86B2E12469DE2 ON sylius_tax_rate (category_id)');
+        $this->addSql('ALTER TABLE sylius_tax_rate ADD CONSTRAINT FK_3CD86B2E12469DE2 FOREIGN KEY (category_id) REFERENCES sylius_tax_category (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        $tax_categories = [
+            'tva_conso_immediate' => 'TVA consommation immédiate',
+            'tva_conso_differee' => 'TVA consommation différée',
+        ];
+
+        foreach ($tax_categories as $code => $name) {
+            $this->addSql("INSERT INTO sylius_tax_category (code, name, created_at, updated_at) VALUES (:code, :name, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)", [
+                'code' => $code,
+                'name' => $name
+            ]);
+        }
+
+        $tax_rates = [
+            'tva_10' => [
+                'category' => 'tva_conso_immediate',
+                'name' => 'Taux 10%',
+                'amount' => 10
+            ],
+            'tva_5_5' => [
+                'category' => 'tva_conso_differee',
+                'name' => 'Taux 5.5%',
+                'amount' => 5.5
+            ]
+        ];
+
+        foreach ($tax_rates as $code => $params) {
+            $this->addSql("INSERT INTO sylius_tax_rate (category_id, code, name, amount, included_in_price, calculator, created_at, updated_at) SELECT sylius_tax_category.id, :code, :name, :amount, TRUE, 'default', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP FROM sylius_tax_category WHERE sylius_tax_category.code = :category", [
+                'code' => $code,
+                'name' => $params['name'],
+                'amount' => $params['amount'],
+                'category' => $params['category'],
+            ]);
+        }
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE sylius_tax_rate DROP CONSTRAINT FK_3CD86B2E12469DE2');
+        $this->addSql('DROP TABLE sylius_tax_category');
+        $this->addSql('DROP TABLE sylius_tax_rate');
+    }
+}

--- a/app/DoctrineMigrations/Version20171130231943.php
+++ b/app/DoctrineMigrations/Version20171130231943.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171130231943 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE menu_item ADD tax_category_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE menu_item ADD CONSTRAINT FK_D754D5509DF894ED FOREIGN KEY (tax_category_id) REFERENCES sylius_tax_category (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_D754D5509DF894ED ON menu_item (tax_category_id)');
+        $this->addSql('ALTER TABLE modifier ADD tax_category_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE modifier ADD CONSTRAINT FK_ABBFD9FD9DF894ED FOREIGN KEY (tax_category_id) REFERENCES sylius_tax_category (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_ABBFD9FD9DF894ED ON modifier (tax_category_id)');
+
+        $this->addSql("UPDATE menu_item SET tax_category_id = (SELECT id FROM sylius_tax_category where code = 'tva_conso_immediate')");
+        $this->addSql("UPDATE modifier SET tax_category_id = (SELECT id FROM sylius_tax_category where code = 'tva_conso_immediate')");
+
+        $this->addSql('ALTER TABLE menu_item ALTER COLUMN tax_category_id SET NOT NULL');
+        $this->addSql('ALTER TABLE modifier ALTER COLUMN tax_category_id SET NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE menu_item DROP CONSTRAINT FK_D754D5509DF894ED');
+        $this->addSql('DROP INDEX IDX_D754D5509DF894ED');
+        $this->addSql('ALTER TABLE menu_item DROP tax_category_id');
+        $this->addSql('ALTER TABLE modifier DROP CONSTRAINT FK_ABBFD9FD9DF894ED');
+        $this->addSql('DROP INDEX IDX_ABBFD9FD9DF894ED');
+        $this->addSql('ALTER TABLE modifier DROP tax_category_id');
+    }
+}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -183,3 +183,5 @@ csa_guzzle:
                 base_uri: "%applicolis_api_base_url%"
                 lazy: true
 
+sylius_taxation:
+    driver: doctrine/orm

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -38,6 +38,10 @@ services:
     tags:
       - { name: kernel.event_subscriber }
 
+  'AppBundle\EventListener\SyliusIdGeneratorSubscriber':
+    tags:
+      - { name: doctrine.event_subscriber, connection: default }
+
   order.entity_listener:
     class: AppBundle\Entity\Listener\OrderListener
     arguments: [ "@security.token_storage", "@delivery_service_factory", "@snc_redis.default", "@serializer" ]

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr-4": { "Tests\\": "tests/" }
     },
     "require": {
-        "php": ">=7.0",
+        "php": "^7.1",
         "symfony/symfony": "3.3.*",
         "symfony/property-info": "3.3.*",
         "api-platform/core": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,8 @@
         "ramsey/uuid-doctrine": "^1.4",
         "ramsey/uuid": "^3.7",
         "misd/phone-number-bundle": "^1.2",
-        "nesbot/carbon": "^1.22"
+        "nesbot/carbon": "^1.22",
+        "sylius/taxation-bundle": "^1.0.4"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0a354d1e0c2b2c503bc9acb4755bdf21",
-    "content-hash": "28f13e6dde801e21db39e2ef62f18b11",
+    "hash": "ef29ae888d1757187516e5686c4c774c",
+    "content-hash": "a590bfea2521f8ccafe702869dcc13e8",
     "packages": [
         {
             "name": "api-platform/core",
@@ -1564,6 +1564,108 @@
             "time": "2016-10-17 18:31:11"
         },
         {
+            "name": "friendsofsymfony/rest-bundle",
+            "version": "2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FriendsOfSymfony/FOSRestBundle.git",
+                "reference": "24422b0b0ba3dcfe0649abb8637f92a101e9981a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FriendsOfSymfony/FOSRestBundle/zipball/24422b0b0ba3dcfe0649abb8637f92a101e9981a",
+                "reference": "24422b0b0ba3dcfe0649abb8637f92a101e9981a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "^1.0",
+                "php": "^5.5.9|~7.0",
+                "psr/log": "^1.0",
+                "symfony/config": "^2.7|^3.0|^4.0",
+                "symfony/debug": "^2.7|^3.0|^4.0",
+                "symfony/dependency-injection": "^2.7|^3.0|^4.0",
+                "symfony/event-dispatcher": "^2.7|^3.0|^4.0",
+                "symfony/finder": "^2.7|^3.0|^4.0",
+                "symfony/framework-bundle": "^2.7|^3.0|^4.0",
+                "symfony/http-foundation": "^2.7|^3.0|^4.0",
+                "symfony/http-kernel": "^2.7|^3.0|^4.0",
+                "symfony/routing": "^2.7|^3.0|^4.0",
+                "symfony/security-core": "^2.7|^3.0|^4.0",
+                "symfony/templating": "^2.7|^3.0|^4.0",
+                "willdurand/jsonp-callback-validator": "^1.0",
+                "willdurand/negotiation": "^2.0"
+            },
+            "conflict": {
+                "jms/serializer": "1.3.0",
+                "jms/serializer-bundle": "<1.2.0",
+                "sensio/framework-extra-bundle": "<3.0.13"
+            },
+            "require-dev": {
+                "jms/serializer-bundle": "^1.2|^2.0",
+                "phpoption/phpoption": "^1.1",
+                "psr/http-message": "^1.0",
+                "sensio/framework-extra-bundle": "^3.0.13|^4.0|^5.0",
+                "symfony/asset": "^2.7|^3.0|^4.0",
+                "symfony/browser-kit": "^2.7|^3.0|^4.0",
+                "symfony/css-selector": "^2.7|^3.0|^4.0",
+                "symfony/dependency-injection": "^2.7|^3.0|^4.0",
+                "symfony/expression-language": "~2.7|^3.0|^4.0",
+                "symfony/form": "^2.7|^3.0|^4.0",
+                "symfony/phpunit-bridge": "^3.2|^4.0",
+                "symfony/security-bundle": "^2.7|^3.0|^4.0",
+                "symfony/serializer": "^2.7.11|^3.0.4|^4.0",
+                "symfony/twig-bundle": "^2.7|^3.0|^4.0",
+                "symfony/validator": "^2.7|^3.0|^4.0",
+                "symfony/web-profiler-bundle": "^2.7|^3.0|^4.0",
+                "symfony/yaml": "^2.7|^3.0|^4.0"
+            },
+            "suggest": {
+                "jms/serializer-bundle": "Add support for advanced serialization capabilities, recommended, requires ^1.0",
+                "sensio/framework-extra-bundle": "Add support for route annotations and the view response listener, requires ^3.0",
+                "symfony/expression-language": "Add support for using the expression language in the routing, requires ^2.7|^3.0",
+                "symfony/serializer": "Add support for basic serialization capabilities and xml decoding, requires ^2.7|^3.0",
+                "symfony/validator": "Add support for validation capabilities in the ParamFetcher, requires ^2.7|^3.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "FOS\\RestBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lukas Kahwe Smith",
+                    "email": "smith@pooteeweet.org"
+                },
+                {
+                    "name": "FriendsOfSymfony Community",
+                    "homepage": "https://github.com/friendsofsymfony/FOSRestBundle/contributors"
+                },
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com"
+                }
+            ],
+            "description": "This Bundle provides various tools to rapidly develop RESTful API's with Symfony",
+            "homepage": "http://friendsofsymfony.github.com",
+            "keywords": [
+                "rest"
+            ],
+            "time": "2017-11-28 07:59:44"
+        },
+        {
             "name": "friendsofsymfony/user-bundle",
             "version": "dev-master",
             "source": {
@@ -2267,6 +2369,202 @@
             "time": "2016-12-05 10:18:33"
         },
         {
+            "name": "jms/parser-lib",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/parser-lib.git",
+                "reference": "c509473bc1b4866415627af0e1c6cc8ac97fa51d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/parser-lib/zipball/c509473bc1b4866415627af0e1c6cc8ac97fa51d",
+                "reference": "c509473bc1b4866415627af0e1c6cc8ac97fa51d",
+                "shasum": ""
+            },
+            "require": {
+                "phpoption/phpoption": ">=0.9,<2.0-dev"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "JMS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache2"
+            ],
+            "description": "A library for easily creating recursive-descent parsers.",
+            "time": "2012-11-18 18:08:43"
+        },
+        {
+            "name": "jms/serializer",
+            "version": "1.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/serializer.git",
+                "reference": "995270cddce65b9c14a58c11cf77116d28d9336c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/serializer/zipball/995270cddce65b9c14a58c11cf77116d28d9336c",
+                "reference": "995270cddce65b9c14a58c11cf77116d28d9336c",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0",
+                "doctrine/instantiator": "^1.0.3",
+                "jms/metadata": "~1.1",
+                "jms/parser-lib": "1.*",
+                "php": ">=5.5.0",
+                "phpcollection/phpcollection": "~0.1",
+                "phpoption/phpoption": "^1.1"
+            },
+            "conflict": {
+                "jms/serializer-bundle": "<1.2.1",
+                "twig/twig": "<1.12"
+            },
+            "require-dev": {
+                "doctrine/orm": "~2.1",
+                "doctrine/phpcr-odm": "^1.3|^2.0",
+                "ext-pdo_sqlite": "*",
+                "jackalope/jackalope-doctrine-dbal": "^1.1.5",
+                "phpunit/phpunit": "^4.8|^5.0",
+                "propel/propel1": "~1.7",
+                "symfony/expression-language": "^2.6|^3.0",
+                "symfony/filesystem": "^2.1",
+                "symfony/form": "~2.1|^3.0",
+                "symfony/translation": "^2.1|^3.0",
+                "symfony/validator": "^2.2|^3.0",
+                "symfony/yaml": "^2.1|^3.0",
+                "twig/twig": "~1.12|~2.0"
+            },
+            "suggest": {
+                "doctrine/cache": "Required if you like to use cache functionality.",
+                "doctrine/collections": "Required if you like to use doctrine collection types as ArrayCollection.",
+                "symfony/yaml": "Required if you'd like to serialize data to YAML format."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "JMS\\Serializer": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                },
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Library for (de-)serializing data of any complexity; supports XML, JSON, and YAML.",
+            "homepage": "http://jmsyst.com/libs/serializer",
+            "keywords": [
+                "deserialization",
+                "jaxb",
+                "json",
+                "serialization",
+                "xml"
+            ],
+            "time": "2017-11-22 16:45:19"
+        },
+        {
+            "name": "jms/serializer-bundle",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/JMSSerializerBundle.git",
+                "reference": "dd40bfcb58ce01a950393f258d3d02a8dc4f4127"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/JMSSerializerBundle/zipball/dd40bfcb58ce01a950393f258d3d02a8dc4f4127",
+                "reference": "dd40bfcb58ce01a950393f258d3d02a8dc4f4127",
+                "shasum": ""
+            },
+            "require": {
+                "jms/serializer": "^1.9",
+                "php": "^5.4|^7.0",
+                "phpoption/phpoption": "^1.1.0",
+                "symfony/framework-bundle": "~2.3|~3.0|~4.0"
+            },
+            "require-dev": {
+                "doctrine/doctrine-bundle": "*",
+                "doctrine/orm": "*",
+                "phpunit/phpunit": "^4.8.35|^5.4.3|^6.0",
+                "symfony/browser-kit": "*",
+                "symfony/class-loader": "*",
+                "symfony/css-selector": "*",
+                "symfony/expression-language": "~2.6|~3.0|~4.0",
+                "symfony/finder": "*",
+                "symfony/form": "*",
+                "symfony/process": "*",
+                "symfony/stopwatch": "*",
+                "symfony/twig-bundle": "*",
+                "symfony/validator": "*",
+                "symfony/yaml": "*"
+            },
+            "suggest": {
+                "jms/di-extra-bundle": "Required to get lazy loading (de)serialization visitors, ~1.3"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "JMS\\SerializerBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                },
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Allows you to easily serialize, and deserialize data of any complexity",
+            "homepage": "http://jmsyst.com/bundles/JMSSerializerBundle",
+            "keywords": [
+                "deserialization",
+                "jaxb",
+                "json",
+                "serialization",
+                "xml"
+            ],
+            "time": "2017-09-29 08:48:26"
+        },
+        {
             "name": "jsor/doctrine-postgis",
             "version": "v1.5.0",
             "source": {
@@ -2924,7 +3222,7 @@
                 "datetime",
                 "time"
             ],
-            "time": "2017-01-16T07:55:07+00:00"
+            "time": "2017-01-16 07:55:07"
         },
         {
             "name": "ocramius/package-versions",
@@ -3041,6 +3339,75 @@
             "time": "2016-11-04 15:53:15"
         },
         {
+            "name": "pagerfanta/pagerfanta",
+            "version": "v1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/whiteoctober/Pagerfanta.git",
+                "reference": "29aade64addfdfb12c05aabf160f09d1aea6b143"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/whiteoctober/Pagerfanta/zipball/29aade64addfdfb12c05aabf160f09d1aea6b143",
+                "reference": "29aade64addfdfb12c05aabf160f09d1aea6b143",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "doctrine/orm": "~2.3",
+                "doctrine/phpcr-odm": "1.*",
+                "jackalope/jackalope-doctrine-dbal": "1.*",
+                "jmikola/geojson": "~1.0",
+                "mandango/mandango": "~1.0@dev",
+                "mandango/mondator": "~1.0@dev",
+                "phpunit/phpunit": "~4 | ~5",
+                "propel/propel": "~2.0@dev",
+                "propel/propel1": "~1.6",
+                "ruflin/elastica": "~1.3",
+                "solarium/solarium": "~3.1"
+            },
+            "suggest": {
+                "doctrine/mongodb-odm": "To use the DoctrineODMMongoDBAdapter.",
+                "doctrine/orm": "To use the DoctrineORMAdapter.",
+                "doctrine/phpcr-odm": "To use the DoctrineODMPhpcrAdapter. >= 1.1.0",
+                "mandango/mandango": "To use the MandangoAdapter.",
+                "propel/propel": "To use the Propel2Adapter",
+                "propel/propel1": "To use the PropelAdapter",
+                "solarium/solarium": "To use the SolariumAdapter."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Pagerfanta\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pablo Díez",
+                    "email": "pablodip@gmail.com"
+                }
+            ],
+            "description": "Pagination for PHP 5.3",
+            "keywords": [
+                "page",
+                "pagination",
+                "paginator",
+                "paging"
+            ],
+            "time": "2017-03-20 13:46:15"
+        },
+        {
             "name": "paragonie/random_compat",
             "version": "v2.0.11",
             "source": {
@@ -3087,6 +3454,54 @@
                 "random"
             ],
             "time": "2017-09-27 21:40:39"
+        },
+        {
+            "name": "phpcollection/phpcollection",
+            "version": "0.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/php-collection.git",
+                "reference": "f2bcff45c0da7c27991bbc1f90f47c4b7fb434a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/php-collection/zipball/f2bcff45c0da7c27991bbc1f90f47c4b7fb434a6",
+                "reference": "f2bcff45c0da7c27991bbc1f90f47c4b7fb434a6",
+                "shasum": ""
+            },
+            "require": {
+                "phpoption/phpoption": "1.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PhpCollection": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "General-Purpose Collection Library for PHP",
+            "keywords": [
+                "collection",
+                "list",
+                "map",
+                "sequence",
+                "set"
+            ],
+            "time": "2015-05-17 12:39:23"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3233,6 +3648,56 @@
                 }
             ],
             "time": "2017-07-14 14:27:02"
+        },
+        {
+            "name": "phpoption/phpoption",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/schmittjoh/php-option.git",
+                "reference": "94e644f7d2051a5f0fcf77d81605f152eecff0ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/94e644f7d2051a5f0fcf77d81605f152eecff0ed",
+                "reference": "94e644f7d2051a5f0fcf77d81605f152eecff0ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.7.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PhpOption\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Johannes M. Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Option Type for PHP",
+            "keywords": [
+                "language",
+                "option",
+                "php",
+                "type"
+            ],
+            "time": "2015-07-25 16:39:46"
         },
         {
             "name": "predis/predis",
@@ -4155,6 +4620,67 @@
             "time": "2016-06-17 11:50:26"
         },
         {
+            "name": "stof/doctrine-extensions-bundle",
+            "version": "v1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/stof/StofDoctrineExtensionsBundle.git",
+                "reference": "4e7499d25dc5d0862da09fa8e336164948a29a25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stof/StofDoctrineExtensionsBundle/zipball/4e7499d25dc5d0862da09fa8e336164948a29a25",
+                "reference": "4e7499d25dc5d0862da09fa8e336164948a29a25",
+                "shasum": ""
+            },
+            "require": {
+                "gedmo/doctrine-extensions": "^2.3.1",
+                "php": ">=5.3.2",
+                "symfony/framework-bundle": "~2.1|~3.0"
+            },
+            "suggest": {
+                "doctrine/doctrine-bundle": "to use the ORM extensions",
+                "doctrine/mongodb-odm-bundle": "to use the MongoDB ODM extensions"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Stof\\DoctrineExtensionsBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christophe Coevoet",
+                    "email": "stof@notk.org"
+                }
+            ],
+            "description": "Integration of the gedmo/doctrine-extensions with Symfony2",
+            "homepage": "https://github.com/stof/StofDoctrineExtensionsBundle",
+            "keywords": [
+                "behaviors",
+                "doctrine2",
+                "extensions",
+                "gedmo",
+                "loggable",
+                "nestedset",
+                "sluggable",
+                "sortable",
+                "timestampable",
+                "translatable",
+                "tree"
+            ],
+            "time": "2016-01-26 23:58:32"
+        },
+        {
             "name": "stripe/stripe-php",
             "version": "v4.13.0",
             "source": {
@@ -4262,6 +4788,374 @@
                 "mailer"
             ],
             "time": "2017-05-01 15:54:03"
+        },
+        {
+            "name": "sylius/registry",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Sylius/Registry.git",
+                "reference": "90ac694e99e89df3e7d62157822dbee1842ca98d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Sylius/Registry/zipball/90ac694e99e89df3e7d62157822dbee1842ca98d",
+                "reference": "90ac694e99e89df3e7d62157822dbee1842ca98d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "webmozart/assert": "^1.0",
+                "zendframework/zend-stdlib": "^3.1"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sylius\\Component\\Registry\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sylius project",
+                    "homepage": "http://sylius.org"
+                },
+                {
+                    "name": "Community contributions",
+                    "homepage": "http://github.com/Sylius/Sylius/contributors"
+                },
+                {
+                    "name": "Paweł Jędrzejewski",
+                    "homepage": "http://pjedrzejewski.com"
+                }
+            ],
+            "description": "Services registry.",
+            "homepage": "http://sylius.org",
+            "keywords": [
+                "registry",
+                "services"
+            ],
+            "time": "2017-10-24 09:00:15"
+        },
+        {
+            "name": "sylius/resource",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Sylius/Resource.git",
+                "reference": "7dc788d217f57deea8c713c34bf6a8fb27649b0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Sylius/Resource/zipball/7dc788d217f57deea8c713c34bf6a8fb27649b0d",
+                "reference": "7dc788d217f57deea8c713c34bf6a8fb27649b0d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/common": "^2.6",
+                "gedmo/doctrine-extensions": "^2.4",
+                "pagerfanta/pagerfanta": "^1.0",
+                "php": "^7.1",
+                "symfony/event-dispatcher": "^3.2",
+                "symfony/polyfill-php70": "~1.0",
+                "symfony/property-access": "^3.2",
+                "winzou/state-machine": "^0.3"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^4.0",
+                "sylius/locale": "^1.0"
+            },
+            "suggest": {
+                "sylius/locale": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sylius\\Component\\Resource\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sylius project",
+                    "homepage": "http://sylius.org"
+                },
+                {
+                    "name": "Community contributions",
+                    "homepage": "http://github.com/Sylius/Sylius/contributors"
+                },
+                {
+                    "name": "Paweł Jędrzejewski",
+                    "homepage": "http://pjedrzejewski.com"
+                }
+            ],
+            "description": "Basic resource interfaces for PHP applications.",
+            "homepage": "http://sylius.org",
+            "keywords": [
+                "api",
+                "doctrine",
+                "ecommerce",
+                "resource",
+                "shop",
+                "sylius"
+            ],
+            "time": "2017-11-07 12:24:44"
+        },
+        {
+            "name": "sylius/resource-bundle",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Sylius/SyliusResourceBundle.git",
+                "reference": "af7a2cb9928b5cfc3a12e77968b09754c002d51b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Sylius/SyliusResourceBundle/zipball/af7a2cb9928b5cfc3a12e77968b09754c002d51b",
+                "reference": "af7a2cb9928b5cfc3a12e77968b09754c002d51b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/doctrine-bundle": "^1.6",
+                "friendsofsymfony/rest-bundle": "^2.1",
+                "jms/serializer-bundle": "^2.0",
+                "php": "^7.1",
+                "stof/doctrine-extensions-bundle": "^1.2",
+                "sylius/registry": "^1.0",
+                "sylius/resource": "^1.0",
+                "symfony/config": "^3.2",
+                "symfony/expression-language": "^3.2",
+                "symfony/form": "^3.2",
+                "symfony/framework-bundle": "^3.2",
+                "symfony/security-csrf": "^3.2",
+                "symfony/templating": "^3.2",
+                "symfony/twig-bundle": "^3.2",
+                "symfony/validator": "^3.2",
+                "symfony/yaml": "^3.2",
+                "white-october/pagerfanta-bundle": "^1.0",
+                "willdurand/hateoas-bundle": "^1.2",
+                "winzou/state-machine-bundle": "^0.3"
+            },
+            "require-dev": {
+                "akeneo/phpspec-skip-example-extension": "^3.0@alpha",
+                "doctrine/mongodb-odm": "^1.0",
+                "doctrine/orm": "~2.5.0",
+                "doctrine/phpcr-odm": "^1.4",
+                "incenteev/composer-parameter-handler": "^2.1",
+                "jackalope/jackalope-doctrine-dbal": "^1.2",
+                "lakion/api-test-case": "^1.0",
+                "matthiasnoback/symfony-dependency-injection-test": "^1.0",
+                "phpspec/phpspec": "^4.0",
+                "phpunit/phpunit": "^5.6",
+                "sensio/generator-bundle": "^3.1",
+                "sylius/grid-bundle": "^1.0",
+                "sylius/locale": "^1.0",
+                "twig/twig": "^2.0"
+            },
+            "suggest": {
+                "doctrine/orm": "~2.5.0",
+                "sylius/locale": "^1.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "incenteev-parameters": {
+                    "file": "test/app/config/parameters.yml",
+                    "dist-file": "test/app/config/parameters.yml.dist"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sylius\\Bundle\\ResourceBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sylius project",
+                    "homepage": "http://sylius.org"
+                },
+                {
+                    "name": "Community contributions",
+                    "homepage": "http://github.com/Sylius/Sylius/contributors"
+                },
+                {
+                    "name": "Paweł Jędrzejewski",
+                    "homepage": "http://pjedrzejewski.com"
+                }
+            ],
+            "description": "Resource component for Sylius.",
+            "homepage": "http://sylius.org",
+            "keywords": [
+                "persistence",
+                "resource",
+                "storage",
+                "sylius"
+            ],
+            "time": "2017-11-17 09:55:22"
+        },
+        {
+            "name": "sylius/taxation",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Sylius/Taxation.git",
+                "reference": "b420cee06f9796277012f919009638c5c78fa013"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Sylius/Taxation/zipball/b420cee06f9796277012f919009638c5c78fa013",
+                "reference": "b420cee06f9796277012f919009638c5c78fa013",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "sylius/registry": "^1.0",
+                "sylius/resource": "^1.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sylius\\Component\\Taxation\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sylius project",
+                    "homepage": "http://sylius.org"
+                },
+                {
+                    "name": "Community contributions",
+                    "homepage": "http://github.com/Sylius/Sylius/contributors"
+                },
+                {
+                    "name": "Paweł Jędrzejewski",
+                    "homepage": "http://pjedrzejewski.com"
+                }
+            ],
+            "description": "Flexible taxation system for PHP ecommerce applications.",
+            "homepage": "http://sylius.org",
+            "keywords": [
+                "ecommerce",
+                "shop",
+                "sylius",
+                "tax",
+                "taxation",
+                "taxes",
+                "vat"
+            ],
+            "time": "2017-10-20 20:25:32"
+        },
+        {
+            "name": "sylius/taxation-bundle",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Sylius/SyliusTaxationBundle.git",
+                "reference": "a084293772700efc46d39748479001bc46eb07aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Sylius/SyliusTaxationBundle/zipball/a084293772700efc46d39748479001bc46eb07aa",
+                "reference": "a084293772700efc46d39748479001bc46eb07aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "stof/doctrine-extensions-bundle": "^1.2",
+                "sylius/registry": "^1.0",
+                "sylius/resource-bundle": "^1.0",
+                "sylius/taxation": "^1.0",
+                "symfony/framework-bundle": "^3.2"
+            },
+            "require-dev": {
+                "doctrine/orm": "~2.5.0",
+                "incenteev/composer-parameter-handler": "~2.0",
+                "phpspec/phpspec": "^4.0",
+                "phpunit/phpunit": "^5.6",
+                "polishsymfonycommunity/symfony-mocker-container": "^1.0",
+                "symfony/browser-kit": "^3.2",
+                "symfony/form": "^3.2"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "incenteev-parameters": {
+                    "file": "test/app/config/parameters.yml"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sylius\\Bundle\\TaxationBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sylius project",
+                    "homepage": "http://sylius.org"
+                },
+                {
+                    "name": "Community contributions",
+                    "homepage": "http://github.com/Sylius/Sylius/contributors"
+                },
+                {
+                    "name": "Paweł Jędrzejewski",
+                    "homepage": "http://pjedrzejewski.com"
+                }
+            ],
+            "description": "Flexible taxation system for Symfony2 ecommerce applications.",
+            "homepage": "http://sylius.org",
+            "keywords": [
+                "ecommerce",
+                "shop",
+                "tax",
+                "taxation",
+                "taxes",
+                "webshop"
+            ],
+            "time": "2017-11-07 04:05:32"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -5182,6 +6076,58 @@
             "time": "2016-11-23 20:04:58"
         },
         {
+            "name": "white-october/pagerfanta-bundle",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/whiteoctober/WhiteOctoberPagerfantaBundle.git",
+                "reference": "9b1f3d43eaeebaf1e2b8d9f8be394c0785184df3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/whiteoctober/WhiteOctoberPagerfantaBundle/zipball/9b1f3d43eaeebaf1e2b8d9f8be394c0785184df3",
+                "reference": "9b1f3d43eaeebaf1e2b8d9f8be394c0785184df3",
+                "shasum": ""
+            },
+            "require": {
+                "pagerfanta/pagerfanta": "1.0.*",
+                "symfony/framework-bundle": "~2.3|~3.0|~4.0",
+                "symfony/property-access": "~2.3|~3.0|~4.0",
+                "symfony/twig-bundle": "~2.3|~3.0|~4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7|~4.0",
+                "symfony/symfony": "~2.3|~3.0|~4.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "WhiteOctober\\PagerfantaBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Pablo Díez",
+                    "email": "pablodip@gmail.com"
+                }
+            ],
+            "description": "Bundle to use Pagerfanta with Symfony2",
+            "keywords": [
+                "page",
+                "paging"
+            ],
+            "time": "2017-11-30 12:07:11"
+        },
+        {
             "name": "willdurand/geocoder",
             "version": "v3.3.2",
             "source": {
@@ -5242,6 +6188,163 @@
             "time": "2015-12-06 20:17:20"
         },
         {
+            "name": "willdurand/hateoas",
+            "version": "2.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/willdurand/Hateoas.git",
+                "reference": "bc5c1035f7f040f13810fbed9ac87ba540af7758"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/willdurand/Hateoas/zipball/bc5c1035f7f040f13810fbed9ac87ba540af7758",
+                "reference": "bc5c1035f7f040f13810fbed9ac87ba540af7758",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "~1.0",
+                "doctrine/common": "~2.0",
+                "jms/metadata": "~1.1",
+                "jms/serializer": "^1.7",
+                "php": "^5.5|^7.0",
+                "phpoption/phpoption": ">=1.1.0,<2.0-dev",
+                "symfony/expression-language": "~2.4 || ~3.0"
+            },
+            "require-dev": {
+                "pagerfanta/pagerfanta": "~1.0",
+                "phpunit/phpunit": "~4.5",
+                "symfony/dependency-injection": "~2.4 || ~3.0",
+                "symfony/routing": "~2.4 || ~3.0",
+                "symfony/yaml": "~2.4 || ~3.0",
+                "twig/twig": "~1.12"
+            },
+            "suggest": {
+                "symfony/routing": "To use the SymfonyRouteFactory.",
+                "symfony/yaml": "To use yaml based configuration.",
+                "twig/twig": "To use the Twig extensions."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.11-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Hateoas": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Adrien Brault",
+                    "email": "adrien.brault@gmail.com"
+                },
+                {
+                    "name": "William Durand",
+                    "email": "william.durand1@gmail.com"
+                }
+            ],
+            "description": "A PHP library to support implementing representations for HATEOAS REST web services",
+            "time": "2017-05-22 10:27:33"
+        },
+        {
+            "name": "willdurand/hateoas-bundle",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/willdurand/BazingaHateoasBundle.git",
+                "reference": "bf57a3e45a26937726f370933eec4d8a7062733c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/willdurand/BazingaHateoasBundle/zipball/bf57a3e45a26937726f370933eec4d8a7062733c",
+                "reference": "bf57a3e45a26937726f370933eec4d8a7062733c",
+                "shasum": ""
+            },
+            "require": {
+                "jms/serializer-bundle": "~1.0 || ^2.0",
+                "php": ">5.4",
+                "symfony/framework-bundle": "~2.3 || ~3.0",
+                "willdurand/hateoas": "^2.10.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5",
+                "symfony/expression-language": "~2.4 || ~3.0",
+                "twig/twig": "~1.12"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Bazinga\\Bundle\\HateoasBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "William Durand",
+                    "email": "william.durand1@gmail.com"
+                }
+            ],
+            "description": "Integration of Hateoas into Symfony2.",
+            "keywords": [
+                "HATEOAS",
+                "rest"
+            ],
+            "time": "2017-06-07 17:54:37"
+        },
+        {
+            "name": "willdurand/jsonp-callback-validator",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/willdurand/JsonpCallbackValidator.git",
+                "reference": "1a7d388bb521959e612ef50c5c7b1691b097e909"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/willdurand/JsonpCallbackValidator/zipball/1a7d388bb521959e612ef50c5c7b1691b097e909",
+                "reference": "1a7d388bb521959e612ef50c5c7b1691b097e909",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "JsonpCallbackValidator": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "William Durand",
+                    "email": "william.durand1@gmail.com",
+                    "homepage": "http://www.willdurand.fr"
+                }
+            ],
+            "description": "JSONP callback validator.",
+            "time": "2014-01-20 22:35:06"
+        },
+        {
             "name": "willdurand/negotiation",
             "version": "v2.3.1",
             "source": {
@@ -5292,6 +6395,106 @@
                 "negotiation"
             ],
             "time": "2017-05-14 17:21:12"
+        },
+        {
+            "name": "winzou/state-machine",
+            "version": "0.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/winzou/state-machine.git",
+                "reference": "4ef48e7bba494514f36884a618a9b889eec3a5b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/winzou/state-machine/zipball/4ef48e7bba494514f36884a618a9b889eec3a5b0",
+                "reference": "4ef48e7bba494514f36884a618a9b889eec3a5b0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "symfony/event-dispatcher": "~2.1|~3.0",
+                "symfony/expression-language": "~2.4|~3.0",
+                "symfony/property-access": "~2.1|~3.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "~2.0",
+                "twig/twig": "~1.0"
+            },
+            "suggest": {
+                "twig/twig": "Access the state machine in your twig templates (~1.0)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "SM": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexandre Bacco",
+                    "email": "alexandre.bacco@gmail.com",
+                    "homepage": "http://alex.bacco.fr"
+                }
+            ],
+            "description": "A very lightweight yet powerful PHP state machine",
+            "homepage": "https://github.com/winzou/StateMachine",
+            "keywords": [
+                "callback",
+                "event",
+                "state",
+                "statemachine"
+            ],
+            "time": "2016-11-03 13:24:00"
+        },
+        {
+            "name": "winzou/state-machine-bundle",
+            "version": "v0.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/winzou/StateMachineBundle.git",
+                "reference": "ce9e0c50ecf6a257fe59ee5ad087710efd905f77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/winzou/StateMachineBundle/zipball/ce9e0c50ecf6a257fe59ee5ad087710efd905f77",
+                "reference": "ce9e0c50ecf6a257fe59ee5ad087710efd905f77",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">5.3.0",
+                "symfony/framework-bundle": "~2.1|~3.0",
+                "winzou/state-machine": "~0.3"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "~2.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "winzou\\Bundle\\StateMachineBundle\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alexandre Bacco",
+                    "homepage": "http://alex.bacco.fr"
+                }
+            ],
+            "description": "Bundle for the very lightweight yet powerful PHP state machine",
+            "keywords": [
+                "bundle",
+                "statemachine",
+                "symfony"
+            ],
+            "time": "2016-10-28 03:32:52"
         },
         {
             "name": "zendframework/zend-code",
@@ -5451,6 +6654,51 @@
                 "zf2"
             ],
             "time": "2017-07-11 19:17:22"
+        },
+        {
+            "name": "zendframework/zend-stdlib",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/debedcfc373a293f9250cc9aa03cf121428c8e78",
+                "reference": "debedcfc373a293f9250cc9aa03cf121428c8e78",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "^2.6.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev",
+                    "dev-develop": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-stdlib",
+            "keywords": [
+                "stdlib",
+                "zf2"
+            ],
+            "time": "2016-09-13 14:38:50"
         }
     ],
     "packages-dev": [
@@ -7777,7 +9025,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0"
+        "php": "^7.1"
     },
     "platform-dev": []
 }

--- a/features/fixtures/ORM/restaurants.yml
+++ b/features/fixtures/ORM/restaurants.yml
@@ -1,3 +1,17 @@
+Sylius\Component\Taxation\Model\TaxCategory:
+  tva_conso_immediate:
+    code: tva_conso_immediate
+    name: "TVA consommation immédiate"
+
+Sylius\Component\Taxation\Model\TaxRate:
+  tva_10:
+    name: "TVA 10%"
+    code: tva_10
+    category: "@tva_conso_immediate"
+    amount: 10.00
+    includedInPrice: true
+    calculator: default
+
 AppBundle\Entity\Base\GeoCoordinates:
   geo_1:
     __construct: [ "48.864577", "2.333338" ]
@@ -10,6 +24,7 @@ AppBundle\Entity\Menu\MenuItem:
   menu_item_{1..9}:
     name: <name()>
     price: <numberBetween(5, 10)>.99
+    tax_category: "@tva_conso_immediate"
 
 AppBundle\Entity\Menu\MenuSection:
   menu_section_1:

--- a/src/AppBundle/Entity/Base/MenuItem.php
+++ b/src/AppBundle/Entity/Base/MenuItem.php
@@ -5,6 +5,8 @@ namespace AppBundle\Entity\Base;
 use AppBundle\Entity\Base\Thing;
 use Doctrine\ORM\Mapping as ORM;
 use ApiPlatform\Core\Annotation\ApiProperty;
+use Sylius\Component\Taxation\Model\TaxCategoryInterface;
+use Sylius\Component\Taxation\Model\TaxableInterface;
 
 /**
  * A food or drink item listed in a menu or menu section.
@@ -13,7 +15,7 @@ use ApiPlatform\Core\Annotation\ApiProperty;
  *
  * @ORM\MappedSuperclass
  */
-abstract class MenuItem extends Thing
+abstract class MenuItem extends Thing implements TaxableInterface
 {
     /**
      * @var int
@@ -23,6 +25,12 @@ abstract class MenuItem extends Thing
      * @ORM\GeneratedValue(strategy="IDENTITY")
      */
     private $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Sylius\Component\Taxation\Model\TaxCategoryInterface")
+     * @ORM\JoinColumn(name="tax_category_id", referencedColumnName="id", nullable=false)
+     */
+    private $taxCategory;
 
     /**
      * @var float The offer price of a product, or of a price component when attached to PriceSpecification and its subtypes.
@@ -38,7 +46,6 @@ abstract class MenuItem extends Thing
      * @ApiProperty(iri="https://schema.org/price")
      */
     protected $price;
-
 
     /**
      * Gets id.
@@ -72,5 +79,15 @@ abstract class MenuItem extends Thing
     public function getPrice()
     {
         return $this->price;
+    }
+
+    public function getTaxCategory(): ?TaxCategoryInterface
+    {
+        return $this->taxCategory;
+    }
+
+    public function setTaxCategory(TaxCategoryInterface $taxCategory)
+    {
+        $this->taxCategory = $taxCategory;
     }
 }

--- a/src/AppBundle/EventListener/SyliusIdGeneratorSubscriber.php
+++ b/src/AppBundle/EventListener/SyliusIdGeneratorSubscriber.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace AppBundle\EventListener;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Id\IdentityGenerator;
+use Doctrine\ORM\Mapping\ClassMetadataInfo;
+
+/**
+ * This class is needed because Sylius uses the "AUTO" strategy, which doesn't work in PostgreSQL.
+ */
+class SyliusIdGeneratorSubscriber implements EventSubscriber
+{
+    public function getSubscribedEvents()
+    {
+        return array(
+            'loadClassMetadata',
+        );
+    }
+
+    public function loadClassMetadata(LoadClassMetadataEventArgs $args)
+    {
+        $metadata = $args->getClassMetadata();
+
+        $classes = [
+            'Sylius\Component\Taxation\Model\TaxCategory',
+            'Sylius\Component\Taxation\Model\TaxRate',
+        ];
+
+        if (!in_array($metadata->getName(), $classes)) {
+            return;
+        }
+
+        if (!$metadata->isIdGeneratorIdentity()) {
+            $metadata->setIdGenerator(new IdentityGenerator($metadata->sequenceGeneratorDefinition['sequenceName']));
+            $metadata->setIdGeneratorType(ClassMetadataInfo::GENERATOR_TYPE_IDENTITY);
+        }
+    }
+}

--- a/src/AppBundle/Form/MenuItemType.php
+++ b/src/AppBundle/Form/MenuItemType.php
@@ -4,6 +4,8 @@ namespace AppBundle\Form;
 
 use AppBundle\Entity\Menu\MenuItem;
 use AppBundle\Form\MenuType\MenuItemModifierType;
+use Sylius\Bundle\TaxationBundle\Form\Type\TaxCategoryChoiceType;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
@@ -21,6 +23,7 @@ class MenuItemType extends AbstractType
             ->add('name', TextType::class)
             ->add('description', TextareaType::class, ['required' => false])
             ->add('price', MoneyType::class)
+            ->add('taxCategory', TaxCategoryChoiceType::class)
             ->add('isAvailable', CheckboxType::class, [
                 'label' => 'Available product?',
                 'required' => false

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -108,6 +108,7 @@ Edit user: Modifier l'utilisateur
 Search restaurant…: Rechercher un restaurant…
 Add a restaurant: Ajouter un restaurant
 Restaurants managed by user: Restaurants gérés par l'utilisateur
+VAT: TVA
 
 profile.addresses.breadcrumb: Addresses
 profile.addresses.empty: Pas d'adresse sauvegardée pour le moment!

--- a/src/AppBundle/Resources/views/Form/menu.html.twig
+++ b/src/AppBundle/Resources/views/Form/menu.html.twig
@@ -73,22 +73,26 @@
   {% set containerSelector = form.vars.id ~ '_container' %}
   <div class="list-group-item" id="{{ form.vars.id }}">
     <div class="form-group row">
-      <div class="col-sm-6">
+      <div class="col-sm-3">
         {{ form_label(form.name) }}
         {{ form_widget(form.name, { attr: { class: 'input-sm' } }) }}
       </div>
-      <div class="col-sm-2">
+      <div class="col-sm-3">
         {{ form_label(form.price) }}
         {{ form_widget(form.price, { attr: { class: 'input-sm text-right' } }) }}
       </div>
       <div class="col-sm-3">
-        {{ form_widget(form.isAvailable, { attr: { class: 'checkbox switch' }}) }}
+        {{ form_label(form.taxCategory, 'VAT'|trans([], 'messages')) }}
+        {{ form_widget(form.taxCategory) }}
       </div>
-      <div class="col-sm-1">
-        <button type="button" class="close" aria-label="Close" tabindex="-1"
-          data-target="{{ '#' ~ form.vars.id }}">
-          <span aria-hidden="true">&times;</span>
-        </button>
+      <div class="col-sm-3">
+        {{ form_widget(form.isAvailable, { attr: { class: 'checkbox switch' }}) }}
+        <div class="pull-right">
+          <button type="button" class="close" aria-label="Close" tabindex="-1"
+            data-target="{{ '#' ~ form.vars.id }}">
+            <i class="fa fa-trash"></i>
+          </button>
+        </div>
       </div>
     </div>
     <div class="form-group show-description">
@@ -160,7 +164,7 @@
     <div class="col-sm-1">
       <button type="button" class="close" aria-label="Close" tabindex="-1"
         data-target="{{ '#' ~ form.vars.id }}">
-        <span aria-hidden="true">&times;</span>
+        <i class="fa fa-trash"></i>
       </button>
     </div>
   </div>
@@ -184,7 +188,7 @@
   <div class="col-sm-3">
     <button type="button" class="close" aria-label="Close" tabindex="-1"
       data-target="{{ '#' ~ form.vars.id }}">
-      <span aria-hidden="true">&times;</span>
+      <i class="fa fa-trash"></i>
     </button>
   </div>
 </div>

--- a/tests/AppBundle/BaseTest.php
+++ b/tests/AppBundle/BaseTest.php
@@ -2,7 +2,6 @@
 
 namespace AppBundle;
 
-
 use AppBundle\Entity\Menu\MenuItem;
 use AppBundle\Entity\Menu\MenuItemModifier;
 use AppBundle\Entity\Menu\Modifier;
@@ -11,7 +10,7 @@ use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\DBAL\Logging\EchoSQLLogger;
 use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-
+use Sylius\Component\Taxation\Model\TaxCategoryInterface;
 
 /**
  * Class BaseTest
@@ -37,7 +36,7 @@ abstract class BaseTest extends KernelTestCase
         self::bootKernel();
         $this->doctrine = static::$kernel->getContainer()->get('doctrine');
         $this->em = $this->doctrine->getManager();
-//        $this->em->getConnection()->getConfiguration()->setSQLLogger( new EchoSQLLogger());
+        // $this->em->getConnection()->getConfiguration()->setSQLLogger( new EchoSQLLogger());
     }
 
     protected function tearDown()
@@ -47,24 +46,26 @@ abstract class BaseTest extends KernelTestCase
         $purger->purge();
     }
 
-    public function createMenuItem($name, $price)
+    public function createMenuItem($name, $price, TaxCategoryInterface $taxCategory)
     {
         $item = new MenuItem();
         $item->setName($name);
         $item->setPrice($price);
+        $item->setTaxCategory($taxCategory);
 
-        $manager = $this->doctrine->getManagerForClass(MenuItem::class);
-        $manager->persist($item);
-        $manager->flush();
+        $menuItemManager = $this->doctrine->getManagerForClass(MenuItem::class);
+        $menuItemManager->persist($item);
+        $menuItemManager->flush();
 
         return $item;
     }
 
-    public function createModifier($name, $price)
+    public function createModifier($name, $price, TaxCategoryInterface $taxCategory)
     {
         $item = new Modifier();
         $item->setName($name);
         $item->setPrice($price);
+        $item->setTaxCategory($taxCategory);
 
         $manager = $this->doctrine->getManagerForClass(Modifier::class);
         $manager->persist($item);
@@ -89,6 +90,4 @@ abstract class BaseTest extends KernelTestCase
 
         return $modifier;
     }
-
-
 }

--- a/tests/AppBundle/Utils/CartTest.php
+++ b/tests/AppBundle/Utils/CartTest.php
@@ -8,27 +8,55 @@ use AppBundle\Entity\Menu\MenuItem;
 use AppBundle\Entity\Menu\MenuSection;
 use AppBundle\Entity\Restaurant;
 
-
 class CartTest extends BaseTest
 {
+    private $restaurant;
+    private $menuSection;
+    private $taxCategory;
 
-    public function setUp() {
+    public function setUp()
+    {
         parent::setUp();
+
+        $taxCategoryFactory = static::$kernel->getContainer()->get('sylius.factory.tax_category');
+        $taxCategoryManager = static::$kernel->getContainer()->get('sylius.manager.tax_category');
+        $taxRateFactory = static::$kernel->getContainer()->get('sylius.factory.tax_rate');
+        $taxRateManager = static::$kernel->getContainer()->get('sylius.manager.tax_rate');
 
         $this->restaurant = new Restaurant();
         $this->restaurant->setId(1);
+
         $menu = new Menu();
         $menu->setRestaurant($this->restaurant);
+
         $this->menuSection = new MenuSection();
         $this->menuSection->setMenu($menu);
+
+        $this->taxCategory = $taxCategoryFactory->createNew();
+        $this->taxCategory->setName('Default');
+        $this->taxCategory->setCode('default');
+
+        $taxCategoryManager->persist($this->taxCategory);
+        $taxCategoryManager->flush();
+
+        $taxRate = $taxRateFactory->createNew();
+        $taxRate->setName('TVA 10%');
+        $taxRate->setCode('tva_10');
+        $taxRate->setCategory($this->taxCategory);
+        $taxRate->setAmount(10.00);
+        $taxRate->setIncludedInPrice(true);
+        $taxRate->setCalculator('default');
+
+        $taxRateManager->persist($taxRate);
+        $taxRateManager->flush();
     }
 
     public function testTotal()
     {
         $cart = new Cart($this->restaurant);
 
-        $item1 = $this->createMenuItem('Item 1', 5);
-        $item2 = $this->createMenuItem('Item 2', 10);
+        $item1 = $this->createMenuItem('Item 1', 5, $this->taxCategory);
+        $item2 = $this->createMenuItem('Item 2', 10, $this->taxCategory);
 
         $item1->setSection($this->menuSection);
         $item2->setSection($this->menuSection);
@@ -46,16 +74,17 @@ class CartTest extends BaseTest
         $this->assertEquals(5, $cart->getTotal());
     }
 
-    public function testTotalWithFreeModifier () {
+    public function testTotalWithFreeModifier()
+    {
         $cart = new Cart();
 
-        $item1 = $this->createMenuItem('Item 1', 5);
+        $item1 = $this->createMenuItem('Item 1', 5, $this->taxCategory);
         $id1 = $item1->getId();
 
         $item1->setSection($this->menuSection);
 
-        $item2 = $this->createModifier('Item 2', 10);
-        $item3 = $this->createModifier('Item 3', 10);
+        $item2 = $this->createModifier('Item 2', 10, $this->taxCategory);
+        $item3 = $this->createModifier('Item 3', 10, $this->taxCategory);
 
         $modifier = $this->createMenuItemModifier($item1, [$item2, $item3], 'FREE', 5);
 
@@ -68,14 +97,15 @@ class CartTest extends BaseTest
         $this->assertEquals(5, $cart->getTotal());
     }
 
-    public function testTotalWithPayingModifier () {
+    public function testTotalWithPayingModifier()
+    {
         $cart = new Cart();
 
-        $item1 = $this->createMenuItem('Item 1', 5);
+        $item1 = $this->createMenuItem('Item 1', 5, $this->taxCategory);
         $item1->setSection($this->menuSection);
 
-        $item2 = $this->createModifier('Item 2', 10);
-        $item3 = $this->createModifier('Item 3', 10);
+        $item2 = $this->createModifier('Item 2', 10, $this->taxCategory);
+        $item3 = $this->createModifier('Item 3', 10, $this->taxCategory);
 
         $modifier = $this->createMenuItemModifier($item1, [$item2, $item3], 'ADD_MENUITEM_PRICE', 5);
 
@@ -84,14 +114,15 @@ class CartTest extends BaseTest
         $this->assertEquals(15, $cart->getTotal());
     }
 
-    public function testTotalWithFlatModifierPrice () {
+    public function testTotalWithFlatModifierPrice()
+    {
         $cart = new Cart();
 
-        $item1 = $this->createMenuItem('Item 1', 5);
+        $item1 = $this->createMenuItem('Item 1', 5, $this->taxCategory);
         $item1->setSection($this->menuSection);
 
-        $item2 = $this->createModifier('Item 2', 10);
-        $item3 = $this->createModifier('Item 3', 10);
+        $item2 = $this->createModifier('Item 2', 10, $this->taxCategory);
+        $item3 = $this->createModifier('Item 3', 10, $this->taxCategory);
 
         $modifier = $this->createMenuItemModifier($item1, [$item2, $item3], 'ADD_MODIFIER_PRICE', 5);
 
@@ -100,9 +131,10 @@ class CartTest extends BaseTest
         $this->assertEquals(10, $cart->getTotal());
     }
 
-    public function testCantAddUnavailable () {
+    public function testCantAddUnavailable()
+    {
         $cart = new Cart();
-        $item1 = $this->createMenuItem('Item 1', 5);
+        $item1 = $this->createMenuItem('Item 1', 5, $this->taxCategory);
         $item1->setSection($this->menuSection);
 
         $this->expectException(UnavailableProductException::class);
@@ -112,13 +144,14 @@ class CartTest extends BaseTest
         $cart->addItem($item1, 1);
     }
 
-    public function testRestaurantMismatch() {
+    public function testRestaurantMismatch()
+    {
         $restaurant = new Restaurant();
         $restaurant->setId(2);
         $restaurant->setName('Test restaurant');
 
         $cart = new Cart($restaurant);
-        $item1 = $this->createMenuItem('Item 1', 5);
+        $item1 = $this->createMenuItem('Item 1', 5, $this->taxCategory);
         $item1->setSection($this->menuSection);
 
         $this->expectException(RestaurantMismatchException::class);


### PR DESCRIPTION
The pull request introduces taxation with [Sylius](http://docs.sylius.org/en/latest/book/index.html). 
It contains the minimal stuff to parameterize taxes for each menu item. 
Once it is merged, we can add screens to manage taxes, and also calculate taxes in cart to create invoices. 

It also introduces a big change: **we need to switch to PHP 7.1**
In any case, the Docker machine is already in PHP 7.1 and support for PHP 7.0 ends in December 2017 🤓

Until we move to YAML mapping (see #155), tables will be prefixed by `sylius_`

