### PR TITLE
Introduce task groups

### DIFF
--- a/app/DoctrineMigrations/Version20180220124056.php
+++ b/app/DoctrineMigrations/Version20180220124056.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180220124056 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE TABLE task_group (id SERIAL NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('ALTER TABLE task ADD group_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE task ADD CONSTRAINT FK_527EDB25FE54D947 FOREIGN KEY (group_id) REFERENCES task_group (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_527EDB25FE54D947 ON task (group_id)');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE task DROP CONSTRAINT FK_527EDB25FE54D947');
+        $this->addSql('DROP TABLE task_group');
+        $this->addSql('DROP INDEX IDX_527EDB25FE54D947');
+        $this->addSql('ALTER TABLE task DROP group_id');
+    }
+}

--- a/assets/css/dashboard.scss
+++ b/assets/css/dashboard.scss
@@ -64,13 +64,20 @@ html, body {
     flex: 1;
     -webkit-flex-direction: column;
     flex-direction: column;
-    > h3, > h4 {
+    > h4 {
       padding: 15px;
       margin: 0;
       background-color: #95A5A6;
       color: #fff;
+      a {
+        color: #fff;
+        &:hover, &:active {
+          color: darken(#fff, 15%);
+          text-decoration: none;
+        }
+      }
     }
-    .dashboard__panel__scroll {
+    &__scroll {
       overflow: auto;
     }
   }
@@ -107,16 +114,6 @@ html, body {
       flex: 1;
       -webkit-flex-direction: column;
       flex-direction: column;
-    }
-
-    .dashboard__panel {
-      h4 > a {
-        color: #fff;
-        &:hover, &:active {
-          color: darken(#fff, 15%);
-          text-decoration: none;
-        }
-      }
     }
 
     .dropzone {
@@ -158,6 +155,10 @@ html, body {
   padding-right: 60px;
   cursor: pointer;
   color: #fff;
+  border-radius: 0;
+  &:last-child {
+    border-radius: 0;
+  }
   a {
     color: #fff;
   }
@@ -187,7 +188,6 @@ html, body {
   }
 }
 
-
 .task__icon {
   font-size: 16px;
   line-height: 16px;
@@ -205,6 +205,12 @@ html, body {
     position: static;
     padding-right: 5px;
     transform: none;
+  }
+}
+
+.task__draggable {
+  &--dragging {
+    opacity: 0.4;
   }
 }
 

--- a/js/app/dashboard/app.js
+++ b/js/app/dashboard/app.js
@@ -1,11 +1,11 @@
 import React from 'react'
+import { findDOMNode } from 'react-dom'
 import { connect } from 'react-redux'
 import dragula from 'dragula'
 import { assignTasks, updateTask } from './store/actions'
 import TaskList from './components/TaskList'
 import UserPanelList from './components/UserPanelList'
-
-let inDraggingUnassignedTask
+import _ from 'lodash'
 
 const drake = dragula({
   copy: true,
@@ -13,25 +13,25 @@ const drake = dragula({
   revertOnSpill: true,
   accepts: (el, target, source, sibling) => target !== source
 })
+.on('drag', function(el, source) {
+  let elements = []
+  if (el.hasAttribute('data-link')) {
+    const siblings = Array.from(el.parentNode.childNodes)
+    elements = _.filter(siblings, sibling => sibling.getAttribute('data-link') === el.getAttribute('data-link'))
+  } else {
+    elements = [ el ]
+  }
+  elements.forEach(el => el.classList.add('task__draggable--dragging'))
+})
 .on('cloned', function (clone, original) {
-  // fired when we start dragging from unassigned tasks
-  inDraggingUnassignedTask = original
-  if ($(original).hasClass('list-group-item')) {
-    $(original).addClass('disabled')
-  } else {
-    $(original).find('.list-group-item').addClass('disabled')
-  }
-}).on('dragend', function (el) {
-  if ($(inDraggingUnassignedTask).hasClass('list-group-item')) {
-    $(inDraggingUnassignedTask).removeClass('disabled')
-  } else {
-    $(inDraggingUnassignedTask).find('.list-group-item').removeClass('disabled')
-  }
-}).on('over', function (el, container, source) {
+  clone.classList.remove('task__draggable--dragging')
+})
+.on('over', function (el, container, source) {
   if ($(container).hasClass('dropzone')) {
     $(container).addClass('dropzone--over')
   }
-}).on('out', function (el, container, source) {
+})
+.on('out', function (el, container, source) {
   if ($(container).hasClass('dropzone')) {
     $(container).removeClass('dropzone--over')
   }
@@ -40,28 +40,35 @@ const drake = dragula({
 /**
  * Code to handle drag and drop from unassigned tasks to assigned
  */
-function configureOnDrop(allTasks, assignTasks) {
+function configureDrake(unassignedTasksContainer, allTasks, assignTasks) {
 
   drake
+    .on('dragend', function (el) {
+      Array.from(unassignedTasksContainer.querySelectorAll('.task__draggable--dragging'))
+        .forEach(el => el.classList.remove('task__draggable--dragging'))
+    })
     .on('drop', function(element, target, source) {
 
       const username = $(target).data('username')
-      let tasks = []
+      const isTask = element.hasAttribute('data-task-id')
+      const elements = isTask ? [ element ] : Array.from(element.querySelectorAll('[data-task-id]'))
 
-      if ($(element).data('task-group') === true) {
-        tasks = $(element)
-          .children()
-          .map((index, el) => $(el).data('task-id'))
-          .map((index, taskID) => _.find(allTasks, task => task['@id'] === taskID))
-          .toArray()
-      } else {
-        const task = _.find(allTasks, task => task['@id'] === $(element).data('task-id'))
-        tasks.push(task)
+      let tasks = elements.map(el => _.find(allTasks, task => task['@id'] === el.getAttribute('data-task-id')))
+
+      // Make sure linked tasks are assigned too
+      const tasksWithLink = _.filter(tasks, task => task.hasOwnProperty('link'))
+      if (tasksWithLink.length > 0) {
+        const links = tasksWithLink.map(task => task.link)
+        const linkedTasks = _.filter(allTasks, task => task.hasOwnProperty('link') && _.includes(links, task.link))
+        linkedTasks.forEach(task => tasks.push(task))
+        tasks = _.uniqBy(tasks, '@id')
       }
 
       assignTasks(username, tasks)
 
       $(target).removeClass('dropzone--loading')
+
+      // Remove cloned element from dropzone
       element.remove()
     })
 
@@ -72,14 +79,17 @@ class DashboardApp extends React.Component {
   componentDidMount() {
     this.props.socket.on('task:done', data => this.props.updateTask(data.task))
     this.props.socket.on('task:failed', data => this.props.updateTask(data.task))
-    configureOnDrop(this.props.allTasks, this.props.assignTasks)
+
+    const unassignedTasksContainer = findDOMNode(this.refs.unassignedTasks).querySelector('.list-group')
+    drake.containers.push(unassignedTasksContainer)
+
+    configureDrake(unassignedTasksContainer, this.props.allTasks, this.props.assignTasks)
   }
 
   render () {
     return (
       <div className="dashboard__aside-container">
-        <TaskList
-          onLoad={ el => drake.containers.push(el) } />
+        <TaskList ref="unassignedTasks" />
         <UserPanelList
           couriersList={ window.AppData.Dashboard.couriersList }
           onLoad={ el => drake.containers.push(el) } />

--- a/js/app/dashboard/components/Task.js
+++ b/js/app/dashboard/components/Task.js
@@ -51,7 +51,7 @@ class Task extends React.Component {
     const classNames = ['task__icon']
     classNames.push(assigned ? 'task__icon--left' : 'task__icon--right')
 
-    if (task.hasOwnProperty('group')) {
+    if (task.hasOwnProperty('link')) {
       return (
         <span className={ classNames.join(' ') }><i className="fa fa-exchange"></i></span>
       )
@@ -75,11 +75,16 @@ class Task extends React.Component {
       'list-group-item',
       'list-group-item--' + task.type.toLowerCase(),
       'list-group-item--' + task.status.toLowerCase(),
-      'task'
+      'task__draggable'
     ]
 
+    let taskAttributes = {}
+    if (task.hasOwnProperty('link')) {
+      taskAttributes = Object.assign(taskAttributes, { 'data-link': task.link })
+    }
+
     return (
-      <div key={ task['@id'] } className={ classNames.join(' ') } data-task-id={ task['@id'] }>
+      <div key={ task['@id'] } className={ classNames.join(' ') } data-task-id={ task['@id'] } { ...taskAttributes }>
         <div>
           <i className={ 'task__icon task__icon--type fa fa-' + (task.type === 'PICKUP' ? 'cube' : 'arrow-down') }></i>
           <span>Tâche #{/([\d]+)/.exec(task['@id'])[0]}</span>

--- a/js/app/dashboard/components/TaskGroup.js
+++ b/js/app/dashboard/components/TaskGroup.js
@@ -3,18 +3,29 @@ import Task from './Task'
 
 export default class extends React.Component {
   render() {
-    const { tasks } = this.props
+    const { group, tasks } = this.props
     return (
-      <div className="task-group" data-task-group="true">
-        { tasks.map(task => {
-          return (
-            <Task
-              key={ task['@id'] }
-              task={ task }
-              assigned={ false }
-            />
-          )
-        })}
+      <div className="panel panel-default nomargin task__draggable">
+        <div className="panel-heading" role="tab">
+          <h4 className="panel-title">
+            <a role="button" data-toggle="collapse" href={ `#task-group-panel-${group.id}` }>
+              <i className="fa fa-folder"></i> { group.name } <span className="badge">{ tasks.length }</span>
+            </a>
+          </h4>
+        </div>
+        <div id={ `task-group-panel-${group.id}` } className="panel-collapse collapse" role="tabpanel">
+          <ul className="list-group">
+            { tasks.map(task => {
+              return (
+                <Task
+                  key={ task['@id'] }
+                  task={ task }
+                  assigned={ false }
+                />
+              )
+            })}
+          </ul>
+        </div>
       </div>
     )
   }

--- a/js/app/dashboard/components/UserPanel.js
+++ b/js/app/dashboard/components/UserPanel.js
@@ -52,7 +52,7 @@ class UserPanel extends React.Component {
 
         const draggedTask = _.find(tasks, task => task['@id'] === el.getAttribute('data-task-id'))
 
-        if (!draggedTask.hasOwnProperty('group')) {
+        if (!draggedTask.hasOwnProperty('link')) {
           return true
         }
 
@@ -115,8 +115,8 @@ class UserPanel extends React.Component {
 
     // Check if we need to remove another linked task
     let tasksToRemove = []
-    if (taskToRemove.hasOwnProperty('group')) {
-      tasksToRemove = _.filter(this.props.tasks, task => task.hasOwnProperty('group') && task.group === taskToRemove.group)
+    if (taskToRemove.hasOwnProperty('link')) {
+      tasksToRemove = _.filter(this.props.tasks, task => task.hasOwnProperty('link') && task.link === taskToRemove.link)
     } else {
       tasksToRemove = [ taskToRemove ]
     }

--- a/js/app/dashboard/components/UserPanelList.js
+++ b/js/app/dashboard/components/UserPanelList.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import { findDOMNode } from 'react-dom'
 import Modal from 'react-modal'
 import _ from 'lodash'
-import { addUsernameToList, closeAddUserModal, openAddUserModal, removeTasks, saveUserTasksRequest, assignTasks } from '../store/actions'
+import { addUsernameToList, closeAddUserModal, openAddUserModal } from '../store/actions'
 import UserPanel from './UserPanel'
 
 
@@ -134,9 +134,6 @@ function mapStateToProps (state) {
 
 function mapDispatchToProps (dispatch) {
   return {
-    assignTasks: (username, tasks) => { dispatch(assignTasks(username, tasks)) },
-    removeTasks: (username, tasks) => { dispatch(removeTasks(username, tasks)) },
-    saveUserTasksRequest: (username, tasks) => { dispatch(saveUserTasksRequest(username, tasks)) },
     addUsername: (username) => { dispatch(addUsernameToList(username)) },
     openAddUserModal: () => { dispatch(openAddUserModal()) },
     closeAddUserModal: () => { dispatch(closeAddUserModal()) }

--- a/js/app/dashboard/store/actions.js
+++ b/js/app/dashboard/store/actions.js
@@ -63,6 +63,10 @@ function togglePolyline(username) {
   return { type: 'TOGGLE_POLYLINE', username }
 }
 
+function setTaskListGroupMode(mode) {
+  return { type: 'SET_TASK_LIST_GROUP_MODE', mode }
+}
+
 export {
   updateTask,
   addUsernameToList,
@@ -72,5 +76,6 @@ export {
   removeTasks,
   openAddUserModal,
   closeAddUserModal,
-  togglePolyline
+  togglePolyline,
+  setTaskListGroupMode,
 }

--- a/js/app/dashboard/store/reducers.js
+++ b/js/app/dashboard/store/reducers.js
@@ -1,24 +1,24 @@
 import { combineReducers } from 'redux'
 import _ from 'lodash'
 
-function addGroupProperty(tasks) {
+function addLinkProperty(tasks) {
   let tasksById = _.keyBy(tasks, task => task['@id'])
 
   const tasksWithPrevious = _.filter(tasks, task => task.previous !== null)
   _.each(tasksWithPrevious, task => {
     const previousTask = tasksById[task.previous]
-    const taskGroup    = [ previousTask, task ]
-    const groupKey     = _.join(_.map(taskGroup, task => task.id), ':')
+    const taskArray    = [ previousTask, task ]
+    const linkKey      = _.join(_.map(taskArray, task => task.id), ':')
 
-    tasksById[task.previous] = Object.assign(tasksById[task.previous], { group: groupKey })
-    tasksById[task['@id']]   = Object.assign(tasksById[task['@id']], { group: groupKey })
+    tasksById[task.previous] = Object.assign(tasksById[task.previous], { link: linkKey })
+    tasksById[task['@id']]   = Object.assign(tasksById[task['@id']], { link: linkKey })
   })
 
   return _.map(tasksById, task => task)
 }
 
 // initial data pumped from the template
-const tasksInitial = addGroupProperty(window.AppData.Dashboard.tasks),
+const tasksInitial = addLinkProperty(window.AppData.Dashboard.tasks),
       unassignedTasksInitial = _.filter(tasksInitial, task => !task.isAssigned),
       assignedTasksList = _.filter(tasksInitial, task => task.isAssigned),
       assignedTasksByUserInitial = _.groupBy(assignedTasksList, task => task.assignedTo)
@@ -85,7 +85,7 @@ const assignedTasksByUser = (state = assignedTasksByUserInitial, action) => {
       newState[action.username].polyline = ''
       break
     case 'SAVE_USER_TASKS_SUCCESS':
-      newState[action.username] = addGroupProperty(action.tasks)
+      newState[action.username] = addLinkProperty(action.tasks)
       newState[action.username].duration = action.duration
       newState[action.username].distance = action.distance
       newState[action.username].polyline = action.polyline
@@ -173,11 +173,21 @@ const polylineEnabled = (state = polylineEnabledByUser, action) => {
   }
 }
 
+const taskListGroupMode = (state = 'GROUP_MODE_FOLDERS', action) => {
+  switch (action.type) {
+    case 'SET_TASK_LIST_GROUP_MODE':
+      return action.mode
+    default:
+      return state
+  }
+}
+
 export default combineReducers({
   allTasks,
   assignedTasksByUser,
   unassignedTasks,
   userPanelLoading,
   addModalIsOpen,
-  polylineEnabled
+  polylineEnabled,
+  taskListGroupMode,
 })

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -18,6 +18,7 @@ use AppBundle\Entity\Restaurant;
 use AppBundle\Entity\Order;
 use AppBundle\Entity\Store;
 use AppBundle\Entity\Task;
+use AppBundle\Entity\Task\Group as TaskGroup;
 use AppBundle\Entity\TaskAssignment;
 use AppBundle\Entity\TaskList;
 use AppBundle\Entity\Zone;
@@ -151,7 +152,16 @@ class AdminController extends Controller
 
                 $taskImport = $taskUploadForm->getData();
 
+                $taskGroup = new TaskGroup();
+                $taskGroup->setName(sprintf('Import %s', date('d/m H:i')));
+
+                $this->getDoctrine()
+                    ->getManagerForClass(TaskGroup::class)
+                    ->persist($taskGroup);
+
                 foreach ($taskImport->tasks as $task) {
+                    $task->setGroup($taskGroup);
+
                     $this->getDoctrine()
                         ->getManagerForClass(Task::class)
                         ->persist($task);

--- a/src/AppBundle/Entity/Task.php
+++ b/src/AppBundle/Entity/Task.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Entity;
 
+use AppBundle\Entity\Task\Group as TaskGroup;
 use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
@@ -128,6 +129,12 @@ class Task
      * @ORM\JoinColumn(name="previous_task_id", referencedColumnName="id", nullable=true)
      */
     private $previous;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="AppBundle\Entity\Task\Group", cascade={"all"})
+     * @ORM\JoinColumn(name="group_id", referencedColumnName="id", nullable=true)
+     */
+    private $group;
 
     public function __construct()
     {
@@ -327,5 +334,17 @@ class Task
                 return $event;
             }
         }
+    }
+
+    public function getGroup()
+    {
+        return $this->group;
+    }
+
+    public function setGroup(TaskGroup $group = null)
+    {
+        $this->group = $group;
+
+        return $this;
     }
 }

--- a/src/AppBundle/Entity/Task/Group.php
+++ b/src/AppBundle/Entity/Task/Group.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace AppBundle\Entity\Task;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="task_group")
+ */
+class Group
+{
+    /**
+     * @ORM\Column(type="integer")
+     * @ORM\Id
+     * @ORM\GeneratedValue(strategy="IDENTITY")
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(type="string")
+     * @Assert\Type(type="string")
+     */
+    protected $name;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+}

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -179,6 +179,9 @@ Specify any useful details to complete task: Précisez tout détail utile pour e
 Import errors: Erreurs d'importation
 Could not geocode address %address%: Impossible de géocoder l'adresse %address%
 You must provide an "address" column: Vous devez spécifier une colonne "address"
+Display: Affichage
+Display by groups: Afficher par groupes
+Display all: Afficher tout
 
 adminDashboard.tooltip.orders: Gestion des commandes restaurateurs
 adminDashboard.tooltip.deliveries: Gestion des courses

--- a/src/AppBundle/Resources/views/Admin/dashboardIframe.html.twig
+++ b/src/AppBundle/Resources/views/Admin/dashboardIframe.html.twig
@@ -104,6 +104,13 @@
 </div>
 <div class="modal fade" id="task-edit-modal" tabindex="-1" role="dialog"></div>
 
+<script id="task-list-group-mode-template" type="text/template">
+  <ul class="list-unstyled nomargin">
+    <li><a href="#" id="task-list-group-mode--group">{% trans %}Display by groups{% endtrans %}</a></li>
+    <li><a href="#" id="task-list-group-mode--none">{% trans %}Display all{% endtrans %}</a></li>
+  </ul>
+</script>
+
 {% endblock %}
 
 {% block styles %}
@@ -129,7 +136,8 @@ window.AppData.Dashboard = {
     'Add a user to the planning': "{% trans %}Add a user to the planning{% endtrans %}",
     'Courier': "{% trans %}Courier{% endtrans %}",
     'Add': "{% trans %}Add{% endtrans %}",
-    'Cancel': "{% trans %}Cancel{% endtrans %}"
+    'Cancel': "{% trans %}Cancel{% endtrans %}",
+    'Display': "{% trans %}Display{% endtrans %}"
   },
   date: "{{ date|date('Y-m-d') }}",
   dashboardURL: "{{ path('admin_dashboard_fullscreen', dashboard_route_params)|raw }}",

--- a/src/AppBundle/Serializer/TaskNormalizer.php
+++ b/src/AppBundle/Serializer/TaskNormalizer.php
@@ -36,6 +36,14 @@ class TaskNormalizer implements NormalizerInterface, DenormalizerInterface
             $data['previous'] = $this->iriConverter->getIriFromItem($object->getPrevious());
         }
 
+        $data['group'] = null;
+        if (null !== $object->getGroup()) {
+            $data['group'] = [
+                'id' => $object->getGroup()->getId(),
+                'name' => $object->getGroup()->getName(),
+            ];
+        }
+
         return $data;
     }
 


### PR DESCRIPTION
This PR introduces **task groups**: a task may belong to a group, to apply bulk actions on it. 
For now, groups can only be drag'n'dropped to assign all tasks at once. 

A new button allows to display grouped tasks, or all tasks at once. 

The drag'n'drop management has also been simplified: linked tasks are not grouped together via a DOM element, but they are highlighted when dragged. 

![task_groups](https://user-images.githubusercontent.com/1162230/36443395-e308d1c4-1678-11e8-8a54-519c414dc3e0.gif)
