### PR TITLE
Tax calculation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,5 @@ migrations-diff:
 
 migrations-migrate:
 	@docker-compose run php bin/console doctrine:migrations:migrate
+	@docker-compose run php bin/console doctrine:migrations:migrate --env=test
 

--- a/app/DoctrineMigrations/Version20171202224801.php
+++ b/app/DoctrineMigrations/Version20171202224801.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Application\Migrations;
+
+use AppBundle\Service\Taxation\FloatCalculator;
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Component\Taxation\Model\TaxRate;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20171202224801 extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE order_ ADD total_excluding_tax DOUBLE PRECISION DEFAULT NULL');
+        $this->addSql('ALTER TABLE order_ ADD total_tax DOUBLE PRECISION DEFAULT NULL');
+        $this->addSql('ALTER TABLE order_ ADD total_including_tax DOUBLE PRECISION DEFAULT NULL');
+
+        $this->addSql('ALTER TABLE delivery ADD tax_category_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE delivery ADD total_excluding_tax DOUBLE PRECISION DEFAULT NULL');
+        $this->addSql('ALTER TABLE delivery ADD total_tax DOUBLE PRECISION DEFAULT NULL');
+        $this->addSql('ALTER TABLE delivery ADD total_including_tax DOUBLE PRECISION DEFAULT NULL');
+
+        // Create taxation for deliveries
+
+        $this->addSql("INSERT INTO sylius_tax_category (code, name, created_at, updated_at) VALUES (:code, :name, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)", [
+                'code' => 'tva_livraison',
+                'name' => 'TVA Livraison'
+            ]);
+        $this->addSql("INSERT INTO sylius_tax_rate (category_id, code, name, amount, included_in_price, calculator, created_at, updated_at) SELECT sylius_tax_category.id, :code, :name, :amount, TRUE, 'default', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP FROM sylius_tax_category WHERE sylius_tax_category.code = :category", [
+                'code' => 'tva_20',
+                'name' => 'TVA 20%',
+                'amount' => 0.20,
+                'category' => 'tva_livraison',
+            ]);
+
+
+        $calculator = new FloatCalculator();
+
+        // Migrate orders
+
+        $stmts = [];
+        $stmts['find_all_orders'] = $this->connection->prepare('SELECT * FROM order_');
+        $stmts['find_all_deliveries'] = $this->connection->prepare('SELECT * FROM delivery');
+        $stmts['order_items_total'] = $this->connection->prepare('SELECT SUM(price * quantity) FROM order_item WHERE order_id = :order_id');
+
+        // Let's suppose everything uses a rate with amount 0.10
+        $taxRate = new TaxRate();
+        $taxRate->setAmount(0.10);
+        $taxRate->setIncludedInPrice(true);
+
+        $stmts['find_all_orders']->execute();
+        while ($order = $stmts['find_all_orders']->fetch()) {
+
+            $stmts['order_items_total']->bindParam('order_id', $order['id']);
+            $stmts['order_items_total']->execute();
+
+            $totalIncludingTax = $stmts['order_items_total']->fetchColumn(0);
+            $totalTax = $calculator->calculate($totalIncludingTax, $taxRate);
+            $totalExcludingTax = $totalIncludingTax - $totalTax;
+
+            $this->addSql('UPDATE order_ SET total_excluding_tax = :total_excluding_tax, total_tax = :total_tax, total_including_tax = :total_including_tax WHERE id = :order_id', [
+                'total_excluding_tax' => $totalExcludingTax,
+                'total_tax' => $totalTax,
+                'total_including_tax' => $totalIncludingTax,
+                'order_id' => $order['id']
+            ]);
+        }
+
+        // Migrate deliveries
+
+        $deliveryTaxRate = new TaxRate();
+        $deliveryTaxRate->setAmount(0.20);
+        $deliveryTaxRate->setIncludedInPrice(true);
+
+        $stmts['find_all_deliveries']->execute();
+        while ($delivery = $stmts['find_all_deliveries']->fetch()) {
+
+            $totalIncludingTax = $delivery['price'];
+            $totalTax = $calculator->calculate($totalIncludingTax, $deliveryTaxRate);
+            $totalExcludingTax = $totalIncludingTax - $totalTax;
+
+            $this->addSql('UPDATE delivery SET tax_category_id = sylius_tax_category.id, total_excluding_tax = :total_excluding_tax, total_tax = :total_tax, total_including_tax = :total_including_tax FROM sylius_tax_category WHERE delivery.id = :delivery_id AND sylius_tax_category.code = :tax_category_code', [
+                'total_excluding_tax' => $totalExcludingTax,
+                'total_tax' => $totalTax,
+                'total_including_tax' => $totalIncludingTax,
+                'delivery_id' => $delivery['id'],
+                'tax_category_code' => 'tva_livraison',
+            ]);
+        }
+
+        $this->addSql('ALTER TABLE order_ ALTER COLUMN total_including_tax SET NOT NULL');
+        $this->addSql('ALTER TABLE order_ ALTER COLUMN total_excluding_tax SET NOT NULL');
+        $this->addSql('ALTER TABLE order_ ALTER COLUMN total_tax SET NOT NULL');
+
+        $this->addSql('ALTER TABLE delivery ALTER COLUMN tax_category_id SET NOT NULL');
+        $this->addSql('ALTER TABLE delivery ALTER COLUMN total_including_tax SET NOT NULL');
+        $this->addSql('ALTER TABLE delivery ALTER COLUMN total_excluding_tax SET NOT NULL');
+        $this->addSql('ALTER TABLE delivery ALTER COLUMN total_tax SET NOT NULL');
+        $this->addSql('ALTER TABLE delivery ADD CONSTRAINT FK_3781EC109DF894ED FOREIGN KEY (tax_category_id) REFERENCES sylius_tax_category (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_3781EC109DF894ED ON delivery (tax_category_id)');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE order_ DROP total_excluding_tax');
+        $this->addSql('ALTER TABLE order_ DROP total_tax');
+        $this->addSql('ALTER TABLE order_ DROP total_including_tax');
+
+        $this->addSql('ALTER TABLE delivery DROP CONSTRAINT FK_3781EC109DF894ED');
+        $this->addSql('DROP INDEX IDX_3781EC109DF894ED');
+        $this->addSql('ALTER TABLE delivery DROP tax_category_id');
+        $this->addSql('ALTER TABLE delivery DROP total_excluding_tax');
+        $this->addSql('ALTER TABLE delivery DROP total_tax');
+        $this->addSql('ALTER TABLE delivery DROP total_including_tax');
+
+        $this->addSql("DELETE FROM sylius_tax_rate WHERE code = :code", [
+            'code' => 'tva_20',
+        ]);
+        $this->addSql("DELETE FROM sylius_tax_category WHERE code = :code", [
+            'code' => 'tva_livraison',
+        ]);
+    }
+}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -44,13 +44,29 @@ services:
 
   order.entity_listener:
     class: AppBundle\Entity\Listener\OrderListener
