### PR TITLE
Introduce manual dispatch.

### DIFF
--- a/app/config/routing.yml
+++ b/app/config/routing.yml
@@ -22,6 +22,25 @@ web:
 fos_user:
     resource: "@FOSUserBundle/Resources/config/routing/all.xml"
 
+admin_delivery_pick:
+    path:     /admin/deliveries/{id}/pick
+    defaults: { _controller: AppBundle:Admin:pickDelivery }
+    methods:  [ POST ]
+
+admin_delivery_deliver:
+    path:     /admin/deliveries/{id}/deliver
+    defaults: { _controller: AppBundle:Admin:deliverDelivery }
+    methods:  [ POST ]
+
+profile_delivery_pick:
+    path:     /profile/deliveries/{id}/pick
+    defaults: { _controller: AppBundle:Profile:pickDelivery }
+    methods:  [ POST ]
+
+profile_delivery_deliver:
+    path:     /profile/deliveries/{id}/deliver
+    defaults: { _controller: AppBundle:Profile:deliverDelivery }
+    methods:  [ POST ]
 
 redirect_to_locale:
     path: /

--- a/js/app/delivery/list.jsx
+++ b/js/app/delivery/list.jsx
@@ -1,0 +1,24 @@
+$('#delivery-modal').on('show.bs.modal', function (event) {
+
+  var button = $(event.relatedTarget)
+  var delivery = button.data('delivery')
+  var action = button.data('action')
+
+  var $modal = $(this)
+
+  $modal.find('[data-action]').each(function(index, el) {
+    if ($(el).data('action') === action) {
+      $(el).removeClass('hidden')
+    } else {
+      $(el).addClass('hidden')
+    }
+  })
+
+  $modal.find('span[data-delivery]').text(delivery)
+
+  const formAction = window.AppData.Delivery.actions[action]
+
+  $modal.find('form')
+    .attr('action', formAction.replace('__DELIVERY_ID__', delivery))
+
+})

--- a/src/AppBundle/Action/Me.php
+++ b/src/AppBundle/Action/Me.php
@@ -56,6 +56,13 @@ class Me
             'status' => $status,
         ];
 
+        $order = null;
+        if (null !== $delivery->getOrder()) {
+            $order = [
+                'id' => $delivery->getOrder()->getId(),
+            ];
+        }
+
         if (null !== $delivery) {
             $data['delivery'] = [
                 'id' => $delivery->getId(),
@@ -68,9 +75,7 @@ class Me
                     'longitude' => $delivery->getDeliveryAddress()->getGeo()->getLongitude(),
                     'latitude' => $delivery->getDeliveryAddress()->getGeo()->getLatitude(),
                 ],
-                'order' => [
-                    'id' => $delivery->getOrder()->getId(),
-                ],
+                'order' => $order,
             ];
         }
 

--- a/src/AppBundle/Controller/ProfileController.php
+++ b/src/AppBundle/Controller/ProfileController.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Controller\Utils\AccessControlTrait;
+use AppBundle\Controller\Utils\DeliveryTrait;
 use AppBundle\Entity\Address;
 use AppBundle\Entity\ApiUser;
 use AppBundle\Entity\Order;
@@ -17,6 +18,7 @@ use Symfony\Component\HttpFoundation\Request;
 class ProfileController extends Controller
 {
     use AccessControlTrait;
+    use DeliveryTrait;
     use AdminTrait;
     use RestaurantTrait;
 
@@ -198,6 +200,7 @@ class ProfileController extends Controller
 
         return [
             'deliveries' => $deliveries,
+            'routes' => $this->getDeliveryRoutes(),
             'avg_delivery_time' => $avgDeliveryTime,
             'delivery_times' => $deliveryTimes,
         ];
@@ -380,5 +383,14 @@ class ProfileController extends Controller
 
             return $this->cancelOrder($id, 'profile_restaurant_orders', ['restaurantId' => $order->getRestaurant()->getId()]);
         }
+    }
+
+    protected function getDeliveryRoutes()
+    {
+        return [
+            'list'    => 'profile_courier_deliveries',
+            'pick'    => 'profile_delivery_pick',
+            'deliver' => 'profile_delivery_deliver'
+        ];
     }
 }

