### PR TITLE
Platform fees

### DIFF
--- a/app/DoctrineMigrations/Version20180508142437.php
+++ b/app/DoctrineMigrations/Version20180508142437.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180508142437 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE contract ADD fee_rate DOUBLE PRECISION DEFAULT NULL');
+        $this->addSql('UPDATE contract SET fee_rate = 0.00');
+        $this->addSql('ALTER TABLE contract ALTER COLUMN fee_rate SET NOT NULL');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE contract DROP fee_rate');
+    }
+}

--- a/app/DoctrineMigrations/Version20180509092646.php
+++ b/app/DoctrineMigrations/Version20180509092646.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180509092646 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('UPDATE contract SET minimum_cart_amount = minimum_cart_amount * 100');
+        $this->addSql('UPDATE contract SET flat_delivery_price = flat_delivery_price * 100');
+
+        $this->addSql('ALTER TABLE contract ALTER minimum_cart_amount TYPE INT');
+        $this->addSql('ALTER TABLE contract ALTER minimum_cart_amount DROP DEFAULT');
+        $this->addSql('ALTER TABLE contract ALTER flat_delivery_price TYPE INT');
+        $this->addSql('ALTER TABLE contract ALTER flat_delivery_price DROP DEFAULT');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE contract ALTER minimum_cart_amount TYPE DOUBLE PRECISION');
+        $this->addSql('ALTER TABLE contract ALTER minimum_cart_amount DROP DEFAULT');
+        $this->addSql('ALTER TABLE contract ALTER flat_delivery_price TYPE DOUBLE PRECISION');
+        $this->addSql('ALTER TABLE contract ALTER flat_delivery_price DROP DEFAULT');
+
+        $this->addSql('UPDATE contract SET minimum_cart_amount = minimum_cart_amount / 100');
+        $this->addSql('UPDATE contract SET flat_delivery_price = flat_delivery_price / 100');
+    }
+}

--- a/app/DoctrineMigrations/Version20180509100908.php
+++ b/app/DoctrineMigrations/Version20180509100908.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180509100908 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE contract ADD customer_amount INT DEFAULT 0 NOT NULL');
+        $this->addSql('UPDATE contract SET customer_amount = flat_delivery_price');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE contract DROP customer_amount');
+    }
+}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -26,6 +26,13 @@ services:
     tags:
       - { name: sylius.context.locale, priority: 64 }
 
+  sylius.order_processing.order_fee_processor:
+    class: AppBundle\Sylius\OrderProcessing\OrderFeeProcessor
+    arguments:
+      - "@sylius.factory.adjustment"
+    tags:
+      - { name: sylius.order_processor, priority: 64 }
+
   sylius.order_processing.order_taxes_processor:
     class: AppBundle\Sylius\OrderProcessing\OrderTaxesProcessor
     arguments:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -78,7 +78,6 @@ services:
     decorates: sylius.factory.order
     arguments:
       - "@coopcycle.sylius.factory.order.inner"
-      - "@sylius.factory.adjustment"
     public: false
 
   sylius.context.cart.restaurant:
@@ -257,7 +256,6 @@ services:
       - "@coopcycle.sylius.factory.order"
       - "@sylius.repository.product_variant"
       - "@sylius.factory.order_item"
-      - "@sylius.factory.adjustment"
       - "@sylius.order_item_quantity_modifier"
       - "@sylius.order_modifier"
     tags: [ { name: serializer.normalizer, priority: 128 } ]

--- a/features/fixtures/ORM/restaurants.yml
+++ b/features/fixtures/ORM/restaurants.yml
@@ -103,16 +103,16 @@ AppBundle\Entity\Restaurant:
 AppBundle\Entity\Contract:
   contract_1:
     restaurant: "@restaurant_1"
-    minimumCartAmount: 15
-    flatDeliveryPrice: 3.5
+    minimumCartAmount: 1500
+    flatDeliveryPrice: 350
     feeRate: 0.00
   contract_2:
     restaurant: "@restaurant_2"
-    minimumCartAmount: 15
-    flatDeliveryPrice: 3.5
+    minimumCartAmount: 1500
+    flatDeliveryPrice: 350
     feeRate: 0.00
   contract_3:
     restaurant: "@restaurant_3"
-    minimumCartAmount: 15
-    flatDeliveryPrice: 3.5
+    minimumCartAmount: 1500
+    flatDeliveryPrice: 350
     feeRate: 0.00

--- a/features/fixtures/ORM/restaurants.yml
+++ b/features/fixtures/ORM/restaurants.yml
@@ -105,11 +105,14 @@ AppBundle\Entity\Contract:
     restaurant: "@restaurant_1"
     minimumCartAmount: 15
     flatDeliveryPrice: 3.5
+    feeRate: 0.00
   contract_2:
     restaurant: "@restaurant_2"
     minimumCartAmount: 15
     flatDeliveryPrice: 3.5
+    feeRate: 0.00
   contract_3:
     restaurant: "@restaurant_3"
     minimumCartAmount: 15
     flatDeliveryPrice: 3.5