-    arguments: [ "@security.token_storage", "@delivery_service_factory", "@snc_redis.default", "@serializer" ]
+    arguments: [ "@security.token_storage", "@delivery_service_factory", "@snc_redis.default", "@serializer", "@order.manager" ]
+    # lazy = true is mandatory
+    # https://symfony.com/doc/3.3/doctrine/event_listeners_subscribers.html#lazy-loading-for-event-listeners
+    # https://github.com/doctrine/DoctrineBundle/issues/300
     tags:
-      - { name: doctrine.orm.entity_listener }
+      - { name: doctrine.orm.entity_listener, lazy: true }
+
+  coopcycle.tax_calculator.float:
+    class: AppBundle\Service\Taxation\FloatCalculator
+    tags:
+      - { name: sylius.tax_calculator, calculator: float, label: "Float" }
 
   order.manager:
     class: AppBundle\Service\OrderManager
-    arguments: [ "@payment_service", "@delivery_service_factory", "@snc_redis.default", "@serializer" ]
+    arguments:
+      - "@payment_service"
+      - "@delivery_service_factory"
+      - "@snc_redis.default"
+      - "@serializer"
+      - "@sylius.tax_rate_resolver"
+      - "@sylius.tax_calculator"
+      - "@sylius.repository.tax_category"
+      - 'tva_livraison' # TODO Load from settings
 
   delivery.entity_listener:
     class: AppBundle\Entity\Listener\DeliveryListener
@@ -66,6 +82,11 @@ services:
   my.order_normalizer:
     class: AppBundle\Serializer\OrderNormalizer
     arguments: [ "@api_platform.jsonld.normalizer.item", "@router" ]
+    tags: [ { name: serializer.normalizer, priority: 128 } ]
+
+  my.delivery_normalizer:
+    class: AppBundle\Serializer\DeliveryNormalizer
+    arguments: [ "@api_platform.jsonld.normalizer.item" ]
     tags: [ { name: serializer.normalizer, priority: 128 } ]
 
   app.menu_normalizer:

--- a/features/fixtures/ORM/restaurants.yml
+++ b/features/fixtures/ORM/restaurants.yml
@@ -2,6 +2,9 @@ Sylius\Component\Taxation\Model\TaxCategory:
   tva_conso_immediate:
     code: tva_conso_immediate
     name: "TVA consommation immédiate"
+  tva_livraison:
+    code: tva_livraison
+    name: "TVA livraison"
 
 Sylius\Component\Taxation\Model\TaxRate:
   tva_10:
@@ -10,7 +13,14 @@ Sylius\Component\Taxation\Model\TaxRate:
     category: "@tva_conso_immediate"
     amount: 0.10
     includedInPrice: true
-    calculator: default
+    calculator: float
+  tva_20:
+    name: "TVA 20%"
+    code: tva_20
+    category: "@tva_livraison"
+    amount: 0.20
+    includedInPrice: true
+    calculator: float
 
 AppBundle\Entity\Base\GeoCoordinates:
   geo_1:

--- a/features/orders.feature
+++ b/features/orders.feature
@@ -100,9 +100,15 @@ Feature: Orders
         "status":"WAITING",
         "courier":null,
         "date":"@string@.startsWith('2017-09-02')",
-        "price": @double@
+        "price": @double@,
+        "totalExcludingTax":@double@,
+        "totalTax":@double@,
+        "totalIncludingTax":@double@
       },
       "total":@number@,
+      "totalExcludingTax":@double@,
+      "totalTax":@double@,
+      "totalIncludingTax":@double@,
       "publicUrl":@string@,
       "status":"CREATED",
       "preparationDate":"@string@.startsWith('2017-09-02T11:45:00')"
@@ -216,7 +222,10 @@ Feature: Orders
       },
       "status":"DISPATCHED",
       "date":"@string@.startsWith('2017-09-02')",
-      "price": @double@
+      "price": @double@,
+      "totalExcludingTax":@double@,
+      "totalTax":@double@,
+      "totalIncludingTax":@double@
     }
     """
     When I add "Content-Type" header equal to "application/ld+json"
@@ -261,7 +270,10 @@ Feature: Orders
       },
       "status":"PICKED",
       "date":"@string@.startsWith('2017-09-02')",
-      "price": @double@
+      "price": @double@,
+      "totalExcludingTax":@double@,
+      "totalTax":@double@,
+      "totalIncludingTax":@double@
     }
     """
     When I add "Content-Type" header equal to "application/ld+json"
@@ -306,7 +318,10 @@ Feature: Orders
       },
       "status":"DELIVERED",
       "date":"@string@.startsWith('2017-09-02')",
-      "price": @double@
+      "price": @double@,
+      "totalExcludingTax":@double@,
+      "totalTax":@double@,
+      "totalIncludingTax":@double@
     }
     """
 

--- a/features/restaurants.feature
+++ b/features/restaurants.feature
@@ -60,7 +60,6 @@ Feature: Manage restaurants
     When I add "Accept" header equal to "application/ld+json"
     And I send a "GET" request to "/api/restaurants/1"
     Then the response status code should be 200
-    Then print last response
     And the response should be in JSON
     And the JSON should match:
     """