--- a/src/AppBundle/Controller/Utils/DeliveryTrait.php
+++ b/src/AppBundle/Controller/Utils/DeliveryTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace AppBundle\Controller\Utils;
+
+use AppBundle\Entity\Delivery;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+trait DeliveryTrait
+{
+    /**
+     * @return array
+     */
+    abstract protected function getDeliveryRoutes();
+
+    public function pickDeliveryAction($id, Request $request)
+    {
+        $delivery = $this->getDoctrine()->getRepository(Delivery::class)->find($id);
+        $this->accessControl($delivery);
+
+        $delivery->setStatus(Delivery::STATUS_PICKED);
+        $this->getDoctrine()->getManagerForClass(Delivery::class)->flush();
+
+        $routes = $this->getDeliveryRoutes();
+
+        return $this->redirectToRoute($routes['list']);
+    }
+
+    public function deliverDeliveryAction($id, Delivery $delivery)
+    {
+        $delivery = $this->getDoctrine()->getRepository(Delivery::class)->find($id);
+        $this->accessControl($delivery);
+
+        $delivery->setStatus(Delivery::STATUS_DELIVERED);
+        $this->getDoctrine()->getManagerForClass(Delivery::class)->flush();
+
+        $routes = $this->getDeliveryRoutes();
+
+        return $this->redirectToRoute($routes['list']);
+    }
+}

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -38,6 +38,10 @@ delivery.status.PICKED: Picked
 delivery.status.DELIVERED: Delivered
 delivery.status.CANCELED: Canceled
 
+delivery.status.DISPATCHED.verb: Dispatch
+delivery.status.PICKED.verb: Pick
+delivery.status.DELIVERED.verb: Deliver
+
 delivery.pricing_rules.help: >
   You can define rules for deliveries pricing:
   each rule defines an « expression » and an associated price.

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -128,6 +128,12 @@ Origin address: Adresse de départ
 Delivery address: Adresse de livraison
 Weight: Poids
 Show canceled orders: Afficher les commandes annulées
+Validate: Valider
+Please choose a courier in the list below: Veuillez choisir un coursier dans la liste ci-dessous
+The delivery will appear in his planning: La livraison apparaîtra dans son planning
+This delivery will be considered as picked: Cette livraison sera considérée comme récupérée
+This delivery will be considered as delivered: Cette livraison sera considérée comme livrée
+This action cannot be undone: Cette action ne peut pas être annulée
 
 profile.addresses.breadcrumb: Addresses
 profile.addresses.empty: Pas d'adresse sauvegardée pour le moment!
@@ -172,10 +178,14 @@ order.status.CANCELED: Annulée
 order.status.PAYMENT_ERROR: Erreur de paiement
 
 delivery.status.WAITING: En attente
-delivery.status.DISPATCHED: Acceptée
+delivery.status.DISPATCHED: Assignée
 delivery.status.PICKED: Récupérée
 delivery.status.DELIVERED: Livrée
 delivery.status.CANCELED: Annulée
+
+delivery.status.DISPATCHED.verb: Assigner
+delivery.status.PICKED.verb: Récupérer
+delivery.status.DELIVERED.verb: Livrer
 
 delivery.pricing_rules.help: >
   Vous pouvez définir des règles pour la tarification des livraisons :

--- a/src/AppBundle/Resources/views/Admin/deliveries.html.twig
+++ b/src/AppBundle/Resources/views/Admin/deliveries.html.twig
@@ -5,24 +5,23 @@
 {% endblock %}
 
 {% block content %}
-  <table class="table">
-  {% for delivery in deliveries %}
-    <tr>
-      <td>
-        {{ delivery.originAddress.streetAddress }}
-        <br>
-        {{ delivery.deliveryAddress.streetAddress }}
-      </td>
-      <td>{{ (delivery.distance / 1000)|round(2) }} Km</td>
-      <td><i class="fa fa-clock-o"></i> {{ (delivery.duration / 60)|round }} Min</td>
-      <td>{{ delivery.date|date('d/m H:i') }}</td>
-      <td class="text-right">
-        {% if delivery.order is not empty %}
-          <a href="{{ path('admin_order', { id: delivery.order.id }) }}">{% trans %}Order{% endtrans %}</a>
-        {% endif %}
-      </td>
-    </tr>
-  {% endfor %}
-  </table>
-  <a href="{{ path('admin_deliveries_new') }}" class="btn btn-success"><i class="fa fa-plus"></i> {% trans %}Add{% endtrans %}</a>
+  {% include "AppBundle::_partials/Delivery/list.html.twig" with { show_courier: true } %}
+  <a href="{{ path('admin_deliveries_new') }}" class="btn btn-success">
+    <i class="fa fa-plus"></i> {% trans %}Add{% endtrans %}
+  </a>
+  {% include "AppBundle::_partials/Delivery/modal.html.twig" %}
+{% endblock %}
+
+{% block scripts %}
+<script>
+window.AppData = window.AppData || {};
+window.AppData.Delivery = {
+  actions: {
+    dispatch: "{{ path(routes.dispatch, { id: '__DELIVERY_ID__' }) }}",
+    pick: "{{ path(routes.pick, { id: '__DELIVERY_ID__' }) }}",
+    deliver: "{{ path(routes.deliver, { id: '__DELIVERY_ID__' }) }}"
+  }
+}
+</script>
+<script src="{{ asset('js/delivery-list.js') }}"></script>
 {% endblock %}

