### PR TITLE
Select address on cart

### DIFF
--- a/src/AppBundle/Controller/RestaurantController.php
+++ b/src/AppBundle/Controller/RestaurantController.php
@@ -289,8 +289,6 @@ class RestaurantController extends Controller
 
         $errors = $this->validator->validate($cart, null, ["cart"]);
 
-//        var_dump($request->request->has('address'));
-
         if (count($errors) > 0) {
             return new JsonResponse([ 'errors' => ValidationUtils::serializeValidationErrors($errors)], 400);
         } else {

--- a/src/AppBundle/Entity/RestaurantRepository.php
+++ b/src/AppBundle/Entity/RestaurantRepository.php
@@ -8,7 +8,9 @@ use Doctrine\ORM\QueryBuilder;
 
 class RestaurantRepository extends EntityRepository
 {
-    private function createNearbyQueryBuilder($latitude, $longitude, $distance = 3000)
+    // default $distance parameter should be less than the value of `maxDistance`
+    // see why: https://github.com/coopcycle/coopcycle-web/pull/160#issue-279389044
+    private function createNearbyQueryBuilder($latitude, $longitude, $distance = 2000)
     {
         $qb = $this->createQueryBuilder('r');
 
@@ -22,7 +24,9 @@ class RestaurantRepository extends EntityRepository
         return $qb;
     }
 
-    public static function addNearbyQueryClause(QueryBuilder $qb, $latitude, $longitude, $distance = 3000)
+    // default $distance parameter should be less than the value of `maxDistance`
+    // see why: https://github.com/coopcycle/coopcycle-web/pull/160#issue-279389044
+    public static function addNearbyQueryClause(QueryBuilder $qb, $latitude, $longitude, $distance = 2000)
     {
         $qb->innerJoin($qb->getRootAlias() . '.address', 'a', Expr\Join::WITH);
 

--- a/src/AppBundle/Resources/views/menu.html.twig
+++ b/src/AppBundle/Resources/views/menu.html.twig
@@ -83,7 +83,7 @@
       {% set deliveryAddress = app.session.get('deliveryAddress') %}
 
       {% if deliveryAddress is empty and cart is not empty %}
-      <a href="{{ path('restaurant', {'id': cart.restaurantId}) }}" class="btn btn-default navbar-btn navbar-right">
+      <a href="{{ path('restaurant', {'id': cart.restaurant.id}) }}" class="btn btn-default navbar-btn navbar-right">
         {% trans %}Cart{% endtrans %}  <span class="glyphicon glyphicon-shopping-cart" aria-hidden="true"></span>  {{ cart.total }} €
       </a>
       {% endif %}


### PR DESCRIPTION
Enable the address selection on Cart .

<strike>I still have an issue before merging : 
 - on restaurant list page the restaurant selection is based on a kilometer radius (`findNearby`)
 - on cart picker the validation is done with the "real" distance by bike

So a delivery address which is valid on restaurants list page may not be valid on the cart selector. Which is terrible?</strike>

@alexsegura do you get the issue? do you have any idea to deal with it?