--- a/js/api/Db.js
+++ b/js/api/Db.js
@@ -59,6 +59,18 @@ module.exports = function(sequelize) {
       field: 'updated_at',
       type: Sequelize.DATE
     },
+    totalExcludingTax: {
+      field: 'total_excluding_tax',
+      type: Sequelize.FLOAT
+    },
+    totalTax: {
+      field: 'total_tax',
+      type: Sequelize.FLOAT
+    },
+    totalIncludingTax: {
+      field: 'total_including_tax',
+      type: Sequelize.FLOAT
+    },
   }, _.extend(sequelizeOptions, {
     tableName: 'order_'
   }));
@@ -89,6 +101,18 @@ module.exports = function(sequelize) {
     date: Sequelize.DATE,
     status: Sequelize.STRING,
     price: Sequelize.FLOAT,
+    totalExcludingTax: {
+      field: 'total_excluding_tax',
+      type: Sequelize.FLOAT
+    },
+    totalTax: {
+      field: 'total_tax',
+      type: Sequelize.FLOAT
+    },
+    totalIncludingTax: {
+      field: 'total_including_tax',
+      type: Sequelize.FLOAT
+    },
   }, _.extend(sequelizeOptions, {
     tableName: 'delivery',
   }));
@@ -115,12 +139,28 @@ module.exports = function(sequelize) {
     },
   }));
 
+  Db.TaxCategory = sequelize.define('tax_category', {
+    name: Sequelize.STRING,
+    code: Sequelize.STRING,
+    createdAt: {
+      field: 'created_at',
+      type: Sequelize.DATE
+    },
+    updatedAt: {
+      field: 'updated_at',
+      type: Sequelize.DATE
+    },
+  }, _.extend(sequelizeOptions, {
+    tableName: 'sylius_tax_category'
+  }));
+
   Db.Restaurant.belongsTo(Db.Address);
 
   Db.Delivery.belongsTo(Db.User, {as: 'courier', foreignKey : 'courier_id' });
   Db.Delivery.belongsTo(Db.Address, { as: 'originAddress', foreignKey : 'origin_address_id' });
   Db.Delivery.belongsTo(Db.Address, { as: 'deliveryAddress', foreignKey : 'delivery_address_id' });
   Db.Delivery.belongsTo(Db.Order);
+  Db.Delivery.belongsTo(Db.TaxCategory, { as: 'taxCategory', foreignKey : 'tax_category_id' });
 
   Db.Order.belongsTo(Db.Restaurant);
   Db.Order.belongsTo(Db.User, {as: 'customer', foreignKey : 'customer_id' });

--- a/js/app/cart/Cart.jsx
+++ b/js/app/cart/Cart.jsx
@@ -8,6 +8,13 @@ import DatePicker from './DatePicker.jsx';
 import AddressPicker from "../address/AddressPicker.jsx";
 import { geocodeByAddress } from 'react-places-autocomplete';
 