--- a/src/AppBundle/Resources/views/Profile/courierDeliveries.html.twig
+++ b/src/AppBundle/Resources/views/Profile/courierDeliveries.html.twig
@@ -9,29 +9,8 @@
 <hr>
 <canvas id="myChart" width="100" height="33"></canvas>
 <hr>
-
-<table class="table">
-  <thead>
-    <th>#</th>
-    <th>{% trans %}Status{% endtrans %}</th>
-    <th class="text-right">{% trans %}Duration{% endtrans %}</th>
-    <th></th>
-  </thead>
-  <tbody>
-  {% for delivery in deliveries %}
-  <tr>
-    <td>#{{ delivery.id }}</td>
-    <td>{% include "AppBundle:Delivery:label.html.twig" %}</td>
-    <td class="text-right">{{ delivery.actualDuration }}</td>
-    <td class="text-right">
-      <a href="{{ path('profile_order', {id: delivery.order.id}) }}">
-        {% trans %}View order{% endtrans %}
-      </a>
-    </td>
-  </tr>
-  {% endfor %}
-  </tbody>
-</table>
+{% include "AppBundle::_partials/Delivery/list.html.twig" %}
+{% include "AppBundle::_partials/Delivery/modal.html.twig" %}
 {% endblock %}
 
 {% block scripts %}
@@ -45,6 +24,7 @@
     {% set pickup_data = pickup_data|merge([item.pickup_time]) %}
     {% set delivery_data = delivery_data|merge([item.delivery_time]) %}
   {% endfor %}
+
   <script>
   window.AppData = window.AppData || {};
   window.AppData.__i18n = {
@@ -58,6 +38,13 @@
       delivery: {{ delivery_data|json_encode()|raw }}
     }
   }
+  window.AppData.Delivery = {
+    actions: {
+      pick: "{{ path(routes.pick, { id: '__DELIVERY_ID__' }) }}",
+      deliver: "{{ path(routes.deliver, { id: '__DELIVERY_ID__' }) }}"
+    }
+  }
   </script>
   <script src="{{ asset('js/profile-deliveries.js') }}"></script>
+  <script src="{{ asset('js/delivery-list.js') }}"></script>
 {% endblock %}

--- a/src/AppBundle/Resources/views/_partials/Delivery/actions.html.twig
+++ b/src/AppBundle/Resources/views/_partials/Delivery/actions.html.twig
@@ -1,0 +1,25 @@
+{% if is_granted('ROLE_ADMIN') and delivery.status == 'WAITING' %}
+  <button type="button" class="btn btn-xs btn-success"
+    data-toggle="modal"
+    data-target="#delivery-modal"
+    data-delivery="{{ delivery.id }}"
+    data-action="dispatch">
+    {% trans %}delivery.status.DISPATCHED.verb{% endtrans %}
+  </button>
+{% elseif is_granted('ROLE_COURIER') and delivery.status == 'DISPATCHED' %}
+  <button type="button" class="btn btn-xs btn-success"
+    data-toggle="modal"
+    data-target="#delivery-modal"
+    data-delivery="{{ delivery.id }}"
+    data-action="pick">
+    {% trans %}delivery.status.PICKED.verb{% endtrans %}
+  </button>
+{% elseif is_granted('ROLE_COURIER') and delivery.status == 'PICKED' %}
+  <button type="button" class="btn btn-xs btn-success"
+    data-toggle="modal"
+    data-target="#delivery-modal"
+    data-delivery="{{ delivery.id }}"
+    data-action="deliver">
+    {% trans %}delivery.status.DELIVERED.verb{% endtrans %}
+  </button>
+{% endif %}