+    feeRate: 0.00

--- a/features/restaurants.feature
+++ b/features/restaurants.feature
@@ -105,7 +105,7 @@ Feature: Manage restaurants
       "openingHours":@array@,
       "availabilities":@array@,
       "minimumCartAmount":@integer@,
-      "flatDeliveryPrice":@double@
+      "flatDeliveryPrice":@integer@
     }
     """
 

--- a/src/AppBundle/Entity/Contract.php
+++ b/src/AppBundle/Entity/Contract.php
@@ -31,6 +31,13 @@ class Contract
     private $flatDeliveryPrice;
 
     /**
+     * @var float
+     * @Assert\NotBlank
+     * @Assert\Type("float")
+     */
+    private $feeRate;
+
+    /**
      * @return Restaurant
      */
     public function getRestaurant()
@@ -57,7 +64,7 @@ class Contract
     /**
      * @param float $minimumCartAmount
      */
-    public function setMinimumCartAmount(float $minimumCartAmount = null)
+    public function setMinimumCartAmount(float $minimumCartAmount)
     {
         $this->minimumCartAmount = $minimumCartAmount;
     }
@@ -73,9 +80,26 @@ class Contract
     /**
      * @param float $flatDeliveryPrice
      */
-    public function setFlatDeliveryPrice(float $flatDeliveryPrice = null)
+    public function setFlatDeliveryPrice(float $flatDeliveryPrice)
     {
         $this->flatDeliveryPrice = $flatDeliveryPrice;
     }
 
+    /**
+     * @return float
+     */
+    public function getFeeRate()
+    {
+        return $this->feeRate;
+    }
+
+    /**
+     * @param float $feeRate
+     */
+    public function setFeeRate(float $feeRate)
+    {
+        $this->feeRate = $feeRate;
+
+        return $this;
+    }
 }

--- a/src/AppBundle/Entity/Contract.php
+++ b/src/AppBundle/Entity/Contract.php
@@ -19,14 +19,14 @@ class Contract
     /**
      * @var float
      * @Assert\NotBlank
-     * @Assert\Type("float")
+     * @Assert\Type("integer")
      */
     private $minimumCartAmount;
 
     /**
      * @var float
      * @Assert\NotBlank
-     * @Assert\Type("float")
+     * @Assert\Type("integer")
      */
     private $flatDeliveryPrice;
 
@@ -54,7 +54,7 @@ class Contract
     }
 
     /**
-     * @return float
+     * @return int
      */
     public function getMinimumCartAmount()
     {
@@ -62,15 +62,15 @@ class Contract
     }
 
     /**
-     * @param float $minimumCartAmount
+     * @param int $minimumCartAmount
      */
-    public function setMinimumCartAmount(float $minimumCartAmount)
+    public function setMinimumCartAmount(int $minimumCartAmount)
     {
         $this->minimumCartAmount = $minimumCartAmount;
     }
 
     /**
-     * @return float
+     * @return int
      */
     public function getFlatDeliveryPrice()
     {
@@ -78,9 +78,9 @@ class Contract
     }
 
     /**
-     * @param float $flatDeliveryPrice
+     * @param int $flatDeliveryPrice
      */
-    public function setFlatDeliveryPrice(float $flatDeliveryPrice)
+    public function setFlatDeliveryPrice(int $flatDeliveryPrice)
     {
         $this->flatDeliveryPrice = $flatDeliveryPrice;
     }

--- a/src/AppBundle/Entity/Contract.php
+++ b/src/AppBundle/Entity/Contract.php
@@ -17,18 +17,27 @@ class Contract
     private $restaurant;
 
     /**
-     * @var float
+     * @var int
      * @Assert\NotBlank
      * @Assert\Type("integer")
      */
     private $minimumCartAmount;
 
     /**
-     * @var float
+     * @var int
+     * The amount (in cents) charged by the platform.
      * @Assert\NotBlank
      * @Assert\Type("integer")
      */
     private $flatDeliveryPrice;
+
+    /**
+     * @var int
+     * The amount (in cents) paid by the customer.
+     * @Assert\NotBlank
+     * @Assert\Type("integer")
+     */
+    private $customerAmount = 0;
 
     /**
      * @var float
@@ -99,6 +108,18 @@ class Contract
     public function setFeeRate(float $feeRate)
     {
         $this->feeRate = $feeRate;
+
+        return $this;
+    }
+
+    public function getCustomerAmount()
+    {
+        return $this->customerAmount;
+    }
+
+    public function setCustomerAmount(int $customerAmount)
+    {
+        $this->customerAmount = $customerAmount;
 
         return $this;
     }

--- a/src/AppBundle/Entity/Sylius/Order.php
+++ b/src/AppBundle/Entity/Sylius/Order.php
@@ -247,15 +247,4 @@ class Order extends BaseOrder implements OrderInterface
 
         $this->delivery = $delivery;
     }
-
-    public function getDeliveryPrice()
-    {
-        if (!is_null($this->delivery)) {
-            $deliveryAdjusment =  $this->getAdjustments()->filter(function ($adjusment) {
-                return $adjusment->getType() == 'delivery';
-            })->first();
-
-            return $deliveryAdjusment->getAmount();
-        }
-    }
 }

--- a/src/AppBundle/Entity/Sylius/Order.php
+++ b/src/AppBundle/Entity/Sylius/Order.php
@@ -95,6 +95,17 @@ class Order extends BaseOrder implements OrderInterface
         return $taxTotal;
     }
 
+    public function getFeeTotal(): int
+    {
+        $feeTotal = 0;
+
+        foreach ($this->getAdjustments(AdjustmentInterface::FEE_ADJUSTMENT) as $feeAdjustment) {
+            $feeTotal += $feeAdjustment->getAmount();
+        }
+
+        return $feeTotal;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/AppBundle/Form/ContractType.php
+++ b/src/AppBundle/Form/ContractType.php
@@ -1,22 +1,28 @@
 <?php
 
-
 namespace AppBundle\Form;
-
 
 use AppBundle\Entity\Contract;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Extension\Core\Type\PercentType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-
 
 class ContractType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('minimumCartAmount', MoneyType::class, ['label' => 'restaurant.contract.minimumCartAmount.label'])
-                ->add('flatDeliveryPrice', MoneyType::class, ['label' => 'restaurant.contract.flatDeliveryPrice.label']);
+        $builder
+            ->add('minimumCartAmount', MoneyType::class, [
+                'label' => 'restaurant.contract.minimumCartAmount.label'
+            ])
+            ->add('flatDeliveryPrice', MoneyType::class, [
+                'label' => 'restaurant.contract.flatDeliveryPrice.label'
+            ])
+            ->add('feeRate', PercentType::class, [
+                'label' => 'restaurant.contract.feeRate.label'
+            ]);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/AppBundle/Form/ContractType.php
+++ b/src/AppBundle/Form/ContractType.php
@@ -15,10 +15,12 @@ class ContractType extends AbstractType
     {
         $builder
             ->add('minimumCartAmount', MoneyType::class, [
-                'label' => 'restaurant.contract.minimumCartAmount.label'
+                'label' => 'restaurant.contract.minimumCartAmount.label',
+                'divisor' => 100,
             ])
             ->add('flatDeliveryPrice', MoneyType::class, [
-                'label' => 'restaurant.contract.flatDeliveryPrice.label'
+                'label' => 'restaurant.contract.flatDeliveryPrice.label',
+                'divisor' => 100,
             ])
             ->add('feeRate', PercentType::class, [
                 'label' => 'restaurant.contract.feeRate.label'

--- a/src/AppBundle/Form/ContractType.php
+++ b/src/AppBundle/Form/ContractType.php
@@ -22,6 +22,10 @@ class ContractType extends AbstractType
                 'label' => 'restaurant.contract.flatDeliveryPrice.label',
                 'divisor' => 100,
             ])
+            ->add('customerAmount', MoneyType::class, [
+                'label' => 'restaurant.contract.customerAmount.label',
+                'divisor' => 100,
+            ])
             ->add('feeRate', PercentType::class, [
                 'label' => 'restaurant.contract.feeRate.label'
             ]);

--- a/src/AppBundle/Resources/config/doctrine/Contract.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Contract.orm.yml
@@ -17,6 +17,11 @@ AppBundle\Entity\Contract:
         feeRate:
             type: float
             column: fee_rate
+        customerAmount:
+            type: integer
+            column: customer_amount
+            options:
+                default: 0
     oneToOne:
         restaurant:
             targetEntity: AppBundle\Entity\Restaurant

--- a/src/AppBundle/Resources/config/doctrine/Contract.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Contract.orm.yml
@@ -4,31 +4,19 @@ AppBundle\Entity\Contract:
     id:
         id:
             type: integer
-            scale: 0
-            length: null
-            unique: false
-            nullable: false
-            precision: 0
             id: true
             generator:
                 strategy: IDENTITY
     fields:
         minimumCartAmount:
             type: float
-            scale: 0
-            length: null
-            unique: false
-            nullable: false
-            precision: 0
             column: minimum_cart_amount
         flatDeliveryPrice:
             type: float
-            scale: 0
-            length: null
-            unique: false
-            nullable: false
-            precision: 0
             column: flat_delivery_price
+        feeRate:
+            type: float
+            column: fee_rate
     oneToOne:
         restaurant:
             targetEntity: AppBundle\Entity\Restaurant

--- a/src/AppBundle/Resources/config/doctrine/Contract.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Contract.orm.yml
@@ -9,10 +9,10 @@ AppBundle\Entity\Contract:
                 strategy: IDENTITY
     fields:
         minimumCartAmount:
-            type: float
+            type: integer
             column: minimum_cart_amount
         flatDeliveryPrice:
-            type: float
+            type: integer
             column: flat_delivery_price
         feeRate:
             type: float

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -184,6 +184,7 @@ restaurant.deliveryPerimeterExpression.title: Delivery perimeter
 restaurant.deliveryPerimeterExpression.help: Define the accepted perimeter for deliveries. You can chose a radius (in km) or a <a target="_blank" href="%zoneHelpUrl%">zone</a>.
 restaurant.contract.minimumCartAmount.label: Minimum cart amount
 restaurant.contract.flatDeliveryPrice.label: Fixed delivery price
+restaurant.contract.feeRate.label: Fee rate
 restaurant.contract.onlyAdmin: Only an administrator can edit contract details.
 restaurant.contract.noContract: No contract details. Please contact an administrator.
 

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -183,8 +183,12 @@ restaurant.stripe_account.title: Stripe Account
 restaurant.deliveryPerimeterExpression.title: Delivery perimeter
 restaurant.deliveryPerimeterExpression.help: Define the accepted perimeter for deliveries. You can chose a radius (in km) or a <a target="_blank" href="%zoneHelpUrl%">zone</a>.
 restaurant.contract.minimumCartAmount.label: Minimum cart amount
-restaurant.contract.flatDeliveryPrice.label: Fixed delivery price
+restaurant.contract.flatDeliveryPrice.label: Amount charged by the platform
+restaurant.contract.flatDeliveryPrice.help: This amount will not be displayed in the cart and will not increase the total amount
+restaurant.contract.customerAmount.label: Amount paid by the customer
+restaurant.contract.customerAmount.help: This amount will be displayed in the cart and will increase the total amount
 restaurant.contract.feeRate.label: Fee rate
+restaurant.contract.feeRate.help: This percentage will be retained by the platform on the total of the products
 restaurant.contract.onlyAdmin: Only an administrator can edit contract details.
 restaurant.contract.noContract: No contract details. Please contact an administrator.
 

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -183,8 +183,12 @@ restaurant.deliveryPerimeterExpression.title: Delivery perimeter
 restaurant.deliveryPerimeterExpression.help: Define the accepted perimeter for deliveries. You can chose a radius (in km) or a <a target="_blank" href="%zoneHelpUrl%">zone</a>.
 restaurant.stripe_account.title: Cuenta Stripe
 restaurant.contract.minimumCartAmount.label: Pedido mínimo
-restaurant.contract.flatDeliveryPrice.label: Precio de entrega fijo
+restaurant.contract.flatDeliveryPrice.label: Suma cargada por la plataforma
+restaurant.contract.flatDeliveryPrice.help: Esta suma no se mostrará en el carrito y no aumentará el precio total
+restaurant.contract.customerAmount.label: Suma pagada por el cliente
+restaurant.contract.customerAmount.help: Esta suma se mostrará en el carrito y aumentará el precio total
 restaurant.contract.feeRate.label: Porcentaje de comisión
+restaurant.contract.feeRate.help: Este porcentaje será retenido por la plataforma en el total de los productos
 restaurant.contract.onlyAdmin: Únicamente un administrador puede editar las condiciones de contrato.
 restaurant.contract.noContract: No existen condiciones de contrato. Por favor contacte a un administrador.
 

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -184,6 +184,7 @@ restaurant.deliveryPerimeterExpression.help: Define the accepted perimeter for d
 restaurant.stripe_account.title: Cuenta Stripe
 restaurant.contract.minimumCartAmount.label: Pedido mínimo
 restaurant.contract.flatDeliveryPrice.label: Precio de entrega fijo
+restaurant.contract.feeRate.label: Porcentaje de comisión
 restaurant.contract.onlyAdmin: Únicamente un administrador puede editar las condiciones de contrato.
 restaurant.contract.noContract: No existen condiciones de contrato. Por favor contacte a un administrador.
 

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -179,6 +179,7 @@ restaurant.contract.title: Contrat
 restaurant.stripe_account.title: Compte Stripe
 restaurant.contract.minimumCartAmount.label: Montant minimum du panier
 restaurant.contract.flatDeliveryPrice.label: Prix fixe de la course
+restaurant.contract.feeRate.label: Pourcentage de commission
 restaurant.contract.onlyAdmin: Éditer les conditions contractuelles est réservé aux administrateurs.
 restaurant.contract.noContract: Pas de conditions contractuelles sauvegardées. Veuillez contacter un administrateur.
 

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -178,8 +178,12 @@ restaurant.deliveryPerimeterExpression.help: Défini le périmètre de livraison
 restaurant.contract.title: Contrat
 restaurant.stripe_account.title: Compte Stripe
 restaurant.contract.minimumCartAmount.label: Montant minimum du panier
-restaurant.contract.flatDeliveryPrice.label: Prix fixe de la course
+restaurant.contract.flatDeliveryPrice.label: Montant facturé par la plateforme
+restaurant.contract.flatDeliveryPrice.help: Ce montant ne sera pas affiché dans le panier et n'augmentera pas le prix total
+restaurant.contract.customerAmount.label: Montant payé par le client
+restaurant.contract.customerAmount.help: Ce montant sera affiché dans le panier et augmentera le prix total
 restaurant.contract.feeRate.label: Pourcentage de commission
+restaurant.contract.feeRate.help: Ce pourcentage sera retenu par la plateforme sur le total des produits
 restaurant.contract.onlyAdmin: Éditer les conditions contractuelles est réservé aux administrateurs.
 restaurant.contract.noContract: Pas de conditions contractuelles sauvegardées. Veuillez contacter un administrateur.
 

--- a/src/AppBundle/Resources/views/Form/restaurant.html.twig
+++ b/src/AppBundle/Resources/views/Form/restaurant.html.twig
@@ -28,3 +28,17 @@
   {{ form_row(form.delete) }}
   {% endif %}
 {% endblock %}
+
+{% block money_widget %}
+  {{ parent() }}
+  {% if help is defined %}
+    <span class="help-block">{{ help|trans }}</span>
+  {% endif %}
+{% endblock %}
+
+{% block percent_widget %}
+  {{ parent() }}
+  {% if help is defined %}
+    <span class="help-block">{{ help|trans }}</span>
+  {% endif %}
+{% endblock %}

--- a/src/AppBundle/Resources/views/Restaurant/form.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/form.html.twig
@@ -198,14 +198,9 @@
   {% endif %}
 
   {% if form.contract is defined %}
-    <div class="row margin-bottom-md">
-      <div class="col-md-6">
-        {{ form_row(form.contract.minimumCartAmount) }}
-      </div>
-      <div class="col-md-6">
-        {{ form_row(form.contract.flatDeliveryPrice) }}
-      </div>
-    </div>
+    {{ form_row(form.contract.minimumCartAmount) }}
+    {{ form_row(form.contract.flatDeliveryPrice) }}
+    {{ form_row(form.contract.feeRate) }}
   {% else %}
     {% if restaurant.id is not null %}
     <div class="row margin-bottom-md">
@@ -216,6 +211,7 @@
           </div>
           <p>{% trans %}restaurant.contract.minimumCartAmount.label{% endtrans %}: {{ restaurant.contract.minimumCartAmount }}€</p>
           <p>{% trans %}restaurant.contract.flatDeliveryPrice.label{% endtrans %}: {{ restaurant.contract.flatDeliveryPrice }}€</p>
+          <p>{% trans %}restaurant.contract.feeRate.label{% endtrans %}: {{ restaurant.contract.feeRate }}%</p>
         </div>
       {% else %}
         <div class="col-md-12">

--- a/src/AppBundle/Resources/views/Restaurant/form.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/form.html.twig
@@ -199,8 +199,9 @@
 
   {% if form.contract is defined %}
     {{ form_row(form.contract.minimumCartAmount) }}
-    {{ form_row(form.contract.flatDeliveryPrice) }}
-    {{ form_row(form.contract.feeRate) }}
+    {{ form_row(form.contract.flatDeliveryPrice, { help: 'restaurant.contract.flatDeliveryPrice.help' }) }}
+    {{ form_row(form.contract.customerAmount, { help: 'restaurant.contract.customerAmount.help' }) }}
+    {{ form_row(form.contract.feeRate, { help: 'restaurant.contract.feeRate.help' }) }}
   {% else %}
     {% if restaurant.id is not null %}
     <div class="row margin-bottom-md">
@@ -210,6 +211,7 @@
             {% trans %}restaurant.contract.onlyAdmin{% endtrans %}
           </div>
           <p>{% trans %}restaurant.contract.minimumCartAmount.label{% endtrans %}: {{ restaurant.contract.minimumCartAmount }}€</p>
+          <p>{% trans %}restaurant.contract.customerAmount.label{% endtrans %}: {{ restaurant.contract.customerAmount }}€</p>
           <p>{% trans %}restaurant.contract.flatDeliveryPrice.label{% endtrans %}: {{ restaurant.contract.flatDeliveryPrice }}€</p>
           <p>{% trans %}restaurant.contract.feeRate.label{% endtrans %}: {{ restaurant.contract.feeRate }}%</p>
         </div>

--- a/src/AppBundle/Serializer/JsonLd/OrderNormalizer.php
+++ b/src/AppBundle/Serializer/JsonLd/OrderNormalizer.php
@@ -5,10 +5,8 @@ namespace AppBundle\Serializer\JsonLd;
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer;
 use AppBundle\Entity\Sylius\Order;
-use AppBundle\Sylius\Order\AdjustmentInterface;
 use AppBundle\Sylius\Order\OrderFactory;
 use AppBundle\Entity\Sylius\ProductVariantRepository;
-use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
 use Sylius\Component\Order\Modifier\OrderItemQuantityModifierInterface;
 use Sylius\Component\Order\Modifier\OrderModifierInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
@@ -22,7 +20,6 @@ class OrderNormalizer implements NormalizerInterface, DenormalizerInterface
     private $orderFactory;
     private $productVariantRepository;
     private $orderItemFactory;
-    private $adjustmentFactory;
     private $orderItemQuantityModifier;
     private $orderModifier;
 
@@ -32,7 +29,6 @@ class OrderNormalizer implements NormalizerInterface, DenormalizerInterface
         OrderFactory $orderFactory,
         ProductVariantRepository $productVariantRepository,
         FactoryInterface $orderItemFactory,
-        AdjustmentFactoryInterface $adjustmentFactory,
         OrderItemQuantityModifierInterface $orderItemQuantityModifier,
         OrderModifierInterface $orderModifier)
     {
@@ -41,7 +37,6 @@ class OrderNormalizer implements NormalizerInterface, DenormalizerInterface
         $this->orderFactory = $orderFactory;
         $this->productVariantRepository = $productVariantRepository;
         $this->orderItemFactory = $orderItemFactory;
-        $this->adjustmentFactory = $adjustmentFactory;
         $this->orderItemQuantityModifier = $orderItemQuantityModifier;
         $this->orderModifier = $orderModifier;
     }
@@ -82,14 +77,6 @@ class OrderNormalizer implements NormalizerInterface, DenormalizerInterface
             return $orderItem;
 
         }, $data['items']);
-
-        $adjustment = $this->adjustmentFactory->createWithData(
-            AdjustmentInterface::DELIVERY_ADJUSTMENT,
-            'Livraison',
-            $order->getRestaurant()->getFlatDeliveryPrice(),
-            $neutral = false
-        );
-        $order->addAdjustment($adjustment);
 
         $order->clearItems();
         foreach ($orderItems as $orderItem) {

--- a/src/AppBundle/Serializer/JsonLd/OrderNormalizer.php
+++ b/src/AppBundle/Serializer/JsonLd/OrderNormalizer.php
@@ -86,7 +86,7 @@ class OrderNormalizer implements NormalizerInterface, DenormalizerInterface
         $adjustment = $this->adjustmentFactory->createWithData(
             AdjustmentInterface::DELIVERY_ADJUSTMENT,
             'Livraison',
-            (int) ($order->getRestaurant()->getFlatDeliveryPrice() * 100),
+            $order->getRestaurant()->getFlatDeliveryPrice(),
             $neutral = false
         );
         $order->addAdjustment($adjustment);

--- a/src/AppBundle/Sylius/Order/AdjustmentInterface.php
+++ b/src/AppBundle/Sylius/Order/AdjustmentInterface.php
@@ -9,4 +9,5 @@ interface AdjustmentInterface extends BaseAdjustmentInterface
     public const TAX_ADJUSTMENT = 'tax';
     public const DELIVERY_ADJUSTMENT = 'delivery';
     public const MENU_ITEM_MODIFIER_ADJUSTMENT = 'menu_item_modifier';
+    public const FEE_ADJUSTMENT = 'fee';
 }

--- a/src/AppBundle/Sylius/Order/OrderFactory.php
+++ b/src/AppBundle/Sylius/Order/OrderFactory.php
@@ -46,7 +46,7 @@ class OrderFactory implements FactoryInterface
         $adjustment = $this->adjustmentFactory->createWithData(
             AdjustmentInterface::DELIVERY_ADJUSTMENT,
             'Livraison',
-            (int) ($restaurant->getFlatDeliveryPrice() * 100),
+            $restaurant->getFlatDeliveryPrice(),
             $neutral = false
         );
         $order->addAdjustment($adjustment);

--- a/src/AppBundle/Sylius/Order/OrderFactory.php
+++ b/src/AppBundle/Sylius/Order/OrderFactory.php
@@ -4,8 +4,6 @@ namespace AppBundle\Sylius\Order;
 
 use AppBundle\Entity\Restaurant;
 use AppBundle\Service\SettingsManager;
-use AppBundle\Sylius\Order\AdjustmentInterface;
-use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
 use Sylius\Component\Taxation\Calculator\CalculatorInterface;
@@ -17,17 +15,12 @@ class OrderFactory implements FactoryInterface
      */
     private $factory;
 
-    private $adjustmentFactory;
-
     /**
      * @param FactoryInterface $factory
      */
-    public function __construct(
-        FactoryInterface $factory,
-        AdjustmentFactoryInterface $adjustmentFactory)
+    public function __construct(FactoryInterface $factory)
     {
         $this->factory = $factory;
-        $this->adjustmentFactory = $adjustmentFactory;
     }
 
     /**
@@ -42,14 +35,6 @@ class OrderFactory implements FactoryInterface
     {
         $order = $this->createNew();
         $order->setRestaurant($restaurant);
-
-        $adjustment = $this->adjustmentFactory->createWithData(
-            AdjustmentInterface::DELIVERY_ADJUSTMENT,
-            'Livraison',
-            $restaurant->getFlatDeliveryPrice(),
-            $neutral = false
-        );
-        $order->addAdjustment($adjustment);
 
         return $order;
     }

--- a/src/AppBundle/Sylius/Order/OrderInterface.php
+++ b/src/AppBundle/Sylius/Order/OrderInterface.php
@@ -20,6 +20,11 @@ interface OrderInterface extends BaseOrderInterface, PaymentsSubjectInterface
     public function getTaxTotal(): int;
 
     /**
+     * @return int
+     */
+    public function getFeeTotal(): int;
+
+    /**
      * @return Restaurant
      */
     public function getRestaurant(): ?Restaurant;

--- a/src/AppBundle/Sylius/OrderProcessing/OrderFeeProcessor.php
+++ b/src/AppBundle/Sylius/OrderProcessing/OrderFeeProcessor.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace AppBundle\Sylius\OrderProcessing;
+
+use AppBundle\Sylius\Order\AdjustmentInterface;
+use AppBundle\Sylius\Order\OrderInterface;
+use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
+use Sylius\Component\Order\Model\OrderInterface as BaseOrderInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Webmozart\Assert\Assert;
+
+final class OrderFeeProcessor implements OrderProcessorInterface
+{
+    private $adjustmentFactory;
+
+    public function __construct(AdjustmentFactoryInterface $adjustmentFactory)
+    {
+        $this->adjustmentFactory = $adjustmentFactory;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(BaseOrderInterface $order): void
+    {
+        Assert::isInstanceOf($order, OrderInterface::class);
+
+        $restaurant = $order->getRestaurant();
+
+        if (null === $restaurant) {
+            return;
+        }
+
+        $order->removeAdjustments(AdjustmentInterface::FEE_ADJUSTMENT);
+
+        $feeRate = $restaurant->getContract()->getFeeRate();
+
+        $feeAdjustment = $this->adjustmentFactory->createWithData(
+            AdjustmentInterface::FEE_ADJUSTMENT,
+            'CoopCycle fees',
+            (int) $order->getItemsTotal() * $feeRate,
+            $neutral = true
+        );
+
+        $order->addAdjustment($feeAdjustment);
+    }
+}

--- a/src/AppBundle/Sylius/OrderProcessing/OrderFeeProcessor.php
+++ b/src/AppBundle/Sylius/OrderProcessing/OrderFeeProcessor.php
@@ -31,17 +31,27 @@ final class OrderFeeProcessor implements OrderProcessorInterface
             return;
         }
 
+        $order->removeAdjustments(AdjustmentInterface::DELIVERY_ADJUSTMENT);
         $order->removeAdjustments(AdjustmentInterface::FEE_ADJUSTMENT);
 
         $feeRate = $restaurant->getContract()->getFeeRate();
+        $customerAmount = $restaurant->getContract()->getCustomerAmount();
+        $businessAmount = $restaurant->getContract()->getFlatDeliveryPrice();
 
         $feeAdjustment = $this->adjustmentFactory->createWithData(
             AdjustmentInterface::FEE_ADJUSTMENT,
             'CoopCycle fees',
-            (int) $order->getItemsTotal() * $feeRate,
+            (int) (($order->getItemsTotal() * $feeRate) + $businessAmount),
             $neutral = true
         );
-
         $order->addAdjustment($feeAdjustment);
+
+        $deliveryAdjustment = $this->adjustmentFactory->createWithData(
+            AdjustmentInterface::DELIVERY_ADJUSTMENT,
+            'Livraison',
+            $customerAmount,
+            $neutral = false
+        );
+        $order->addAdjustment($deliveryAdjustment);
     }
 }

--- a/src/AppBundle/Validator/Constraints/OrderValidator.php
+++ b/src/AppBundle/Validator/Constraints/OrderValidator.php
@@ -60,7 +60,7 @@ class OrderValidator extends ConstraintValidator
         }
 
 
-        $minimumAmount = (int) ($restaurant->getMinimumCartAmount() * 100);
+        $minimumAmount = $restaurant->getMinimumCartAmount();
         $itemsTotal = $order->getItemsTotal();
 
         if ($itemsTotal < $minimumAmount) {

--- a/tests/AppBundle/StripeTrait.php
+++ b/tests/AppBundle/StripeTrait.php
@@ -47,7 +47,22 @@ trait StripeTrait
         Stripe::setAccountId($this->origAccountId);
     }
 
-    private function shouldSendStripeRequest($method, $path, array $params = [], $headers = null, $hasFile = false)
+    protected function shouldNotSendStripeRequest()
+    {
+        ApiRequestor::setHttpClient($this->stripeHttpClient->reveal());
+
+        $this->stripeHttpClient
+            ->request(
+                Argument::type('string'),
+                Argument::type('string'),
+                Argument::type('array'),
+                Argument::type('array'),
+                Argument::type('bool')
+            )
+            ->shouldNotBeCalled();
+    }
+
+    protected function shouldSendStripeRequest($method, $path, array $params = [], $headers = null, $hasFile = false)
     {
         ApiRequestor::setHttpClient($this->stripeHttpClient->reveal());
 

--- a/tests/AppBundle/Sylius/OrderProcessing/OrderFeeProcessorTest.php
+++ b/tests/AppBundle/Sylius/OrderProcessing/OrderFeeProcessorTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\AppBundle\Sylius\OrderProcessing;
+
+use AppBundle\Entity\Contract;
+use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\Sylius\Order;
+use AppBundle\Sylius\Order\AdjustmentInterface;
+use AppBundle\Sylius\OrderProcessing\OrderFeeProcessor;
+use Prophecy\Argument;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Model\OrderItemInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class OrderFeeProcessorTest extends KernelTestCase
+{
+    private $adjustmentFactory;
+    private $orderFeeProcessor;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        self::bootKernel();
+
+        $this->adjustmentFactory = static::$kernel->getContainer()->get('sylius.factory.adjustment');
+
+        $this->orderFeeProcessor = new OrderFeeProcessor($this->adjustmentFactory);
+    }
+
+    private static function createContract($flatDeliveryPrice, $feeRate)
+    {
+        $contract = new Contract();
+        $contract->setFlatDeliveryPrice($flatDeliveryPrice);
+        $contract->setFeeRate($feeRate);
+
+        return $contract;
+    }
+
+    private function createOrderItem($total)
+    {
+        $orderItem = $this->prophesize(OrderItemInterface::class);
+        $orderItem
+            ->getTotal()
+            ->willReturn($total);
+
+        $orderItem
+            ->setOrder(Argument::type(OrderInterface::class))
+            ->shouldBeCalled();
+
+        return $orderItem->reveal();
+    }
+
+    public function testOrderWithoutRestaurant()
+    {
+        $order = new Order();
+        $order->addItem($this->createOrderItem(100));
+
+        $this->orderFeeProcessor->process($order);
+
+        $adjustments = $order->getAdjustments(AdjustmentInterface::FEE_ADJUSTMENT);
+
+        $this->assertCount(0, $adjustments);
+        $this->assertEquals(0, $order->getFeeTotal());
+    }
+
+    public function testOrderWithoutRestaurantFees()
+    {
+        $contract = self::createContract(5.00, 0.00);
+
+        $restaurant = new Restaurant();
+        $restaurant->setContract($contract);
+
+        $order = new Order();
+        $order->setRestaurant($restaurant);
+        $order->addItem($this->createOrderItem(100));
+
+        $this->orderFeeProcessor->process($order);
+
+        $adjustments = $order->getAdjustments(AdjustmentInterface::FEE_ADJUSTMENT);
+
+        $this->assertCount(1, $adjustments);
+        $this->assertEquals(0, $order->getFeeTotal());
+    }
+
+    public function testOrderWithRestaurantFees()
+    {
+        $contract = self::createContract(5.00, 0.25);
+
+        $restaurant = new Restaurant();
+        $restaurant->setContract($contract);
+
+        $order = new Order();
+        $order->setRestaurant($restaurant);
+        $order->addItem($this->createOrderItem(100));
+
+        // Add a non-neutral adjustment to make sure fees are calculated on the items total
+        $adjustment = $this->adjustmentFactory->createWithData(
+            'foo',
+            'Foo',
+            350,
+            $neutral = false
+        );
+        $order->addAdjustment($adjustment);
+
+        $this->orderFeeProcessor->process($order);
+
+        $adjustments = $order->getAdjustments(AdjustmentInterface::FEE_ADJUSTMENT);
+
+        $this->assertCount(1, $adjustments);
+        $this->assertEquals(25, $order->getFeeTotal());
+    }
+}

--- a/tests/AppBundle/Sylius/OrderProcessing/OrderFeeProcessorTest.php
+++ b/tests/AppBundle/Sylius/OrderProcessing/OrderFeeProcessorTest.php
@@ -66,7 +66,7 @@ class OrderFeeProcessorTest extends KernelTestCase
 
     public function testOrderWithoutRestaurantFees()
     {
-        $contract = self::createContract(5.00, 0.00);
+        $contract = self::createContract(500, 0.00);
 
         $restaurant = new Restaurant();
         $restaurant->setContract($contract);
@@ -85,7 +85,7 @@ class OrderFeeProcessorTest extends KernelTestCase
 
     public function testOrderWithRestaurantFees()
     {
-        $contract = self::createContract(5.00, 0.25);
+        $contract = self::createContract(500, 0.25);
 
         $restaurant = new Restaurant();
         $restaurant->setContract($contract);

--- a/tests/AppBundle/Validator/OrderValidatorTest.php
+++ b/tests/AppBundle/Validator/OrderValidatorTest.php
@@ -167,7 +167,7 @@ class OrderValidatorTest extends ConstraintValidatorTestCase
 
         $contract = new Contract();
         $contract->setMinimumCartAmount(0);
-        $contract->setFlatDeliveryPrice(10);
+        $contract->setFlatDeliveryPrice(1000);
 
         $restaurant = new Restaurant();
         $restaurant->setMaxDistanceExpression('distance < 3000');
@@ -231,7 +231,7 @@ class OrderValidatorTest extends ConstraintValidatorTestCase
         $restaurant = $this->createRestaurantProphecy(
             $restaurantAddress->reveal(),
             $shippingAddress->reveal(),
-            $minimumCartAmount = 20,
+            $minimumCartAmount = 2000,
             $maxDistanceExpression = 'distance < 3000',
             $canDeliver = true
         );


### PR DESCRIPTION
Administrators can now specify an amount that will be charged by the platform, independently from the amount that will be charge to the customer. 
This allows "offering" the delivery to the customer, while still charging something to the business. 

Also, you can now specify a percentage fee that will be calculated on the items total. 

Finally, the platform fees are now stored inside the order using an adjustment. 