+import numeral  from 'numeral';
+import 'numeral/locales'
+
+const locale = $('html').attr('lang')
+
+numeral.locale(locale)
+
 class Cart extends React.Component
 {
   constructor(props) {
@@ -147,7 +154,7 @@ class Cart extends React.Component
         itemCount = _.reduce(this.state.items, function(memo, item) {
       return memo + (item.quantity);
     }, 0),
-        total = (itemsTotalPrice + flatDeliveryPrice).toFixed(2)
+        total = (itemsTotalPrice + flatDeliveryPrice)
 
     if (items.length === 0) {
       cartWarning = ( <div className="alert alert-warning">Votre panier est vide</div> )
@@ -197,8 +204,15 @@ class Cart extends React.Component
               {cartWarning}
               {cartContent}
               <hr />
-              {items.length > 0 && (<span>Prix de la course {flatDeliveryPrice.toFixed(2)}€<br /></span>)}
-              <strong>Total {total} €</strong>
+              {items.length > 0 && (
+              <div>
+                <span>Prix de la course </span>
+                <strong className="pull-right">{ numeral(flatDeliveryPrice).format('0,0.00 $') }</strong>
+              </div> )}
+              <div>
+                <span>Total</span>
+                <strong className="pull-right">{ numeral(total).format('0,0.00 $') }</strong>
+              </div>
               <hr />
               <a href={validateCartURL} className={btnClasses.join(' ')}>Commander</a>
             </div>

--- a/js/app/restaurant/OrderDetails.jsx
+++ b/js/app/restaurant/OrderDetails.jsx
@@ -86,7 +86,7 @@ class OrderList extends React.Component {
           { this.state.order.orderedItem.map((item, key) =>
             <tr key={ key }>
               <td>{ item.quantity } x { item.name }</td>
-              <td className="text-right">{ numeral(item.quantity * item.price).format('$0,0.00') }</td>
+              <td className="text-right">{ numeral(item.quantity * item.price).format('0,0.00 $') }</td>
             </tr>
           ) }
         </tbody>
@@ -99,8 +99,16 @@ class OrderList extends React.Component {
       <table className="table">
         <tbody>
           <tr>
-            <td><strong>Total</strong></td>
-            <td className="text-right"><strong>{ numeral(this.state.order.total).format('$0,0.00') }</strong></td>
+            <td><strong>Total HT</strong></td>
+            <td className="text-right"><strong>{ numeral(this.state.order.totalExcludingTax).format('0,0.00 $') }</strong></td>
+          </tr>
+          <tr>
+            <td><strong>Total TVA</strong></td>
+            <td className="text-right"><strong>{ numeral(this.state.order.totalTax).format('0,0.00 $') }</strong></td>
+          </tr>
+          <tr>
+            <td><strong>Total TTC</strong></td>
+            <td className="text-right"><strong>{ numeral(this.state.order.totalIncludingTax).format('0,0.00 $') }</strong></td>
           </tr>
         </tbody>
       </table>

--- a/js/app/restaurant/OrderList.jsx
+++ b/js/app/restaurant/OrderList.jsx
@@ -43,6 +43,16 @@ class OrderList extends React.Component
     return (
       <div>
         <table className="table table-hover">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>État</th>
+              <th>Date de préparation</th>
+              <th className="text-right">Commande</th>
+              <th className="text-right">Livraison</th>
+              <th></th>
+            </tr>
+          </thead>
           <tbody>
           { _.map(orders, (order) => this.renderOrderRow(order)) }
           </tbody>
@@ -60,10 +70,11 @@ class OrderList extends React.Component
 
     return (
       <tr key={ order['@id'] } onClick={ () => this.props.onOrderClick(order) } style={{ cursor: 'pointer' }} className={ className }>
-        <td>#{ order['@id'].replace('/api/orders/', '') }</td>
+        <td>{ order['@id'].replace('/api/orders/', '') }</td>
         <td><OrderLabel order={ order } /></td>
         <td><i className="fa fa-clock-o" aria-hidden="true"></i>  { moment(order.preparationDate).format('lll') }</td>
-        <td>{ numeral(order.total).format('$0,0.00') }</td>
+        <td className="text-right">{ numeral(order.totalIncludingTax).format('0,0.00 $') }</td>
+        <td className="text-right">{ numeral(order.delivery.totalIncludingTax).format('0,0.00 $') }</td>
         <td className="text-right">{ order.customer.username }</td>
       </tr>
     )

--- a/js/tests/dispatch.js
+++ b/js/tests/dispatch.js
@@ -16,6 +16,7 @@ function init() {
 
     Promise.all([
       utils.createRestaurant('Awesome Pizza', { latitude: 48.884550, longitude: 2.341358 }),
+      utils.createTaxCategory('Default', 'default'),
       utils.createUser('bill'),
       utils.createUser('sarah', ['ROLE_COURIER']),
       utils.createUser('bob', ['ROLE_COURIER']),

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -469,4 +469,19 @@ class AdminController extends Controller
             'form' => $form->createView(),
         ];
     }
+
+    /**
+     * @Route("/admin/settings/taxation", name="admin_taxation_settings")
+     * @Template
+     */
+    public function taxationSettingsAction(Request $request)
+    {
+        $taxCategoryRepository = $this->get('sylius.repository.tax_category');
+
+        $taxCategories = $taxCategoryRepository->findAll();
+
+        return [
+            'taxCategories' => $taxCategories
+        ];
+    }
 }

--- a/src/AppBundle/Controller/OrderController.php
+++ b/src/AppBundle/Controller/OrderController.php
@@ -13,7 +13,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
 
-
 /**
  * @Route("/order")
  */
@@ -44,9 +43,7 @@ class OrderController extends Controller
 
         $delivery = new Delivery($order);
         $delivery->setDate($cart->getDate());
-        $delivery->setOriginAddress($restaurant->getAddress());
         $delivery->setDeliveryAddress($cart->getAddress());
-        $delivery->setPrice($restaurant->getContract()->getFlatDeliveryPrice());
 
         return $order;
     }
@@ -161,8 +158,8 @@ class OrderController extends Controller
      * @param Request $request
      *
      */
-    public function orderPublic($uuid, Request $request) {
-
+    public function orderPublic($uuid, Request $request)
+    {
         $orders = $this->getDoctrine()
             ->getRepository(Order::class)->findBy(['uuid' => $uuid]);
 
@@ -196,6 +193,5 @@ class OrderController extends Controller
             'delivery_events_json' => $this->get('serializer')->serialize($deliveryEvents, 'json'),
             'layout' => 'AppBundle::base.html.twig'
         );
-
     }
 }

--- a/src/AppBundle/Entity/Model/TaxableTrait.php
+++ b/src/AppBundle/Entity/Model/TaxableTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace AppBundle\Entity\Model;
+
+use Doctrine\ORM\Mapping as ORM;
+
+trait TaxableTrait
+{
+    /**
+     * @ORM\Column(type="float")
+     */
+    private $totalExcludingTax;
+
+    /**
+     * @ORM\Column(type="float")
+     */
+    private $totalTax;
+
+    /**
+     * @ORM\Column(type="float")
+     */
+    private $totalIncludingTax;
+
+    public function getTotalExcludingTax()
+    {
+        return $this->totalExcludingTax;
+    }
+
+    public function setTotalExcludingTax($totalExcludingTax)
+    {
+        $this->totalExcludingTax = $totalExcludingTax;
+
+        return $this;
+    }
+
+    public function getTotalTax()
+    {
+        return $this->totalTax;
+    }
+
+    public function setTotalTax($totalTax)
+    {
+        $this->totalTax = $totalTax;
+
+        return $this;
+    }
+
+    public function getTotalIncludingTax()
+    {
+        return $this->totalIncludingTax;
+    }
+
+    public function setTotalIncludingTax($totalIncludingTax)
+    {
+        $this->totalIncludingTax = $totalIncludingTax;
+
+        return $this;
+    }
+}

--- a/src/AppBundle/Entity/Order.php
+++ b/src/AppBundle/Entity/Order.php
@@ -4,6 +4,7 @@ namespace AppBundle\Entity;
 
 use AppBundle\Entity\Menu\Modifier;
 use AppBundle\Entity\Base\MenuItem;
+use AppBundle\Entity\Model\TaxableTrait;
 use AppBundle\Utils\CartItem;
 use Doctrine\ORM\Mapping as ORM;
 use Gedmo\Mapping\Annotation as Gedmo;
@@ -46,6 +47,8 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  */
 class Order
 {
+    use TaxableTrait;
+
     // the order is created but not paid yet
     const STATUS_CREATED            = 'CREATED';
     // the payment for this order failed
@@ -275,6 +278,11 @@ class Order
     {
         $this->restaurant = $restaurant;
 
+        if (null !== $this->delivery) {
+            $this->delivery->setPriceFromOrder($this);
+            $this->delivery->setOriginAddressFromOrder($this);
+        }
+
         return $this;
     }
 
@@ -320,7 +328,6 @@ class Order
         }
 
         return $total;
-
     }
 
     /**
@@ -365,8 +372,8 @@ class Order
 
     public function setDelivery(Delivery $delivery)
     {
-        $this->delivery = $delivery;
         $delivery->setOrder($this);
+        $this->delivery = $delivery;
 
         return $this;
     }

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -110,6 +110,10 @@ Add a restaurant: Ajouter un restaurant
 Restaurants managed by user: Restaurants gérés par l'utilisateur
 VAT: TVA
 Your changes were saved.: Vos changements ont été sauvegardés.
+Taxation: Taxes
+Categories: Catégories
+Menu categories: Catégories du menu
+
 
 profile.addresses.breadcrumb: Addresses
 profile.addresses.empty: Pas d'adresse sauvegardée pour le moment!

--- a/src/AppBundle/Resources/views/Admin/taxationSettings.html.twig
+++ b/src/AppBundle/Resources/views/Admin/taxationSettings.html.twig
@@ -1,0 +1,24 @@
+{% extends "AppBundle::admin.html.twig" %}
+
+{% block breadcrumb %}
+<li>{% trans %}Settings{% endtrans %}</li>
+<li>{% trans %}Taxation{% endtrans %}</li>
+{% endblock %}
+
+{% block content %}
+<table class="table">
+<tbody>
+{% for taxCategory in taxCategories %}
+{% set taxRate = taxCategory.rates|first %}
+<tr>
+  <td>#{{ taxCategory.id }}</td>
+  <td>{{ taxCategory.name }}</td>
+  <td>{{ (taxRate.amount * 100)|number_format(2, '.', ',') }} %</td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+{% endblock %}
+
+{% block scripts %}
+{% endblock %}

--- a/src/AppBundle/Resources/views/Profile/orders.html.twig
+++ b/src/AppBundle/Resources/views/Profile/orders.html.twig
@@ -13,8 +13,8 @@
     </div>
   {% else %}
     <table class="table">
+      <tbody>
       {% for order in orders %}
-        <tbody>
         <tr>
           <td width="10%"><a href="{{ path('profile_order', { id: order.id }) }}">#{{ order.id }}</a></td>
           <td width="10%">{% include "AppBundle:Order:label.html.twig" %}</td>
@@ -23,8 +23,8 @@
           <td>{{ order.createdAt|ago }}</td>
           <td><span class="pull-right">{{ order.total }} €</span></td>
         </tr>
-        </tbody>
       {% endfor %}
+      </tbody>
     </table>
   {% endif %}
 {% endblock %}

--- a/src/AppBundle/Resources/views/admin.html.twig
+++ b/src/AppBundle/Resources/views/admin.html.twig
@@ -28,8 +28,8 @@
               <i class="fa fa-cog"></i>  {% trans %}Settings{% endtrans %} <span class="caret"></span>
             </a>
             <ul class="dropdown-menu">
-              <li class="dropdown-header">Menu</li>
-              <li><a href="{{ path('admin_menu_categories') }}">{% trans %}Categories{% endtrans %}</a></li>
+              <li><a href="{{ path('admin_menu_categories') }}">{% trans %}Menu categories{% endtrans %}</a></li>
+              <li><a href="{{ path('admin_taxation_settings') }}">{% trans %}Taxation{% endtrans %}</a></li>
             </ul>
           </li>
           {% endif %}

--- a/src/AppBundle/Serializer/DeliveryNormalizer.php
+++ b/src/AppBundle/Serializer/DeliveryNormalizer.php
@@ -3,28 +3,23 @@
 namespace AppBundle\Serializer;
 
 use ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer;
-use AppBundle\Entity\Order;
+use AppBundle\Entity\Delivery;
 use Symfony\Component\Routing\Router;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-class OrderNormalizer implements NormalizerInterface, DenormalizerInterface
+class DeliveryNormalizer implements NormalizerInterface, DenormalizerInterface
 {
     private $normalizer;
 
-    public function __construct(ItemNormalizer $normalizer, Router $router)
+    public function __construct(ItemNormalizer $normalizer)
     {
         $this->normalizer = $normalizer;
-        $this->router = $router;
     }
 
     public function normalize($object, $format = null, array $context = array())
     {
         $data =  $this->normalizer->normalize($object, $format, $context);
-
-        $data['total'] = $object->getTotal();
-        $data['publicUrl'] = $this->router->generate('order_public', ['uuid' => $object->getUuid()], true);
-        $data['preparationDate'] = $object->getPreparationDate()->format(\DateTime::ATOM);
 
         $data['totalExcludingTax'] = $object->getTotalExcludingTax();
         $data['totalTax'] = $object->getTotalTax();
@@ -35,7 +30,7 @@ class OrderNormalizer implements NormalizerInterface, DenormalizerInterface
 
     public function supportsNormalization($data, $format = null)
     {
-        return $this->normalizer->supportsNormalization($data, $format) && $data instanceof Order;
+        return $this->normalizer->supportsNormalization($data, $format) && $data instanceof Delivery;
     }
 
     public function denormalize($data, $class, $format = null, array $context = array())
@@ -45,6 +40,6 @@ class OrderNormalizer implements NormalizerInterface, DenormalizerInterface
 
     public function supportsDenormalization($data, $type, $format = null)
     {
-        return $this->normalizer->supportsDenormalization($data, $type, $format) && $type instanceof Order;
+        return $this->normalizer->supportsDenormalization($data, $type, $format) && $type instanceof Delivery;
     }
 }

--- a/src/AppBundle/Service/OrderManager.php
+++ b/src/AppBundle/Service/OrderManager.php
@@ -6,6 +6,9 @@ use AppBundle\Entity\Order;
 use AppBundle\Service\DeliveryService\Factory as DeliveryServiceFactory;
 use AppBundle\Service\PaymentService;
 use Predis\Client as Redis;
+use Sylius\Component\Taxation\Calculator\CalculatorInterface;
+use Sylius\Component\Taxation\Repository\TaxCategoryRepositoryInterface;
+use Sylius\Component\Taxation\Resolver\TaxRateResolverInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -15,14 +18,24 @@ class OrderManager
     private $payment;
     private $redis;
     private $serializer;
+    private $taxRateResolver;
+    private $calculator;
+    private $taxCategoryRepository;
+    private $deliveryTaxCategoryCode;
 
     public function __construct(PaymentService $payment, DeliveryServiceFactory $deliveryServiceFactory,
-        Redis $redis, SerializerInterface $serializer)
+        Redis $redis, SerializerInterface $serializer,
+        TaxRateResolverInterface $taxRateResolver, CalculatorInterface $calculator,
+        TaxCategoryRepositoryInterface $taxCategoryRepository, $deliveryTaxCategoryCode)
     {
         $this->deliveryServiceFactory = $deliveryServiceFactory;
         $this->payment = $payment;
         $this->redis = $redis;
         $this->serializer = $serializer;
+        $this->taxRateResolver = $taxRateResolver;
+        $this->calculator = $calculator;
+        $this->taxCategoryRepository = $taxCategoryRepository;
+        $this->deliveryTaxCategoryCode = $deliveryTaxCategoryCode;
     }
 
     public function pay(Order $order, $stripeToken)
@@ -49,5 +62,43 @@ class OrderManager
         $this->deliveryServiceFactory
             ->createForRestaurant($order->getRestaurant())
             ->create($order);
+    }
+
+    public function applyTaxes(Order $order)
+    {
+        $deliveryTaxCategory = $this->taxCategoryRepository->findOneBy(['code' => $this->deliveryTaxCategoryCode]);
+
+        $delivery = $order->getDelivery();
+        $delivery->setTaxCategory($deliveryTaxCategory);
+
+        $deliveryTaxRate = $this->taxRateResolver->resolve($delivery);
+
+        $deliveryTotalIncludingTax = $delivery->getPrice();
+        $deliveryTotalTax = $this->calculator->calculate($deliveryTotalIncludingTax, $deliveryTaxRate);
+        $deliveryTotalExcludingTax = $deliveryTotalIncludingTax - $deliveryTotalTax;
+
+        $delivery->setTotalExcludingTax($deliveryTotalExcludingTax);
+        $delivery->setTotalTax($deliveryTotalTax);
+        $delivery->setTotalIncludingTax($deliveryTotalIncludingTax);
+
+        $orderTotalTax = 0;
+        $orderTotalIncludingTax = 0;
+
+        foreach ($order->getOrderedItem() as $item) {
+            $rate = $this->taxRateResolver->resolve($item->getMenuItem());
+
+            if (null === $rate) {
+                continue;
+            }
+
+            $itemTotalIncludingTax = $item->getPrice() * $item->getQuantity();
+
+            $orderTotalTax += $this->calculator->calculate($itemTotalIncludingTax, $rate);
+            $orderTotalIncludingTax += $itemTotalIncludingTax;
+        }
+
+        $order->setTotalExcludingTax($orderTotalIncludingTax - $orderTotalTax);
+        $order->setTotalTax($orderTotalTax);
+        $order->setTotalIncludingTax($orderTotalIncludingTax);
     }
 }

--- a/src/AppBundle/Service/Taxation/FloatCalculator.php
+++ b/src/AppBundle/Service/Taxation/FloatCalculator.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppBundle\Service\Taxation;
+
+use Sylius\Component\Taxation\Calculator\CalculatorInterface;
+use Sylius\Component\Taxation\Model\TaxRateInterface;
+
+final class FloatCalculator implements CalculatorInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function calculate(float $base, TaxRateInterface $rate): float
+    {
+        if ($rate->isIncludedInPrice()) {
+            return $this->numberFormat($base - ($base / (1 + $rate->getAmount())));
+        }
+
+        return $this->numberFormat($base * $rate->getAmount());
+    }
+
+    private function numberFormat(float $amount)
+    {
+        return (float) number_format($amount, 2, '.', '');
+    }
+}

--- a/src/AppBundle/Tests/Action/TestCase.php
+++ b/src/AppBundle/Tests/Action/TestCase.php
@@ -12,6 +12,9 @@ use AppBundle\Service\RoutingInterface;
 use Doctrine\Bundle\DoctrineBundle\Registry as DoctrineRegistry;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Predis\Client as Redis;
+use Sylius\Component\Taxation\Calculator\CalculatorInterface;
+use Sylius\Component\Taxation\Repository\TaxCategoryRepositoryInterface;
+use Sylius\Component\Taxation\Resolver\TaxRateResolverInterface;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -36,6 +39,9 @@ class TestCase extends BaseTestCase
         $paymentService = $this->prophesize(PaymentService::class);
         $routing = $this->prophesize(RoutingInterface::class);
         $deliveryService = $this->prophesize(DeliveryServiceInterface::class);
+        $taxRateResolver = $this->prophesize(TaxRateResolverInterface::class);
+        $calculator = $this->prophesize(CalculatorInterface::class);
+        $taxCategoryRepository = $this->prophesize(TaxCategoryRepositoryInterface::class);
 
         $deliveryServiceFactory = new DeliveryServiceFactory([], $deliveryService->reveal());
 
@@ -50,7 +56,11 @@ class TestCase extends BaseTestCase
             $paymentService->reveal(),
             $deliveryServiceFactory,
             $this->redisProphecy->reveal(),
-            $serializer->reveal()
+            $serializer->reveal(),
+            $taxRateResolver->reveal(),
+            $calculator->reveal(),
+            $taxCategoryRepository->reveal(),
+            'foo'
         );
 
         $this->action = new $this->actionClass(

--- a/tests/AppBundle/BaseTest.php
+++ b/tests/AppBundle/BaseTest.php
@@ -2,14 +2,20 @@
 
 namespace AppBundle;
 
+use AppBundle\Entity\Address;
+use AppBundle\Entity\ApiUser;
+use AppBundle\Entity\Contract;
 use AppBundle\Entity\Menu\MenuItem;
 use AppBundle\Entity\Menu\MenuItemModifier;
 use AppBundle\Entity\Menu\Modifier;
+use AppBundle\Entity\Restaurant;
 use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\DBAL\Logging\EchoSQLLogger;
 use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Sylius\Component\Taxation\Model\TaxCategoryInterface;
 
 /**
@@ -30,12 +36,15 @@ abstract class BaseTest extends KernelTestCase
      */
     protected $doctrine;
 
+    private $userManipulator;
+
     protected function setUp()
     {
         parent::setUp();
         self::bootKernel();
         $this->doctrine = static::$kernel->getContainer()->get('doctrine');
         $this->em = $this->doctrine->getManager();
+        $this->userManipulator = static::$kernel->getContainer()->get('fos_user.util.user_manipulator');
         // $this->em->getConnection()->getConfiguration()->setSQLLogger( new EchoSQLLogger());
     }
 
@@ -46,7 +55,36 @@ abstract class BaseTest extends KernelTestCase
         $purger->purge();
     }
 
-    public function createMenuItem($name, $price, TaxCategoryInterface $taxCategory)
+    protected function createTaxCategory($categoryName, $categoryCode, $rateName, $rateCode, $rateAmount, $rateCalculator = 'default')
+    {
+        $taxCategoryFactory = static::$kernel->getContainer()->get('sylius.factory.tax_category');
+        $taxCategoryManager = static::$kernel->getContainer()->get('sylius.manager.tax_category');
+
+        $taxRateFactory = static::$kernel->getContainer()->get('sylius.factory.tax_rate');
+        $taxRateManager = static::$kernel->getContainer()->get('sylius.manager.tax_rate');
+
+        $taxCategory = $taxCategoryFactory->createNew();
+        $taxCategory->setName($categoryName);
+        $taxCategory->setCode($categoryCode);
+
+        $taxCategoryManager->persist($taxCategory);
+        $taxCategoryManager->flush();
+
+        $taxRate = $taxRateFactory->createNew();
+        $taxRate->setName($rateName);
+        $taxRate->setCode($rateCode);
+        $taxRate->setCategory($taxCategory);
+        $taxRate->setAmount($rateAmount);
+        $taxRate->setIncludedInPrice(true);
+        $taxRate->setCalculator($rateCalculator);
+
+        $taxRateManager->persist($taxRate);
+        $taxRateManager->flush();
+
+        return $taxCategory;
+    }
+
+    protected function createMenuItem($name, $price, TaxCategoryInterface $taxCategory)
     {
         $item = new MenuItem();
         $item->setName($name);
@@ -60,7 +98,7 @@ abstract class BaseTest extends KernelTestCase
         return $item;
     }
 
-    public function createModifier($name, $price, TaxCategoryInterface $taxCategory)
+    protected function createModifier($name, $price, TaxCategoryInterface $taxCategory)
     {
         $item = new Modifier();
         $item->setName($name);
@@ -74,7 +112,7 @@ abstract class BaseTest extends KernelTestCase
         return $item;
     }
 
-    public function createMenuItemModifier($menuItem, $menuItemChoices, $calculusStrategy, $price)
+    protected function createMenuItemModifier($menuItem, $menuItemChoices, $calculusStrategy, $price)
     {
         $modifier = new MenuItemModifier();
         $modifier->setMenuItem($menuItem);
@@ -89,5 +127,38 @@ abstract class BaseTest extends KernelTestCase
         $menuItem->getModifiers()->add($modifier);
 
         return $modifier;
+    }
+
+    protected function createRestaurant(Address $address, array $openingHours, $minimumCartAmount, $flatDeliveryPrice)
+    {
+        $contract = new Contract();
+        $contract->setMinimumCartAmount($minimumCartAmount);
+        $contract->setFlatDeliveryPrice($flatDeliveryPrice);
+
+        $restaurant = new Restaurant();
+        $restaurant->setOpeningHours($openingHours);
+        $restaurant->setAddress($address);
+        $restaurant->setContract($contract);
+
+        $this->doctrine->getManagerForClass(Restaurant::class)->persist($restaurant);
+        $this->doctrine->getManagerForClass(Restaurant::class)->flush();
+
+        return $restaurant;
+    }
+
+    protected function createUser($username)
+    {
+        $user = $this->userManipulator->create($username, 'password', "test@coopcycle.org", true, false);
+        $this->userManipulator->addRole($username, 'ROLE_USER');
+
+        return $user;
+    }
+
+    protected function authenticate(UserInterface $user)
+    {
+        $token = new UsernamePasswordToken($user, null, 'secured_area', array('ROLE_USER'));
+
+        $tokenStorage = static::$kernel->getContainer()->get('security.token_storage');
+        $tokenStorage->setToken($token);
     }
 }

--- a/tests/AppBundle/Entity/DeliveryTest.php
+++ b/tests/AppBundle/Entity/DeliveryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\AppBundle\Entity;
+
+use AppBundle\Entity\Address;
+use AppBundle\Entity\Contract;
+use AppBundle\Entity\Delivery;
+use AppBundle\Entity\Order;
+use AppBundle\Entity\Restaurant;
+use PHPUnit\Framework\TestCase;
+
+class DeliveryTest extends TestCase
+{
+    private $address;
+    private $contract;
+
+    public function setUp()
+    {
+        $this->address = new Address();
+        $this->address->setStreetAddress('1, rue de la Paix');
+        $this->address->setPostalCode('75000');
+        $this->address->setAddressLocality('Paris');
+
+        $this->contract = new Contract();
+        $this->contract->setFlatDeliveryPrice(03.50);
+    }
+
+    public function testConstructor()
+    {
+        $restaurant = new Restaurant();
+        $restaurant->setContract($this->contract);
+        $restaurant->setAddress($this->address);
+
+        $order = new Order();
+        $order->setRestaurant($restaurant);
+
+        $delivery = new Delivery($order);
+
+        $this->assertEquals(03.50, $delivery->getPrice());
+        $this->assertSame($this->address, $delivery->getOriginAddress());
+    }
+
+    public function testSetOrder()
+    {
+        $restaurant = new Restaurant();
+        $restaurant->setContract($this->contract);
+        $restaurant->setAddress($this->address);
+
+        $order = new Order();
+        $order->setRestaurant($restaurant);
+
+        $delivery = new Delivery();
+        $delivery->setOrder($order);
+
+        $this->assertEquals(03.50, $delivery->getPrice());
+        $this->assertSame($this->address, $delivery->getOriginAddress());
+    }
+}

--- a/tests/AppBundle/Service/OrderManagerTest.php
+++ b/tests/AppBundle/Service/OrderManagerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace AppBundle\Utils;
+
+use AppBundle\BaseTest;
+use AppBundle\Entity\Contract;
+use AppBundle\Entity\Delivery;
+use AppBundle\Entity\Order;
+use AppBundle\Entity\Restaurant;
+use AppBundle\Utils\CartItem;
+
+class OrderManagerTest extends BaseTest
+{
+    private $orderManager;
+    private $taxCategoryImmediate;
+    private $taxCategoryDeferred;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->orderManager = static::$kernel->getContainer()->get('order.manager');
+
+        $this->taxCategoryImmediate = $this->createTaxCategory('TVA consommation immédiate', 'tva_conso_immediate',
+            'TVA 10%', 'tva_10', 0.10, 'float');
+        $this->taxCategoryDeferred = $this->createTaxCategory('TVA consommation différée', 'tva_conso_differee',
+            'TVA 5.5%', 'tva_5_5', 0.055, 'float');
+
+        $this->createTaxCategory('TVA livraison', 'tva_livraison', 'TVA 20%', 'tva_20', 0.20, 'float');
+    }
+
+    public function testApplyTaxes()
+    {
+        // 5 - (5 / (1 + 0.10)) = 0.45
+        $item1 = $this->createMenuItem('Item 1', 5.00, $this->taxCategoryImmediate);
+        // 10 - (10 / (1 + 0.055)) = 0.52
+        $item2 = $this->createMenuItem('Item 2', 10.00, $this->taxCategoryDeferred);
+
+        $contract = new Contract();
+        // 3.5 - (3.5 / (1 + 0.20)) = 0.58
+        $contract->setFlatDeliveryPrice(3.5);
+
+        $restaurant = new Restaurant();
+        $restaurant->setContract($contract);
+
+        $delivery = new Delivery();
+        $delivery->setDate(new \DateTime('today 12:30:00'));
+        $delivery->setDuration(30);
+        $delivery->setDistance(1500);
+
+        $order = new Order();
+        $order->setRestaurant($restaurant);
+        $order->setDelivery($delivery);
+
+        $order->addCartItem(new CartItem($item1, 1), $item1);
+        $order->addCartItem(new CartItem($item2, 1), $item2);
+
+        $this->orderManager->applyTaxes($order);
+
+        $this->assertEquals(02.92, $delivery->getTotalExcludingTax());
+        $this->assertEquals(00.58, $delivery->getTotalTax());
+        $this->assertEquals(03.50, $delivery->getTotalIncludingTax());
+
+        $this->assertEquals(14.03, $order->getTotalExcludingTax());
+        $this->assertEquals(00.97, $order->getTotalTax());
+        $this->assertEquals(15.00, $order->getTotalIncludingTax());
+    }
+}