--- a/src/AppBundle/Resources/views/_partials/Delivery/list.html.twig
+++ b/src/AppBundle/Resources/views/_partials/Delivery/list.html.twig
@@ -1,0 +1,55 @@
+<table class="table">
+  <thead>
+    <th>#</th>
+    <th>État</th>
+    <th>Date</th>
+    <th>Départ / Arrivée</th>
+    {% if show_courier is defined and show_courier %}
+    <th>Coursier</th>
+    {% endif %}
+    <th colspan="2" class="text-right">Estimations</th>
+    <th class="text-right">Commande</th>
+    <th></th>
+  </thead>
+  <tbody>
+  {% for delivery in deliveries %}
+    <tr>
+      <td width="5%">#{{ delivery.id }}</td>
+      <td width="5%">{% include "AppBundle:Delivery:label.html.twig" %}</td>
+      <td width="15%">
+      {{ delivery.date|localizeddate('short', 'short') }}
+      </td>
+      <td>
+        {{ delivery.originAddress.streetAddress }}
+        <br>
+        {{ delivery.deliveryAddress.streetAddress }}
+      </td>
+      {% if show_courier is defined and show_courier %}
+      <td width="10%">
+        {% if delivery.courier is not empty %}
+        <a href="{{ path('admin_user_details', { username: delivery.courier.username }) }}" title="{{ delivery.courier.username }}">
+          <i class="fa fa-user"></i> {{ delivery.courier.username }}
+        </a>
+        {% else %}
+        <i class="fa fa-ban"></i>
+        {% endif %}
+      </td>
+      {% endif %}
+      <td width="10%" class="text-right">{{ (delivery.distance / 1000)|round(2) }} Km</td>
+      <td width="10%" class="text-right"><i class="fa fa-clock-o"></i> {{ (delivery.duration / 60)|round }} Min</td>
+      <td class="text-right">
+        {% if delivery.order is not empty %}
+        <a href="{{ path('admin_order', { id: delivery.order.id }) }}" title="{% trans %}Order{% endtrans %}">
+          #{{ delivery.order.id }}
+        </a>
+        {% else %}
+        <i class="fa fa-ban"></i>
+        {% endif %}
+      </td>
+      <td class="text-right">
+        {% include "AppBundle::_partials/Delivery/actions.html.twig" %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>

--- a/src/AppBundle/Resources/views/_partials/Delivery/modal.html.twig
+++ b/src/AppBundle/Resources/views/_partials/Delivery/modal.html.twig
@@ -1,0 +1,61 @@
+<div id="delivery-modal" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <form method="post" class="form-horizontal">
+      <div class="modal-content">
+        <div class="modal-header">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+          <h4 class="modal-title">
+            {% trans %}Delivery{% endtrans %} #<span data-delivery></span>
+          </h4>
+        </div>
+        <div class="modal-body">
+
+          <div class="alert alert-info" data-action="dispatch">
+            {% trans %}Please choose a courier in the list below{% endtrans %}
+            <br>
+            {% trans %}The delivery will appear in his planning{% endtrans %}
+          </div>
+          <div class="alert alert-warning" data-action="pick">
+            {% trans %}This delivery will be considered as picked{% endtrans %}
+            <br>
+            {% trans %}This action cannot be undone{% endtrans %}
+          </div>
+          <div class="alert alert-warning" data-action="deliver">
+            {% trans %}This delivery will be considered as delivered{% endtrans %}
+            <br>
+            {% trans %}This action cannot be undone{% endtrans %}
+          </div>
+
+          {% if couriers is defined %}
+          <div class="form-group" data-action="dispatch">
+            <label for="courier" class="col-sm-2 control-label">
+              {% trans %}Courier{% endtrans %}
+              </label>
+            <div class="col-sm-10">
+              <select name="courier" class="form-control">
+                <option></option>
+                {% for courier in couriers %}
+                  <option value="{{ courier.id }}">
+                    {{ courier.username }}
+                  </option>
+                {% endfor %}
+              </select>
+            </div>
+          </div>
+          {% endif %}
+
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">
+            {% trans %}Cancel{% endtrans %}
+          </button>
+          <button type="submit" class="btn btn-primary">
+            {% trans %}Validate{% endtrans %}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ var webpackConfig = {
     'js/order-tracking': './js/app/order/tracking.jsx',
     'js/profile-deliveries': './js/app/profile/deliveries.js',
     'js/delivery-form': './js/app/delivery/form.jsx',
+    'js/delivery-list': './js/app/delivery/list.jsx',
     'js/delivery-pricing-rules': './js/app/delivery/pricing-rules.jsx',
     'js/restaurant-form': './js/app/restaurant/form.jsx',
     'js/restaurant-menu': './js/app/restaurant/menu.jsx',


### PR DESCRIPTION
A really simple implementation of manual dispatch. 

**Administrator** can assign couriers to deliveries.

![manual_dispatch_admin](https://user-images.githubusercontent.com/1162230/34186045-9bdaaf50-e529-11e7-83de-94a9208b14c6.gif)

**Courier** can see assigned deliveries assigned in personal account, and change the status. 

![manual_dispatch_courier](https://user-images.githubusercontent.com/1162230/34186089-f862c992-e529-11e7-9804-a591701f187f.gif)

This is just a first step before adding more cool stuff, but we need this at least to display it in the native app. 

ping @couleurmate