### PR TITLE
Improve list display for deliveries

### DIFF
--- a/assets/css/dashboard.scss
+++ b/assets/css/dashboard.scss
@@ -165,36 +165,15 @@ html, body {
   font-size: 12px;
   position: relative;
   cursor: pointer;
-  color: #fff;
   border-radius: 0;
   padding: 8px;
+
+  a {
+    color: rgb(51, 51, 51);
+  }
+
   &:last-child {
     border-radius: 0;
-  }
-  a {
-    color: #fff;
-  }
-  &--pickup {
-    background-color: lighten(#3498DB, 15%);
-  }
-  &--pickup:hover {
-    background-color: lighten(#3498DB, 5%);
-  }
-  &--dropoff {
-    cursor: grab;
-    background-color: lighten(#2ECC71, 15%);
-  }
-  &--dropoff:hover {
-    background-color: lighten(#2ECC71, 5%);
-  }
-  &--done {
-    opacity: 0.6;
-  }
-  &--failed {
-    background-color: lighten(#E74C3C, 15%);
-  }
-  &--failed:hover {
-    background-color: lighten(#E74C3C, 5%);
   }
 }
 

--- a/js/app/dashboard/components/Task.js
+++ b/js/app/dashboard/components/Task.js
@@ -60,11 +60,6 @@ class Task extends React.Component {
     const classNames = ['task__icon']
     classNames.push(assigned ? 'task__icon--left' : 'task__icon--right')
 
-    if (task.hasOwnProperty('link')) {
-      return (
-        <span className={ classNames.join(' ') }><i className="fa fa-exchange"></i></span>
-      )
-    }
   }
 
   renderTags() {
@@ -111,7 +106,7 @@ class Task extends React.Component {
 
     return (
       <span
-        style={{display: 'block'}}
+        style={{display: 'block', borderLeft: '6px solid ' + task.deliveryColor}}
         key={task['@id']}
         className={classNames.join(' ')}
         data-task-id={task['@id']}

--- a/src/AppBundle/Entity/Delivery.php
+++ b/src/AppBundle/Entity/Delivery.php
@@ -45,6 +45,8 @@ class Delivery extends TaskCollection implements TaskCollectionInterface
     const VEHICLE_BIKE = 'bike';
     const VEHICLE_CARGO_BIKE = 'cargo_bike';
 
+    const COLORS_LIST = ['#213ab2', '#b2213a', '#5221b2', '#93c63f', '#b22182', '#3ab221', '#b25221', '#2182b2', '#3ab221', '#9c21b2', '#c63f4f', '#b2217f', '#82b221', '#5421b2', '#3f93c6', '#21b252', '#c6733f'];
+
     /**
      * @Groups({"delivery"})
      */
@@ -224,5 +226,13 @@ class Delivery extends TaskCollection implements TaskCollectionInterface
         $delivery->getDropoff()->setDoneBefore($dropoffDoneBefore);
 
         return $delivery;
+    }
+
+    public function getColor()
+    {
+        if(!is_null($this->getId())) {
+            return $this::COLORS_LIST[$this->getId() % count($this::COLORS_LIST)];
+        }
+
     }
 }

--- a/src/AppBundle/Resources/views/Admin/deliveries.html.twig
+++ b/src/AppBundle/Resources/views/Admin/deliveries.html.twig
@@ -19,11 +19,10 @@
       <th>{% trans %}adminDashboard.deliveries.dueDate{% endtrans %}</th>
       <th>{% trans %}adminDashboard.deliveries.courier{% endtrans %}</th>
       <th>{% trans %}adminDashboard.deliveries.address{% endtrans %}</th>
-      <th>{% trans %}adminDashboard.deliveries.delivery{% endtrans %}</th>
     </thead>
     <tbody>
     {% for task in tasks %}
-      <tr>
+      <tr {% if task.delivery is not null %}style="border-left: 6px solid {{ task.delivery.color }};"{% endif %}>
         <td width="1%">
           {% include "AppBundle::_partials/Task/statusIcon.html.twig" %}
         </td>
@@ -47,14 +46,6 @@
         </td>
         <td>
           {{ task.address.streetAddress }}
-        </td>
-        <td width="5%" class="text-right">
-          {% if task.delivery is not null %}
-          <a href="{{ path(routes.view, { id: task.delivery.id }) }}"
-            title="{% trans with { '%id%': task.delivery.id } %}Delivery #%id%{% endtrans %}">
-            <i class="fa fa-exchange"></i>
-          </a>
-          {% endif %}
         </td>
       </tr>
     {% endfor %}

--- a/src/AppBundle/Serializer/DeliveryNormalizer.php
+++ b/src/AppBundle/Serializer/DeliveryNormalizer.php
@@ -21,11 +21,11 @@ class DeliveryNormalizer implements NormalizerInterface, DenormalizerInterface
     {
         $data =  $this->normalizer->normalize($object, $format, $context);
 
-        unset($data['items']);
+        if (isset($data['items'])) {
+            unset($data['items']);
+        }
 
-        $data['totalExcludingTax'] = $object->getTotalExcludingTax();
-        $data['totalTax'] = $object->getTotalTax();
-        $data['totalIncludingTax'] = $object->getTotalIncludingTax();
+        $data['color'] = $object->getColor();
 
         return $data;
     }

--- a/src/AppBundle/Serializer/TaskNormalizer.php
+++ b/src/AppBundle/Serializer/TaskNormalizer.php
@@ -34,6 +34,11 @@ class TaskNormalizer implements NormalizerInterface, DenormalizerInterface
             $data['previous'] = $this->iriConverter->getIriFromItem($object->getPrevious());
         }
 
+        $data['deliveryColor'] = null;
+        if (!is_null($object->getDelivery())) {
+            $data['deliveryColor'] = $object->getDelivery()->getColor();
+        }
+
         $data['group'] = null;
         if (null !== $object->getGroup()) {
 


### PR DESCRIPTION
Use colors to show clearly linked tasks (a.k.a deliveries for the moment)

<img width="329" alt="capture d ecran 2018-04-20 a 18 24 44" src="https://user-images.githubusercontent.com/4426585/39062646-766e763a-44c8-11e8-92d8-cd172c308b2d.png">

<img width="1207" alt="capture d ecran 2018-04-20 a 18 24 19" src="https://user-images.githubusercontent.com/4426585/39062649-79dadf20-44c8-11e8-9fe7-7a655c068e1d.png">