--- a/tests/AppBundle/Utils/CartTest.php
+++ b/tests/AppBundle/Utils/CartTest.php
@@ -18,11 +18,6 @@ class CartTest extends BaseTest
     {
         parent::setUp();
 
-        $taxCategoryFactory = static::$kernel->getContainer()->get('sylius.factory.tax_category');
-        $taxCategoryManager = static::$kernel->getContainer()->get('sylius.manager.tax_category');
-        $taxRateFactory = static::$kernel->getContainer()->get('sylius.factory.tax_rate');
-        $taxRateManager = static::$kernel->getContainer()->get('sylius.manager.tax_rate');
-
         $this->restaurant = new Restaurant();
         $this->restaurant->setId(1);
 
@@ -32,23 +27,7 @@ class CartTest extends BaseTest
         $this->menuSection = new MenuSection();
         $this->menuSection->setMenu($menu);
 
-        $this->taxCategory = $taxCategoryFactory->createNew();
-        $this->taxCategory->setName('Default');
-        $this->taxCategory->setCode('default');
-
-        $taxCategoryManager->persist($this->taxCategory);
-        $taxCategoryManager->flush();
-
-        $taxRate = $taxRateFactory->createNew();
-        $taxRate->setName('TVA 10%');
-        $taxRate->setCode('tva_10');
-        $taxRate->setCategory($this->taxCategory);
-        $taxRate->setAmount(10.00);
-        $taxRate->setIncludedInPrice(true);
-        $taxRate->setCalculator('default');
-
-        $taxRateManager->persist($taxRate);
-        $taxRateManager->flush();
+        $this->taxCategory = $this->createTaxCategory('Default', 'default', 'TVA 10%', 'tva_10', 10.00);
     }
 
     public function testTotal()


### PR DESCRIPTION
This pull request is another prerequisite to be able to generate invoices. 

The most important change is that it introduces 3 new properties to `Order` & `Delivery`: 
- `totalExcludingTax`
- `totalTax`
- `totalIncludingTax`

They are calculated by `OrderManager::applyTaxes`. 
Also, the goal is to avoid knowing anything about how the prices are calculated, everything is processed by a listener before saving in database. 

Please note that `order.totalIncludingTax` & `delivery.totalIncludingTax` are kept separated, i.e. `order.totalIncludingTax` does **not** include the delivery price. 

To obtain the end user price, it is necessary to do:
```
order.totalIncludingTax + delivery.totalIncludingTax
```