### PR TITLE
Dispatch adress bug

### DIFF
--- a/js/api/models/Courier.js
+++ b/js/api/models/Courier.js
@@ -83,11 +83,11 @@ Courier.prototype.toJSON = function() {
 
 Courier.nearestForDelivery = function(delivery, distance = 3500) {
 
-  var address = delivery.deliveryAddress;
+  var address = delivery.originAddress;
 
   return new Promise(function(resolve, reject) {
 
-    // Returns all the couriers which are in distance from the delivery address
+    // Returns all the couriers which are in distance from the restaurant address
     REDIS.georadius('couriers:geo', address.position.longitude, address.position.latitude, distance, "m", 'WITHDIST', 'ASC', function(err, matches) {
       if (!matches) {
         return resolve(null);

--- a/js/tests/dispatch.js
+++ b/js/tests/dispatch.js
@@ -65,10 +65,7 @@ describe('Dispatch WebSocket', function() {
 
           restaurant = newRestaurant
 
-          utils.createRandomOrder('bill', restaurant, 'default')
-            .then(resolve)
-            .catch(reject)
-        })
+        }).then(resolve).catch(reject)
       })
     })
   });
@@ -111,6 +108,7 @@ describe('Dispatch WebSocket', function() {
       ws.onerror = function(e) {
         reject(e.message);
       };
+    utils.createRandomOrder('bill', restaurant, 'default')
     });
   })
 
@@ -149,6 +147,7 @@ describe('Dispatch WebSocket', function() {
 
       sarah.onmessage = function(e) {
         assert.equal('message', e.type);
+
         var data = JSON.parse(e.data);
         assert.equal('delivery', data.type);
 
@@ -158,13 +157,64 @@ describe('Dispatch WebSocket', function() {
       };
 
       bob.onmessage = function(e) {
-        assert.equal('message', e.type);
-        var data = JSON.parse(e.data);
-        if ('delivery' === data.type) {
-          sarah.close();
-          bob.close();
-          reject('Farest courier should not receive order');
+        sarah.close();
+        bob.close();
+        reject('Farest courier should not receive order');
+      };
+
+      return utils.createRandomOrder('bill', restaurant, 'default')
+    })
+
+  })
+
+  it('should dispatch order to closest courier (one is at the exact same place as the restaurant)', function() {
+
+    this.timeout(5000);
+
+    var createWebSocket = function(username, coordinates) {
+
+      var ws = new WebSocket('http://localhost:8000', {
+        headers: {
+          Authorization: 'Bearer ' + utils.createJWT(username)
         }
+      });
+
+      ws.onopen = function() {
+        assert.equal(WebSocket.OPEN, ws.readyState);
+
+        ws.send(JSON.stringify({
+          type: "updateCoordinates",
+          coordinates: coordinates
+        }));
+      };
+
+      return ws;
+    };
+
+    return new Promise(function (resolve, reject) {
+
+      var sarah = createWebSocket('sarah', { latitude: 48.884550, longitude: 2.341358 });
+      var bob = createWebSocket('bob', { latitude: 48.86069, longitude: 2.35525 });
+
+      sarah.onerror = bob.onerror = function(e) {
+        reject(e.message);
+      };
+
+      sarah.onmessage = function(e) {
+        assert.equal('message', e.type);
+
+        var data = JSON.parse(e.data);
+        assert.equal('delivery', data.type);
+
+        sarah.close();
+        bob.close();
+        resolve();
+      };
+
+      bob.onmessage = function(e) {
+        sarah.close();
+        bob.close();
+        reject('Farest courier should not receive order');
       };
 
       return utils.createRandomOrder('bill', restaurant, 'default')

--- a/js/tests/dispatch.js
+++ b/js/tests/dispatch.js
@@ -149,7 +149,6 @@ describe('Dispatch WebSocket', function() {
 
       sarah.onmessage = function(e) {
         assert.equal('message', e.type);
-
         var data = JSON.parse(e.data);
         assert.equal('delivery', data.type);
 
@@ -160,7 +159,6 @@ describe('Dispatch WebSocket', function() {
 
       bob.onmessage = function(e) {
         assert.equal('message', e.type);
-
         var data = JSON.parse(e.data);
         if ('delivery' === data.type) {
           sarah.close();

--- a/js/tests/dispatch.js
+++ b/js/tests/dispatch.js
@@ -141,7 +141,7 @@ describe('Dispatch WebSocket', function() {
     return new Promise(function (resolve, reject) {
 
       var sarah = createWebSocket('sarah', { latitude: 48.883083, longitude: 2.344276 });
-      var bob = createWebSocket('bob', { latitude: 48.884053, longitude: 2.333172 });
+      var bob = createWebSocket('bob', { latitude: 48.86069, longitude: 2.35525 });
 
       sarah.onerror = bob.onerror = function(e) {
         reject(e.message);
@@ -162,7 +162,7 @@ describe('Dispatch WebSocket', function() {
         assert.equal('message', e.type);
 
         var data = JSON.parse(e.data);
-        if ('order' === data.type) {
+        if ('delivery' === data.type) {
           sarah.close();
           bob.close();
           reject('Farest courier should not receive order');


### PR DESCRIPTION
I changed three things in the 'should dispatch order to closest courier' test case:

- The error is now raised as long as the wrong courrier receive a message. Before we were checking that the message type was 'order', I don't think that this is useful and furthermore if we want to check the message type I think it should be delivery.

- I removed the createRandomOrder function from the beforeEach one. In some test case we were creating two random order because of that. I am may have missed something here, not 100 % sure I should have removed it.

- I changed the courier location, see below

![image](https://user-images.githubusercontent.com/7386377/33794612-4a8fdd62-dccf-11e7-9c69-3b60f08468f7.png)

For the rest it is pretty straightforward, we were choosing the delivery address as the origin point while we should have chosen the restaurant address.