### PR TITLE
handle failed payments

### DIFF
--- a/app/config/state_machine.yml
+++ b/app/config/state_machine.yml
@@ -42,14 +42,6 @@ winzou_state_machine:
                     do: ["@coopcycle.order_manager", "capturePayment"]
                     args: ["object"]
             after:
-                after_create_create_payment:
-                    on: ["create"]
-                    do: ["@sm.callback.cascade_transition", "apply"]
-                    args: ["object.getLastPayment('cart')", "event", "'create'", "'sylius_payment'"]
-                after_create_authorize_payment:
-                    on: "create"
-                    do: ["@coopcycle.order_manager", "authorizePayment"]
-                    args: ["object"]
                 after_create_dispatch_event:
                     on: "create"
                     do: ["@coopcycle.order_manager", "dispatchOrderEvent"]
@@ -112,6 +104,10 @@ winzou_state_machine:
                 to: void
         callbacks:
             after:
+                after_create_authorize_payment:
+                    on: "create"
+                    do: ["@coopcycle.order_manager", "authorizePayment"]
+                    args: ["object.getOrder()"]
                 after_authorize_dispatch_event:
                     on: "authorize"
                     do: ["@coopcycle.order_manager", "dispatchPaymentEvent"]
@@ -120,6 +116,10 @@ winzou_state_machine:
                     on: "complete"
                     do: ["@coopcycle.order_manager", "createTransfer"]
                     args: ["object"]
+                after_fail_transfer:
+                    on: "fail"
+                    do: ["@coopcycle.order_manager", "afterPaymentFailed"]
+                    args: ["object.getOrder()"]
     stripe_transfer:
         class: AppBundle\Entity\StripeTransfer
         property_path: state

--- a/src/AppBundle/Controller/PublicController.php
+++ b/src/AppBundle/Controller/PublicController.php
@@ -51,6 +51,8 @@ class PublicController extends Controller
             $form = $this->createForm(StripePaymentType::class, $stripePayment);
 
             $form->handleRequest($request);
+
+            // TODO : handle this with orderManager
             if ($form->isSubmitted() && $form->isValid()) {
 
                 try {

--- a/src/AppBundle/Service/OrderManager.php
+++ b/src/AppBundle/Service/OrderManager.php
@@ -233,6 +233,21 @@ class OrderManager
 
     }
 
+    /**
+     * Create a fresh payment after payment failure
+     *
+     * @param OrderInterface $order
+     */
+    public function afterPaymentFailed(OrderInterface $order) {
+
+        if ($order->getTotal() === 0) {
+            return;
+        }
+
+        $payment = StripePayment::create($order);
+        $order->addPayment($payment);
+    }
+
     public function completePayment(PaymentInterface $payment)
     {
         $stateMachine = $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH);


### PR DESCRIPTION
I have to deconstruct the cascade thing.

I don't think it was possible to retry payments with this state machine, because we need to dissociate order creation and payment creation. Plus creating the order at the step before it's cleaner, we then have an unique payment URL per order, we may implement later a [forgotten cart feature](http://shopifynation.com/marketing/shopify-abandoned-cart-orders-feature/)