### PR TITLE
Leverage Sylius for product options & menus

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -20,6 +20,7 @@ class AppKernel extends Kernel
             new Sylius\Bundle\MoneyBundle\SyliusMoneyBundle(),
             new Sylius\Bundle\OrderBundle\SyliusOrderBundle(),
             new Sylius\Bundle\ProductBundle\SyliusProductBundle(),
+            new Sylius\Bundle\TaxonomyBundle\SyliusTaxonomyBundle(),
             // Sylius bundles need to be registered before DoctrineBundle
             new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),

--- a/app/DoctrineMigrations/Version20180509130706.php
+++ b/app/DoctrineMigrations/Version20180509130706.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180509130706 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE TABLE restaurant_product (restaurant_id INT NOT NULL, product_id INT NOT NULL, PRIMARY KEY(restaurant_id, product_id))');
+        $this->addSql('CREATE INDEX IDX_190158D8B1E7706E ON restaurant_product (restaurant_id)');
+        $this->addSql('CREATE INDEX IDX_190158D84584665A ON restaurant_product (product_id)');
+        $this->addSql('ALTER TABLE restaurant_product ADD CONSTRAINT FK_190158D8B1E7706E FOREIGN KEY (restaurant_id) REFERENCES restaurant (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE restaurant_product ADD CONSTRAINT FK_190158D84584665A FOREIGN KEY (product_id) REFERENCES sylius_product (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        $stmt = [];
+        $stmt['restaurants'] =
+            $this->connection->prepare('SELECT id, menu_id FROM restaurant');
+        $stmt['menu_sections'] =
+            $this->connection->prepare('SELECT id FROM menu_section WHERE menu_id = :menu_id');
+        $stmt['menu_items'] =
+            $this->connection->prepare('SELECT id FROM menu_item WHERE parent_id = :parent_id');
+        $stmt['products'] =
+            $this->connection->prepare('SELECT id FROM sylius_product WHERE code = :code');
+
+        $stmt['restaurants']->execute();
+        while ($restaurant = $stmt['restaurants']->fetch()) {
+
+            $stmt['menu_sections']->bindParam('menu_id', $restaurant['menu_id']);
+            $stmt['menu_sections']->execute();
+
+            while ($menuSection = $stmt['menu_sections']->fetch()) {
+
+                $stmt['menu_items']->bindParam('parent_id', $menuSection['id']);
+                $stmt['menu_items']->execute();
+
+                while ($menuItem = $stmt['menu_items']->fetch()) {
+
+                    $productCode = sprintf('CPCCL-FDTCH-%d', $menuItem['id']);
+
+                    $stmt['products']->bindParam('code', $productCode);
+                    $stmt['products']->execute();
+
+                    while ($product = $stmt['products']->fetch()) {
+                        $this->addSql('INSERT INTO restaurant_product (restaurant_id, product_id) VALUES (:restaurant_id, :product_id)', [
+                            'restaurant_id' => $restaurant['id'],
+                            'product_id' => $product['id']
+                        ]);
+                    }
+                }
+            }
+        }
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('DROP TABLE restaurant_product');
+    }
+}

--- a/app/DoctrineMigrations/Version20180510114932.php
+++ b/app/DoctrineMigrations/Version20180510114932.php
@@ -1,0 +1,187 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180510114932 extends AbstractMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    private $locale;
+    private $productOptionByCodeStmt;
+
+    private function getProductOptionStrategy($calculusStrategy)
+    {
+        switch ($calculusStrategy) {
+            case 'FREE':
+                return 'free';
+            case 'ADD_MENUITEM_PRICE':
+                return 'option';
+            case 'ADD_MODIFIER_PRICE':
+                return 'option_value';
+        }
+    }
+
+    private function insertOrUpdateProductOption($code, $name, $strategy, $price)
+    {
+        $this->productOptionByCodeStmt->bindParam('code', $code);
+        $this->productOptionByCodeStmt->execute();
+
+        if ($this->productOptionByCodeStmt->rowCount() === 0) {
+            $this->addSql('INSERT INTO sylius_product_option (code, position, strategy, price, created_at, updated_at) VALUES (:code, 1, :strategy, :price, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)', [
+                    'code' => $code,
+                    'strategy' => $strategy,
+                    'price' => $price
+                ]);
+            $this->addSql('INSERT INTO sylius_product_option_translation (translatable_id, name, locale) SELECT currval(\'sylius_product_option_id_seq\'), :name, :locale', [
+                    'name' => $name,
+                    'locale' => $this->locale,
+                ]);
+        } else {
+            $this->addSql('UPDATE sylius_product_option SET strategy = :strategy, price = :price WHERE code = :code', [
+                'code' => $code,
+                'strategy' => $strategy,
+                'price' => $price
+            ]);
+        }
+    }
+
+    private function insertOrUpdateProductOptionValue($optionCode, $code, $name, $price)
+    {
+        $this->productOptionValueByCodeStmt->bindParam('code', $code);
+        $this->productOptionValueByCodeStmt->execute();
+
+        if ($this->productOptionValueByCodeStmt->rowCount() === 0) {
+            $this->addSql('INSERT INTO sylius_product_option_value (option_id, code, price) SELECT id, :code, :price FROM sylius_product_option WHERE code = :option_code', [
+                    'option_code' => $optionCode,
+                    'code' => $code,
+                    'price' => $price
+                ]);
+            $this->addSql('INSERT INTO sylius_product_option_value_translation (translatable_id, value, locale) SELECT currval(\'sylius_product_option_value_id_seq\'), :name, :locale', [
+                    'name' => $name,
+                    'locale' => $this->locale,
+                ]);
+        } else {
+            $this->addSql('UPDATE sylius_product_option_value SET price = :price WHERE code = :code', [
+                'code' => $code,
+                'price' => $price
+            ]);
+        }
+    }
+
+    private function findRestaurantByMenuItem($menuItemId)
+    {
+        $this->restaurantByMenuItemStmt->bindParam('menu_item_id', $menuItemId);
+        $this->restaurantByMenuItemStmt->execute();
+
+        return $this->restaurantByMenuItemStmt->fetch();
+    }
+
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE sylius_product_option ADD strategy VARCHAR(255) DEFAULT \'free\' NOT NULL');
+        $this->addSql('ALTER TABLE sylius_product_option ADD price INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE sylius_product_option_value ADD price INT DEFAULT NULL');
+        $this->addSql('CREATE TABLE restaurant_product_option (restaurant_id INT NOT NULL, option_id INT NOT NULL, PRIMARY KEY(restaurant_id, option_id))');
+        $this->addSql('CREATE INDEX IDX_C713F7D5B1E7706E ON restaurant_product_option (restaurant_id)');
+        $this->addSql('CREATE INDEX IDX_C713F7D5A7C41D6F ON restaurant_product_option (option_id)');
+        $this->addSql('ALTER TABLE restaurant_product_option ADD CONSTRAINT FK_C713F7D5B1E7706E FOREIGN KEY (restaurant_id) REFERENCES restaurant (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE restaurant_product_option ADD CONSTRAINT FK_C713F7D5A7C41D6F FOREIGN KEY (option_id) REFERENCES sylius_product_option (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        $stmt = [];
+        $stmt['menu_item'] =
+            $this->connection->prepare('SELECT * FROM menu_item');
+        $stmt['menu_item_modifier'] =
+            $this->connection->prepare('SELECT * FROM menu_item_modifier WHERE menu_item_id = :menu_item_id');
+        $stmt['modifier'] =
+            $this->connection->prepare('SELECT * FROM modifier WHERE menu_item_modifier_id = :menu_item_modifier_id');
+
+        $this->productOptionByCodeStmt =
+            $this->connection->prepare('SELECT * FROM sylius_product_option WHERE code = :code');
+        $this->productOptionValueByCodeStmt =
+            $this->connection->prepare('SELECT * FROM sylius_product_option_value WHERE code = :code');
+        $this->restaurantByMenuItemStmt =
+            $this->connection->prepare('SELECT restaurant.id FROM menu_item JOIN menu_section ON menu_item.parent_id = menu_section.id JOIN menu ON menu.id = menu_section.menu_id JOIN restaurant ON restaurant.menu_id = menu.id WHERE menu_item.id = :menu_item_id');
+
+        $this->locale = $this->container->getParameter('coopcycle.locale');
+
+        $stmt['menu_item']->execute();
+        while ($menuItem = $stmt['menu_item']->fetch()) {
+
+            $stmt['menu_item_modifier']->bindParam('menu_item_id', $menuItem['id']);
+            $stmt['menu_item_modifier']->execute();
+
+            $restaurant = $this->findRestaurantByMenuItem($menuItem['id']);
+
+            if (!$restaurant) {
+                continue;
+            }
+
+            // A MenuItemModifier is actually a ProductOption
+            while ($menuItemModifier = $stmt['menu_item_modifier']->fetch()) {
+
+                $stmt['modifier']->bindParam('menu_item_modifier_id', $menuItemModifier['id']);
+                $stmt['modifier']->execute();
+
+                $productOptionCode = sprintf('CPCCL-FDTCH-%d-OPT-%d', $menuItem['id'], $menuItemModifier['id']);
+                $productOptionName = $menuItemModifier['name'];
+                $productOptionStrategy = $this->getProductOptionStrategy($menuItemModifier['calculus_strategy']);
+                $productOptionPrice = null;
+                if ($menuItemModifier['calculus_strategy'] === 'ADD_MENUITEM_PRICE') {
+                    $productOptionPrice = (int) $menuItemModifier['price'] * 100;
+                }
+
+                $this->insertOrUpdateProductOption(
+                    $productOptionCode,
+                    $productOptionName,
+                    $productOptionStrategy,
+                    $productOptionPrice
+                );
+
+                $this->addSql('INSERT INTO restaurant_product_option (restaurant_id, option_id) SELECT :restaurant_id, id FROM sylius_product_option WHERE code = :code', [
+                    'restaurant_id' => $restaurant['id'],
+                    'code' => $productOptionCode
+                ]);
+
+                // A Modifier is actually a ProductOptionValue
+                while ($modifier = $stmt['modifier']->fetch()) {
+
+                    $productOptionValueCode = sprintf('%s-%d', $productOptionCode, $modifier['id']);
+                    $productOptionValueName = $modifier['name'];
+                    $productOptionValuePrice = null;
+                    if ($menuItemModifier['calculus_strategy'] === 'ADD_MODIFIER_PRICE') {
+                        $productOptionValuePrice = (int) $modifier['price'] * 100;
+                    }
+
+                    $this->insertOrUpdateProductOptionValue(
+                        $productOptionCode,
+                        $productOptionValueCode,
+                        $productOptionValueName,
+                        $productOptionValuePrice
+                    );
+                }
+            }
+        }
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE sylius_product_option DROP strategy');
+        $this->addSql('ALTER TABLE sylius_product_option DROP price');
+        $this->addSql('ALTER TABLE sylius_product_option_value DROP price');
+        $this->addSql('DROP TABLE restaurant_product_option');
+    }
+}

--- a/app/DoctrineMigrations/Version20180510150318.php
+++ b/app/DoctrineMigrations/Version20180510150318.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180510150318 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE TABLE sylius_taxon (id SERIAL NOT NULL, tree_root INT DEFAULT NULL, parent_id INT DEFAULT NULL, code VARCHAR(255) NOT NULL, tree_left INT NOT NULL, tree_right INT NOT NULL, tree_level INT NOT NULL, position INT NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_CFD811CA77153098 ON sylius_taxon (code)');
+        $this->addSql('CREATE INDEX IDX_CFD811CAA977936C ON sylius_taxon (tree_root)');
+        $this->addSql('CREATE INDEX IDX_CFD811CA727ACA70 ON sylius_taxon (parent_id)');
+        $this->addSql('CREATE TABLE sylius_taxon_translation (id SERIAL NOT NULL, translatable_id INT NOT NULL, name VARCHAR(255) NOT NULL, slug VARCHAR(255) NOT NULL, description TEXT DEFAULT NULL, locale VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_1487DFCF2C2AC5D3 ON sylius_taxon_translation (translatable_id)');
+        $this->addSql('CREATE UNIQUE INDEX slug_uidx ON sylius_taxon_translation (locale, slug)');
+        $this->addSql('CREATE UNIQUE INDEX sylius_taxon_translation_uniq_trans ON sylius_taxon_translation (translatable_id, locale)');
+        $this->addSql('ALTER TABLE sylius_taxon ADD CONSTRAINT FK_CFD811CAA977936C FOREIGN KEY (tree_root) REFERENCES sylius_taxon (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE sylius_taxon ADD CONSTRAINT FK_CFD811CA727ACA70 FOREIGN KEY (parent_id) REFERENCES sylius_taxon (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE sylius_taxon_translation ADD CONSTRAINT FK_1487DFCF2C2AC5D3 FOREIGN KEY (translatable_id) REFERENCES sylius_taxon (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE sylius_taxon DROP CONSTRAINT FK_CFD811CAA977936C');
+        $this->addSql('ALTER TABLE sylius_taxon DROP CONSTRAINT FK_CFD811CA727ACA70');
+        $this->addSql('ALTER TABLE sylius_taxon_translation DROP CONSTRAINT FK_1487DFCF2C2AC5D3');
+        $this->addSql('DROP TABLE sylius_taxon');
+        $this->addSql('DROP TABLE sylius_taxon_translation');
+    }
+}

--- a/app/DoctrineMigrations/Version20180510150849.php
+++ b/app/DoctrineMigrations/Version20180510150849.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180510150849 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE TABLE restaurant_taxon (restaurant_id INT NOT NULL, taxon_id INT NOT NULL, PRIMARY KEY(restaurant_id, taxon_id))');
+        $this->addSql('CREATE INDEX IDX_117A907AB1E7706E ON restaurant_taxon (restaurant_id)');
+        $this->addSql('CREATE INDEX IDX_117A907ADE13F470 ON restaurant_taxon (taxon_id)');
+        $this->addSql('ALTER TABLE restaurant_taxon ADD CONSTRAINT FK_117A907AB1E7706E FOREIGN KEY (restaurant_id) REFERENCES restaurant (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE restaurant_taxon ADD CONSTRAINT FK_117A907ADE13F470 FOREIGN KEY (taxon_id) REFERENCES sylius_taxon (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('DROP TABLE restaurant_taxon');
+    }
+}

--- a/app/DoctrineMigrations/Version20180511084515.php
+++ b/app/DoctrineMigrations/Version20180511084515.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180511084515 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE TABLE sylius_product_taxon (id SERIAL NOT NULL, product_id INT NOT NULL, taxon_id INT NOT NULL, position INT NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_169C6CD94584665A ON sylius_product_taxon (product_id)');
+        $this->addSql('CREATE INDEX IDX_169C6CD9DE13F470 ON sylius_product_taxon (taxon_id)');
+        $this->addSql('CREATE UNIQUE INDEX sylius_product_taxon_unique ON sylius_product_taxon (product_id, taxon_id)');
+        $this->addSql('ALTER TABLE sylius_product_taxon ADD CONSTRAINT FK_169C6CD94584665A FOREIGN KEY (product_id) REFERENCES sylius_product (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE sylius_product_taxon ADD CONSTRAINT FK_169C6CD9DE13F470 FOREIGN KEY (taxon_id) REFERENCES sylius_taxon (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('DROP TABLE sylius_product_taxon');
+    }
+}

--- a/app/DoctrineMigrations/Version20180513153919.php
+++ b/app/DoctrineMigrations/Version20180513153919.php
@@ -1,0 +1,175 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Sylius\Component\Product\Generator\CartesianSetBuilder;
+
+/**
+ * This crazy migration creates all the ProductVariant with all the ProductOptionValue permutations.
+ */
+class Version20180513153919 extends AbstractMigration
+{
+    private $setBuilder;
+
+    private function associateProductAndOption($productCode, $productOptionCode)
+    {
+        $this->productOptionsAssociationStmt->bindParam('product_code', $productCode);
+        $this->productOptionsAssociationStmt->bindParam('option_code', $productOptionCode);
+        $this->productOptionsAssociationStmt->execute();
+
+        if ($this->productOptionsAssociationStmt->rowCount() === 0) {
+            $this->addSql('INSERT INTO sylius_product_options (product_id, option_id) SELECT sylius_product.id, sylius_product_option.id FROM sylius_product, sylius_product_option WHERE sylius_product.code = :product_code AND sylius_product_option.code = :option_code', [
+                'product_code' => $productCode,
+                'option_code' => $productOptionCode,
+            ]);
+        }
+    }
+
+    private function createVariant($productCode, $modifierMap, $permutation, $taxCategoryId, $price)
+    {
+        $modifiersIds = [];
+        if (!is_array($permutation)) {
+            $modifierId = $modifierMap[$permutation];
+            $modifiersIds[] = $modifierId;
+        } else {
+            foreach ($permutation as $code) {
+                $modifierId = $modifierMap[$code];
+                $modifiersIds[] = $modifierId;
+            }
+            sort($modifiersIds);
+        }
+
+        $productVariantCode = sprintf('%s-MOD-%s', $productCode, implode('-', $modifiersIds));
+
+        $this->productVariantStmt->bindParam('code', $productVariantCode);
+        $this->productVariantStmt->execute();
+
+        if ($this->productVariantStmt->rowCount() === 0) {
+            $this->addSql('INSERT INTO sylius_product_variant (product_id, code, created_at, updated_at, position, tax_category_id, price) SELECT id, :variant_code, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1, :tax_category_id, :price FROM sylius_product WHERE code = :product_code', [
+                'variant_code' => $productVariantCode,
+                'product_code' => $productCode,
+                'tax_category_id' => $taxCategoryId,
+                'price' => (int) $price * 100,
+            ]);
+        }
+
+        if (!is_array($permutation)) {
+            $this->associateProductVariantAndOptionValue($productVariantCode, $permutation);
+            return;
+        }
+
+        foreach ($permutation as $code) {
+            $this->associateProductVariantAndOptionValue($productVariantCode, $code);
+        }
+    }
+
+    private function associateProductVariantAndOptionValue($productVariantCode, $optionValueCode)
+    {
+        $this->productOptionValueAssociationStmt->bindParam('variant_code', $productVariantCode);
+        $this->productOptionValueAssociationStmt->bindParam('option_value_code', $optionValueCode);
+        $this->productOptionValueAssociationStmt->execute();
+
+        if ($this->productVariantStmt->rowCount() === 0) {
+            $this->addSql('INSERT INTO sylius_product_variant_option_value (variant_id, option_value_id) SELECT sylius_product_variant.id, sylius_product_option_value.id FROM sylius_product_variant, sylius_product_option_value WHERE sylius_product_variant.code = :variant_code AND sylius_product_option_value.code = :option_value_code', [
+                'variant_code' => $productVariantCode,
+                'option_value_code' => $optionValueCode,
+            ]);
+        }
+    }
+
+    public function up(Schema $schema)
+    {
+        $stmt = [];
+        $stmt['menu_item'] =
+            $this->connection->prepare('SELECT * FROM menu_item');
+        $stmt['menu_item_modifier'] =
+            $this->connection->prepare('SELECT * FROM menu_item_modifier WHERE menu_item_id = :menu_item_id');
+        $stmt['modifier'] =
+            $this->connection->prepare('SELECT * FROM modifier WHERE menu_item_modifier_id = :menu_item_modifier_id');
+        $stmt['product_variant'] =
+            $this->connection->prepare('SELECT sylius_product_variant.* FROM sylius_product_variant JOIN sylius_product ON sylius_product_variant.product_id = sylius_product.id WHERE sylius_product.code = :code');
+        $stmt['product_variant_option_value'] =
+            $this->connection->prepare('SELECT sylius_product_variant_option_value.* FROM sylius_product_variant_option_value JOIN sylius_product_variant ON sylius_product_variant_option_value.variant_id = sylius_product_variant.id WHERE sylius_product_variant.code = :code');
+
+        $this->productOptionsAssociationStmt =
+            $this->connection->prepare('SELECT * FROM sylius_product_options JOIN sylius_product ON sylius_product_options.product_id = sylius_product.id JOIN sylius_product_option ON sylius_product_options.option_id = sylius_product_option.id WHERE sylius_product.code = :product_code AND sylius_product_option.code = :option_code');
+
+        $this->productVariantStmt =
+            $this->connection->prepare('SELECT * FROM sylius_product_variant where code = :code');
+
+        $this->productOptionValueAssociationStmt =
+            $this->connection->prepare('SELECT sylius_product_variant_option_value.* FROM sylius_product_variant_option_value JOIN sylius_product_variant ON sylius_product_variant_option_value.variant_id = sylius_product_variant.id JOIN sylius_product_option_value ON sylius_product_variant_option_value.option_value_id = sylius_product_option_value.id WHERE sylius_product_variant.code = :variant_code AND sylius_product_option_value.code = :option_value_code');
+
+        $this->setBuilder = new CartesianSetBuilder();
+
+        $stmt['menu_item']->execute();
+        while ($menuItem = $stmt['menu_item']->fetch()) {
+
+            $productCode = sprintf('CPCCL-FDTCH-%d', $menuItem['id']);
+
+            $stmt['menu_item_modifier']->bindParam('menu_item_id', $menuItem['id']);
+            $stmt['menu_item_modifier']->execute();
+
+            // Skip menu items with no menu item modifier
+            if ($stmt['menu_item_modifier']->rowCount() === 0) {
+                continue;
+            }
+
+            $optionSet = [];
+            $modifierMap = []; // Maps product option code with modifier id
+
+            $i = 0;
+            while ($menuItemModifier = $stmt['menu_item_modifier']->fetch()) {
+
+                $productOptionCode = sprintf('CPCCL-FDTCH-%d-OPT-%d', $menuItem['id'], $menuItemModifier['id']);
+
+                $this->associateProductAndOption($productCode, $productOptionCode);
+
+                $stmt['product_variant']->bindParam('code', $productCode);
+                $stmt['product_variant']->execute();
+
+                while ($productVariant = $stmt['product_variant']->fetch()) {
+
+                    $stmt['product_variant_option_value']->bindParam('code', $productVariant['code']);
+                    $stmt['product_variant_option_value']->execute();
+
+                    // Delete default variant created on previous migration
+                    if ($stmt['product_variant_option_value']->rowCount() === 0) {
+                        // FIXME Find a way to change the variant instead of deleting it
+                        $this->addSql('DELETE FROM sylius_order_item USING sylius_product_variant WHERE sylius_product_variant.id = sylius_order_item.variant_id AND sylius_product_variant.code = :code', [
+                            'code' => $productVariant['code'],
+                        ]);
+                        $this->addSql('DELETE FROM sylius_product_variant WHERE code = :code', [
+                            'code' => $productVariant['code'],
+                        ]);
+                    }
+                }
+
+                $stmt['modifier']->bindParam('menu_item_modifier_id', $menuItemModifier['id']);
+                $stmt['modifier']->execute();
+
+                $modifiersIds = [];
+                while ($modifier = $stmt['modifier']->fetch()) {
+                    $productOptionValueCode = sprintf('%s-%d', $productOptionCode, $modifier['id']);
+                    $optionSet[$i][] = $productOptionValueCode;
+                    $modifierMap[$productOptionValueCode] = $modifier['id'];
+                }
+
+                ++$i;
+            }
+
+            $permutations = $this->setBuilder->build($optionSet);
+
+            foreach ($permutations as $permutation) {
+                $this->createVariant($productCode, $modifierMap, $permutation, $menuItem['tax_category_id'], $menuItem['price']);
+            }
+        }
+    }
+
+    public function down(Schema $schema)
+    {
+
+    }
+}

--- a/app/DoctrineMigrations/Version20180514202719.php
+++ b/app/DoctrineMigrations/Version20180514202719.php
@@ -1,0 +1,157 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+use Ramsey\Uuid\Uuid;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180514202719 extends AbstractMigration implements ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    private $locale;
+
+    private function createMenu(array $menu)
+    {
+        // Build nested set values
+        $left = 2;
+        foreach ($menu['children'] as $key => $child) {
+            $menu['children'][$key]['left'] = $left;
+            $menu['children'][$key]['right'] = ($left + 1);
+            $left += 2;
+        }
+
+        $menu['left'] = 1;
+        $menu['right'] = $left;
+
+        $this->addSql('INSERT INTO sylius_taxon (code, tree_left, tree_right, tree_level, position) VALUES (:code, :tree_left, :tree_right, 0, 1)', [
+            'code' => $menu['code'],
+            'tree_left' => $menu['left'],
+            'tree_right' => $menu['right'],
+        ]);
+
+        $this->addSql('UPDATE sylius_taxon SET tree_root = id WHERE code = :code', [
+            'code' => $menu['code'],
+        ]);
+
+        $this->addSql('INSERT INTO sylius_taxon_translation (translatable_id, name, slug, locale) SELECT id, :name, :code, :locale FROM sylius_taxon WHERE code = :code', [
+            'code' => $menu['code'],
+            'name' => 'Default',
+            'locale' => $this->locale,
+        ]);
+
+        $i = 1;
+        foreach ($menu['children'] as $child) {
+
+            $this->addSql('INSERT INTO sylius_taxon (tree_root, parent_id, code, tree_left, tree_right, tree_level, position) SELECT id, id, :code, :tree_left, :tree_right, 1, :position FROM sylius_taxon WHERE code = :parent_code', [
+                'code' => $child['code'],
+                'tree_left' => $child['left'],
+                'tree_right' => $child['right'],
+                'position' => $i++,
+                'parent_code' => $menu['code'],
+            ]);
+            $this->addSql('INSERT INTO sylius_taxon_translation (translatable_id, name, slug, locale) SELECT id, :name, :code, :locale FROM sylius_taxon WHERE code = :code', [
+                'code' => $child['code'],
+                'name' => $child['name'],
+                'locale' => $this->locale,
+            ]);
+
+            $j = 1;
+            foreach ($child['products'] as $productCode) {
+                $this->addSql('INSERT INTO sylius_product_taxon (product_id, taxon_id, position) SELECT sylius_product.id, sylius_taxon.id, :position FROM sylius_product, sylius_taxon WHERE sylius_product.code = :product_code AND sylius_taxon.code = :taxon_code', [
+                    'product_code' => $productCode,
+                    'taxon_code' => $child['code'],
+                    'position' => $j++,
+                ]);
+            }
+        }
+
+        $this->addSql('INSERT INTO restaurant_taxon (restaurant_id, taxon_id) SELECT :restaurant_id, id FROM sylius_taxon WHERE code = :code', [
+            'restaurant_id' => $menu['restaurant_id'],
+            'code' => $menu['code'],
+        ]);
+    }
+
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->locale = $this->container->getParameter('coopcycle.locale');
+
+        $stmt = [];
+        $stmt['menu'] =
+            $this->connection->prepare('SELECT menu.id, restaurant.id AS restaurant_id FROM menu JOIN restaurant ON menu.id = restaurant.menu_id');
+        $stmt['menu_section'] =
+            $this->connection->prepare('SELECT * FROM menu_section WHERE menu_id = :menu_id');
+        $stmt['menu_item'] =
+            $this->connection->prepare('SELECT * FROM menu_item WHERE parent_id = :menu_section_id ORDER BY position ASC');
+
+        $stmt['menu']->execute();
+        while ($menu = $stmt['menu']->fetch()) {
+
+            $stmt['menu_section']->bindParam('menu_id', $menu['id']);
+            $stmt['menu_section']->execute();
+
+            $menu['code'] = Uuid::uuid4()->toString();
+            $menu['children'] = [];
+
+            while ($menuSection = $stmt['menu_section']->fetch()) {
+
+                if (empty($menuSection['name'])) {
+                    $menuSection['name'] = '???';
+                }
+
+                $menuSection['code'] = Uuid::uuid4()->toString();
+
+                $stmt['menu_item']->bindParam('menu_section_id', $menuSection['id']);
+                $stmt['menu_item']->execute();
+
+                $menuSection['products'] = [];
+                while ($menuItem = $stmt['menu_item']->fetch()) {
+                    $productCode = sprintf('CPCCL-FDTCH-%d', $menuItem['id']);
+                    $menuSection['products'][] = $productCode;
+                }
+
+                $menu['children'][] = $menuSection;
+            }
+
+            $this->createMenu($menu);
+        }
+
+        $this->addSql('ALTER TABLE restaurant DROP CONSTRAINT fk_eb95123fccd7e912');
+        $this->addSql('DROP INDEX uniq_eb95123fccd7e912');
+        $this->addSql('ALTER TABLE restaurant RENAME COLUMN menu_id TO legacy_menu_id');
+        $this->addSql('ALTER TABLE restaurant ADD CONSTRAINT FK_EB95123F12B2DF0A FOREIGN KEY (legacy_menu_id) REFERENCES menu (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_EB95123F12B2DF0A ON restaurant (legacy_menu_id)');
+
+        // Indexes on restaurant_product_option
+        $this->addSql('ALTER INDEX idx_c713f7d5b1e7706e RENAME TO IDX_CB35112EB1E7706E');
+        $this->addSql('ALTER INDEX idx_c713f7d5a7c41d6f RENAME TO IDX_CB35112EA7C41D6F');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('DELETE FROM restaurant_taxon');
+        $this->addSql('DELETE FROM sylius_taxon');
+
+        $this->addSql('ALTER TABLE restaurant DROP CONSTRAINT FK_EB95123F12B2DF0A');
+        $this->addSql('DROP INDEX UNIQ_EB95123F12B2DF0A');
+        $this->addSql('ALTER TABLE restaurant RENAME COLUMN legacy_menu_id TO menu_id');
+        $this->addSql('ALTER TABLE restaurant ADD CONSTRAINT fk_eb95123fccd7e912 FOREIGN KEY (menu_id) REFERENCES menu (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE UNIQUE INDEX uniq_eb95123fccd7e912 ON restaurant (menu_id)');
+
+        // Indexes on restaurant_product_option
+        $this->addSql('ALTER INDEX idx_cb35112ea7c41d6f RENAME TO idx_c713f7d5a7c41d6f');
+        $this->addSql('ALTER INDEX idx_cb35112eb1e7706e RENAME TO idx_c713f7d5b1e7706e');
+    }
+}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -235,6 +235,12 @@ sylius_product:
             classes:
                 model: AppBundle\Entity\Sylius\ProductVariant
                 repository: AppBundle\Entity\Sylius\ProductVariantRepository
+        product_option:
+            classes:
+                model: AppBundle\Entity\Sylius\ProductOption
+        product_option_value:
+            classes:
+                model: AppBundle\Entity\Sylius\ProductOptionValue
 
 sylius_locale:
     locale: "%locale%"

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -231,6 +231,9 @@ sylius_order:
 
 sylius_product:
     resources:
+        product:
+            classes:
+                model: AppBundle\Entity\Sylius\Product
         product_variant:
             classes:
                 model: AppBundle\Entity\Sylius\ProductVariant
@@ -241,6 +244,13 @@ sylius_product:
         product_option_value:
             classes:
                 model: AppBundle\Entity\Sylius\ProductOptionValue
+
+sylius_taxonomy:
+    resources:
+        taxon:
+            classes:
+                model: AppBundle\Entity\Sylius\Taxon
+                # interface: Sylius\Component\Taxonomy\Model\TaxonInterface
 
 sylius_locale:
     locale: "%locale%"

--- a/app/config/doctrine_extensions.yml
+++ b/app/config/doctrine_extensions.yml
@@ -58,12 +58,12 @@ services:
         calls:
             - [ setAnnotationReader, [ "@annotation_reader" ] ]
 
-    # gedmo.listener.sortable:
-    #     class: Gedmo\Sortable\SortableListener
-    #     tags:
-    #         - { name: doctrine.event_subscriber, connection: default }
-    #     calls:
-    #         - [ setAnnotationReader, [ "@annotation_reader" ] ]
+    gedmo.listener.sortable:
+        class: Gedmo\Sortable\SortableListener
+        tags:
+            - { name: doctrine.event_subscriber, connection: default }
+        calls:
+            - [ setAnnotationReader, [ "@annotation_reader" ] ]
 
     # gedmo.listener.loggable:
     #     class: Gedmo\Loggable\LoggableListener

--- a/app/config/doctrine_extensions.yml
+++ b/app/config/doctrine_extensions.yml
@@ -16,12 +16,12 @@ services:
 
 
     # Doctrine Extension listeners to handle behaviors
-    # gedmo.listener.tree:
-    #     class: Gedmo\Tree\TreeListener
-    #     tags:
-    #         - { name: doctrine.event_subscriber, connection: default }
-    #     calls:
-    #         - [ setAnnotationReader, [ "@annotation_reader" ] ]
+    gedmo.listener.tree:
+        class: Gedmo\Tree\TreeListener
+        tags:
+            - { name: doctrine.event_subscriber, connection: default }
+        calls:
+            - [ setAnnotationReader, [ "@annotation_reader" ] ]
 
     # gedmo.listener.translatable:
     #     class: Gedmo\Translatable\TranslatableListener

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -315,6 +315,18 @@ services:
     arguments: [ '@security.authorization_checker', '@security.token_storage' ]
     tags: [ form.type ]
 
+  'AppBundle\Form\ProductOptionType':
+    arguments: [ '@translator' ]
+    tags: [ form.type ]
+
+  'AppBundle\Form\MenuEditor\TaxonProductType':
+    arguments: [ '@sylius.repository.product' ]
+    tags: [ form.type ]
+
+  'AppBundle\Form\ProductType':
+    arguments: [ '@sylius.generator.product_variant', '@sylius.factory.product_variant', '@sylius.product_variant_resolver.default' ]
+    tags: [ form.type ]
+
   my.jwt_listener:
     class: AppBundle\EventListener\JwtListener
     tags:
@@ -361,6 +373,13 @@ services:
   coopcycle.twig.runtime.order_state_resolver:
     class: AppBundle\Twig\OrderStateResolver
     arguments: [ '@sm.factory' ]
+    public: false
+    tags:
+      - { name: twig.runtime }
+
+  coopcycle.twig.runtime.sylius_variant_resolver:
+    class: AppBundle\Twig\SyliusVariantResolver
+    arguments: [ '@sylius.product_variant_resolver.default' ]
     public: false
     tags:
       - { name: twig.runtime }

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -615,6 +615,50 @@ form[name="menu"] {
   }
 }
 
+.menuEditor {
+  display: flex;
+  &__left, &__right {
+    flex: 1;
+  }
+  &__left {
+    padding-right: 15px;
+  }
+  &__right {
+    padding-left: 15px;
+    display: flex;
+  }
+  &__productList {
+    flex: 1;
+  }
+  &__product {
+    padding: 10px;
+    margin-bottom: 10px;
+    background-color: lighten(lightgrey, 10%);
+  }
+  &__product:last-child {
+    margin-bottom: 0;
+  }
+
+  &__panel {
+    margin-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    &__title {
+      padding: 10px;
+      background-color: lightgrey;
+      color: #fff;
+      margin: 0;
+    }
+    &__body {
+      flex: 1;
+      border: 2px dashed lightgrey;
+      border-top: none;
+      padding: 10px;
+      min-height: 50px;
+    }
+  }
+}
+
 .role-icons {
   .fa {
     margin-left: 5px;

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
         "sylius/payment": "^1.1",
         "laravolt/avatar": "^2.0",
         "sylius/product-bundle": "^1.1",
-        "duccio/apns-php": "^1.0"
+        "duccio/apns-php": "^1.0",
+        "sylius/taxonomy-bundle": "^1.1"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "634357600a74911a354a1609475ec4c3",
+    "content-hash": "4775990a8ed345b498c8443ce70f310f",
     "packages": [
         {
             "name": "api-platform/core",
@@ -7213,6 +7213,141 @@
                 "webshop"
             ],
             "time": "2018-03-15T09:57:54+00:00"
+        },
+        {
+            "name": "sylius/taxonomy",
+            "version": "v1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Sylius/Taxonomy.git",
+                "reference": "b40340c6b91d9c704e3fe77615c2b5874c9e534a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Sylius/Taxonomy/zipball/b40340c6b91d9c704e3fe77615c2b5874c9e534a",
+                "reference": "b40340c6b91d9c704e3fe77615c2b5874c9e534a",
+                "shasum": ""
+            },
+            "require": {
+                "behat/transliterator": "^1.1",
+                "php": "^7.1",
+                "sylius/resource": "^1.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sylius\\Component\\Taxonomy\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Community contributions",
+                    "homepage": "http://github.com/Sylius/Sylius/contributors"
+                },
+                {
+                    "name": "Paweł Jędrzejewski",
+                    "homepage": "http://pjedrzejewski.com"
+                },
+                {
+                    "name": "Sylius project",
+                    "homepage": "http://sylius.com"
+                }
+            ],
+            "description": "Taxonomies - categorization of domain models in PHP projects.",
+            "homepage": "http://sylius.com",
+            "keywords": [
+                "categorization",
+                "classification",
+                "ecommerce",
+                "taxon",
+                "taxonomy"
+            ],
+            "time": "2018-02-08T16:38:47+00:00"
+        },
+        {
+            "name": "sylius/taxonomy-bundle",
+            "version": "v1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Sylius/SyliusTaxonomyBundle.git",
+                "reference": "2898055cbecf0e36380f09918ce55a0157b2be07"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Sylius/SyliusTaxonomyBundle/zipball/2898055cbecf0e36380f09918ce55a0157b2be07",
+                "reference": "2898055cbecf0e36380f09918ce55a0157b2be07",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "stof/doctrine-extensions-bundle": "^1.2",
+                "sylius/resource-bundle": "^1.0",
+                "sylius/taxonomy": "^1.0",
+                "symfony/framework-bundle": "^3.4"
+            },
+            "require-dev": {
+                "doctrine/orm": "^2.5",
+                "phpspec/phpspec": "^4.0",
+                "phpunit/phpunit": "^6.5",
+                "symfony/dependency-injection": "^3.4"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Sylius\\Bundle\\TaxonomyBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Community contributions",
+                    "homepage": "http://github.com/Sylius/Sylius/contributors"
+                },
+                {
+                    "name": "Paweł Jędrzejewski",
+                    "homepage": "http://pjedrzejewski.com"
+                },
+                {
+                    "name": "Sylius project",
+                    "homepage": "http://sylius.com"
+                }
+            ],
+            "description": "Flexible categorization system for Symfony2.",
+            "homepage": "http://sylius.com",
+            "keywords": [
+                "categorization",
+                "category",
+                "ecommerce",
+                "shop",
+                "sylius",
+                "taxonomies",
+                "taxonomy"
+            ],
+            "time": "2018-03-19T04:02:53+00:00"
         },
         {
             "name": "symfony/monolog-bundle",

--- a/js/app/cart/index.jsx
+++ b/js/app/cart/index.jsx
@@ -144,7 +144,7 @@ class CartHelper {
       .fail(e => this.handleAjaxResponse(e.responseJSON))
   }
 
-  addMenuItem(url, quantity) {
+  addProduct(url, quantity) {
     this.cartComponentRef.current.setLoading(true)
     $.post(url, {
       quantity: quantity
@@ -153,7 +153,7 @@ class CartHelper {
     .fail(e => this.handleAjaxResponse(e.responseJSON))
   }
 
-  addMenuItemWithModifiers(url, data, quantity) {
+  addProductWithOptions(url, data, quantity) {
     this.cartComponentRef.current.setLoading(true)
     data.push({
       name: 'quantity',

--- a/js/app/restaurant/menu-editor.js
+++ b/js/app/restaurant/menu-editor.js
@@ -1,0 +1,113 @@
+import dragula from 'dragula'
+
+const containers = [].slice.call(document.querySelectorAll('[data-draggable-target]'))
+const source = document.querySelector('[data-draggable-source]')
+
+containers.push(source)
+
+const childrenContainer = document.querySelector('#menu_editor_children')
+
+function reorderProducts(taxonId) {
+
+  const drakeContainer = document
+    .querySelector(`[data-draggable-target][data-taxon-id="${taxonId}"]`)
+
+  const formContainer = childrenContainer
+    .querySelector(`[data-taxon-id="${taxonId}"]`)
+    .querySelector('[data-prototype]')
+
+  const productPositions = [].slice.call(drakeContainer.children).map((el, index) => {
+    console.log(el.getAttribute('data-product-id'), index)
+    return {
+      product: el.getAttribute('data-product-id'),
+      position: (index + 1)
+    }
+  })
+
+  productPositions.forEach(productPosition => {
+
+    const productInput = $(formContainer)
+      // .find("[name$='[product]']")
+      .find(`[value="${productPosition.product}"]`)
+
+    $(productInput)
+      .closest('div')
+      .find("[name$='[position]']")
+      .val(productPosition.position)
+
+  })
+
+}
+
+function removeProduct(taxonId, productId) {
+  const formContainer = childrenContainer
+    .querySelector(`[data-taxon-id="${taxonId}"]`)
+    .querySelector('[data-prototype]')
+
+  const productInput = $(formContainer)
+    // .find("[name$='[product]']")
+    .find(`[value="${productId}"]`)
+
+  $(productInput).closest('div').remove()
+}
+
+const drake = dragula(containers)
+.on('drop', (el, target, source, sibling) => {
+
+  // Products have been reordered in the same taxon
+  if (target === source) {
+
+    const taxonId = target.getAttribute('data-taxon-id')
+    reorderProducts(taxonId)
+
+    return
+  }
+
+  if (target.hasAttribute('data-draggable-target')) {
+
+    const taxonId = target.getAttribute('data-taxon-id')
+    const productId = el.getAttribute('data-product-id')
+
+    const formContainer = childrenContainer
+      .querySelector(`[data-taxon-id="${taxonId}"]`)
+      .querySelector('[data-prototype]')
+
+    const prototype = formContainer.getAttribute('data-prototype')
+
+    const index = $(formContainer).children().length
+    const form = prototype.replace(/__taxonProducts__/g, index)
+
+    const $form = $(form)
+
+    $form
+      .find("[name$='[product]']")
+      .val(productId)
+    $form
+      .find("[name$='[position]']")
+      .val(index + 1)
+
+    $(formContainer).append($form)
+
+    reorderProducts(taxonId)
+
+    // Product was moved from a taxon to another
+    if (source.hasAttribute('data-draggable-target')) {
+
+      const sourceTaxonId = source.getAttribute('data-taxon-id')
+
+      removeProduct(sourceTaxonId, productId)
+      reorderProducts(sourceTaxonId)
+    }
+
+  }
+
+  if (target.hasAttribute('data-draggable-source')) {
+
+    const taxonId = source.getAttribute('data-taxon-id')
+    const productId = el.getAttribute('data-product-id')
+
+    removeProduct(taxonId, productId)
+    reorderProducts(taxonId)
+  }
+
+})

--- a/src/AppBundle/Entity/Restaurant.php
+++ b/src/AppBundle/Entity/Restaurant.php
@@ -10,6 +10,8 @@ use AppBundle\Utils\ValidationUtils;
 use AppBundle\Validator\Constraints as CustomAssert;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\ArrayCollection;
+use Sylius\Component\Product\Model\ProductInterface;
+use Sylius\Component\Taxonomy\Model\TaxonInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -174,6 +176,8 @@ class Restaurant extends FoodEstablishment
 
     private $productOptions;
 
+    private $taxons;
+
     /**
      * @var Contract
      * @Groups({"order_create"})
@@ -187,6 +191,7 @@ class Restaurant extends FoodEstablishment
         $this->owners = new ArrayCollection();
         $this->products = new ArrayCollection();
         $this->productOptions = new ArrayCollection();
+        $this->taxons = new ArrayCollection();
     }
 
     /**
@@ -512,9 +517,27 @@ class Restaurant extends FoodEstablishment
         return $this->products;
     }
 
+    public function addProduct(ProductInterface $product)
+    {
+        if (!$this->products->contains($product)) {
+            $this->products->add($product);
+        }
+    }
+
     public function getProductOptions()
     {
         return $this->productOptions;
+    }
+
+    public function getTaxons()
+    {
+        return $this->taxons;
+    }
+
+    public function addTaxon(TaxonInterface $taxon)
+    {
+        // TODO Check if this is a root taxon
+        $this->taxons->add($taxon);
     }
 
     public function canDeliverAddress(Address $address, $distance, ExpressionLanguage $language = null)

--- a/src/AppBundle/Entity/Restaurant.php
+++ b/src/AppBundle/Entity/Restaurant.php
@@ -170,6 +170,10 @@ class Restaurant extends FoodEstablishment
 
     private $owners;
 
+    private $products;
+
+    private $productOptions;
+
     /**
      * @var Contract
      * @Groups({"order_create"})
@@ -181,14 +185,8 @@ class Restaurant extends FoodEstablishment
         $this->servesCuisine = new ArrayCollection();
         $this->closingRules = new ArrayCollection();
         $this->owners = new ArrayCollection();
-    }
-
-    /**
-     * @param int $id
-     */
-    public function setId(int $id)
-    {
-        $this->id = $id;
+        $this->products = new ArrayCollection();
+        $this->productOptions = new ArrayCollection();
     }
 
     /**
@@ -507,6 +505,16 @@ class Restaurant extends FoodEstablishment
     public function getOwners()
     {
         return $this->owners;
+    }
+
+    public function getProducts()
+    {
+        return $this->products;
+    }
+
+    public function getProductOptions()
+    {
+        return $this->productOptions;
     }
 
     public function canDeliverAddress(Address $address, $distance, ExpressionLanguage $language = null)

--- a/src/AppBundle/Entity/Restaurant.php
+++ b/src/AppBundle/Entity/Restaurant.php
@@ -446,6 +446,16 @@ class Restaurant extends FoodEstablishment
         $this->hasMenu = $menu;
     }
 
+    public function hasMenuTaxon()
+    {
+        return null !== $this->getMenu();
+    }
+
+    public function getMenuTaxon()
+    {
+        return $this->taxons->first();
+    }
+
     /**
      * @return string
      */
@@ -515,6 +525,11 @@ class Restaurant extends FoodEstablishment
     public function getProducts()
     {
         return $this->products;
+    }
+
+    public function hasProduct(ProductInterface $product)
+    {
+        return $this->products->contains($product);
     }
 
     public function addProduct(ProductInterface $product)

--- a/src/AppBundle/Entity/Sylius/Product.php
+++ b/src/AppBundle/Entity/Sylius/Product.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AppBundle\Entity\Sylius;
+
+use AppBundle\Entity\Restaurant;
+use AppBundle\Sylius\Product\ProductInterface;
+use Sylius\Component\Product\Model\Product as BaseProduct;
+
+class Product extends BaseProduct implements ProductInterface
+{
+    protected $restaurant;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRestaurant(): ?Restaurant
+    {
+        return $this->restaurant;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRestaurant(?Restaurant $restaurant): void
+    {
+        $restaurant->addProduct($this);
+
+        $this->restaurant = $restaurant;
+    }
+}

--- a/src/AppBundle/Entity/Sylius/ProductOption.php
+++ b/src/AppBundle/Entity/Sylius/ProductOption.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace AppBundle\Entity\Sylius;
+
+use AppBundle\Sylius\Product\ProductOptionInterface;
+use Sylius\Component\Product\Model\ProductOption as BaseProductOption;
+
+class ProductOption extends BaseProductOption implements ProductOptionInterface
+{
+    /**
+     * @var string
+     */
+    protected $strategy = ProductOptionInterface::STRATEGY_FREE;
+
+    /**
+     * @var int
+     */
+    protected $price;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getStrategy(): string
+    {
+        return $this->strategy;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setStrategy(string $strategy): void
+    {
+        $this->strategy = $strategy;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPrice(): ?int
+    {
+        return $this->price;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPrice(?int $price): void
+    {
+        $this->price = $price;
+    }
+}

--- a/src/AppBundle/Entity/Sylius/ProductOptionValue.php
+++ b/src/AppBundle/Entity/Sylius/ProductOptionValue.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AppBundle\Entity\Sylius;
+
+use AppBundle\Sylius\Product\ProductOptionValueInterface;
+use Sylius\Component\Product\Model\ProductOptionValue as BaseProductOptionValue;
+
+class ProductOptionValue extends BaseProductOptionValue implements ProductOptionValueInterface
+{
+    /**
+     * @var int
+     */
+    protected $price;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPrice(): ?int
+    {
+        return $this->price;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setPrice(?int $price): void
+    {
+        $this->price = $price;
+    }
+}

--- a/src/AppBundle/Entity/Sylius/ProductTaxon.php
+++ b/src/AppBundle/Entity/Sylius/ProductTaxon.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace AppBundle\Entity\Sylius;
+
+use Sylius\Component\Product\Model\ProductInterface;
+use Sylius\Component\Taxonomy\Model\TaxonInterface;
+
+class ProductTaxon
+{
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @var ProductInterface
+     */
+    protected $product;
+
+    /**
+     * @var TaxonInterface
+     */
+    protected $taxon;
+
+    /**
+     * @var int
+     */
+    protected $position;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getProduct(): ?ProductInterface
+    {
+        return $this->product;
+    }
+
+    public function setProduct(?ProductInterface $product): void
+    {
+        $this->product = $product;
+    }
+
+    public function getTaxon(): ?TaxonInterface
+    {
+        return $this->taxon;
+    }
+
+    public function setTaxon(?TaxonInterface $taxon): void
+    {
+        $this->taxon = $taxon;
+    }
+
+    public function getPosition(): ?int
+    {
+        return $this->position;
+    }
+
+    public function setPosition(?int $position): void
+    {
+        $this->position = $position;
+    }
+}

--- a/src/AppBundle/Entity/Sylius/Taxon.php
+++ b/src/AppBundle/Entity/Sylius/Taxon.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AppBundle\Entity\Sylius;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Sylius\Component\Product\Model\ProductInterface;
+use Sylius\Component\Taxonomy\Model\Taxon as BaseTaxon;
+
+class Taxon extends BaseTaxon
+{
+    private $taxonProducts;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->taxonProducts = new ArrayCollection();
+    }
+
+    public function getTaxonProducts()
+    {
+        return $this->taxonProducts;
+    }
+
+    public function setTaxonProducts(Collection $taxonProducts)
+    {
+        $this->taxonProducts = $taxonProducts;
+    }
+
+    public function getProducts()
+    {
+        return $this->taxonProducts->map(function (ProductTaxon $productTaxon): ProductInterface {
+            return $productTaxon->getProduct();
+        });
+    }
+}

--- a/src/AppBundle/Form/MenuEditor/TaxonProductType.php
+++ b/src/AppBundle/Form/MenuEditor/TaxonProductType.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace AppBundle\Form\MenuEditor;
+
+use AppBundle\Entity\Sylius\ProductTaxon;
+use Sylius\Component\Product\Model\ProductInterface;
+use Sylius\Component\Product\Repository\ProductRepositoryInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TaxonProductType extends AbstractType
+{
+    private $productRepository;
+
+    public function __construct(ProductRepositoryInterface $productRepository)
+    {
+        $this->productRepository = $productRepository;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('product', IntegerType::class)
+            ->add('position', IntegerType::class);
+
+        $builder
+            ->get('product')
+            ->addModelTransformer(new CallbackTransformer(
+                function ($entity) {
+                    if ($entity instanceof ProductInterface) {
+                        return $entity->getId();
+                    }
+                },
+                function ($id) {
+                    if (!$id) {
+                        return null;
+                    }
+
+                    return $this->productRepository->find($id);
+                }
+            ))
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => ProductTaxon::class,
+        ));
+    }
+}

--- a/src/AppBundle/Form/MenuEditor/TaxonType.php
+++ b/src/AppBundle/Form/MenuEditor/TaxonType.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace AppBundle\Form\MenuEditor;
+
+use AppBundle\Entity\Sylius\Taxon;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TaxonType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('taxonProducts', CollectionType::class, [
+                'entry_type' => TaxonProductType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'by_reference' => false,
+                'prototype' => true,
+                'prototype_name' => '__taxonProducts__',
+                'label' => false,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => Taxon::class,
+        ));
+    }
+}

--- a/src/AppBundle/Form/MenuEditorType.php
+++ b/src/AppBundle/Form/MenuEditorType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Form\MenuEditor\TaxonType;
+use AppBundle\Utils\MenuEditor;
+use Sylius\Component\Taxonomy\Model\Taxon;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class MenuEditorType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('children', CollectionType::class, [
+                'entry_type' => TaxonType::class,
+                'allow_add' => false,
+                'allow_delete' => false,
+                'label' => false,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => MenuEditor::class,
+        ));
+    }
+}

--- a/src/AppBundle/Form/MenuTaxonType.php
+++ b/src/AppBundle/Form/MenuTaxonType.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Entity\Menu;
+use Sylius\Component\Taxonomy\Model\Taxon;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class MenuTaxonType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => 'form.menu_taxon.name.label'
+            ])
+            ->add('childName', TextType::class, [
+                'mapped' => false,
+                'attr' => [
+                    'placeholder' => 'form.menu_taxon.child_name.placeholder'
+                ]
+            ])
+            ->add('addChild', SubmitType::class, [
+                'label' => 'form.menu_taxon.add_child.label'
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => Taxon::class,
+        ));
+    }
+}

--- a/src/AppBundle/Form/ProductOptionType.php
+++ b/src/AppBundle/Form/ProductOptionType.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Entity\Sylius\ProductOption;
+use AppBundle\Sylius\Product\ProductOptionInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class ProductOptionType extends AbstractType
+{
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name', TextType::class, [
+                'label' => 'form.product_option.name.label'
+            ])
+            ->add('strategy', ChoiceType::class, [
+                'choices' => [
+                    $this->translator->trans('product_option.strategy.STRATEGY_FREE') => ProductOptionInterface::STRATEGY_FREE,
+                    $this->translator->trans('product_option.strategy.STRATEGY_OPTION') => ProductOptionInterface::STRATEGY_OPTION,
+                    $this->translator->trans('product_option.strategy.STRATEGY_OPTION_VALUE') => ProductOptionInterface::STRATEGY_OPTION_VALUE,
+                ],
+                'label' => 'form.product_option.strategy.label'
+            ])
+            ->add('price', MoneyType::class, [
+                'label' => 'form.product_option.price.label',
+                'required' => false
+            ])
+            ->add('values', CollectionType::class, [
+                'entry_type' => ProductOptionValueType::class,
+                'allow_add' => true,
+                'allow_delete' => true,
+                'by_reference' => false,
+                'label' => false,
+                // 'button_add_label' => 'sylius.form.option_value.add_value',
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => ProductOption::class,
+        ));
+    }
+}

--- a/src/AppBundle/Form/ProductOptionValueType.php
+++ b/src/AppBundle/Form/ProductOptionValueType.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Entity\Sylius\ProductOptionValue;
+use Sylius\Bundle\ProductBundle\Form\Type\ProductOptionValueTranslationType;
+use Sylius\Bundle\ResourceBundle\Form\Type\ResourceTranslationsType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ProductOptionValueType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('translations', ResourceTranslationsType::class, [
+                'entry_type' => ProductOptionValueTranslationType::class,
+            ])
+            ->add('price', MoneyType::class, [
+                'label' => 'form.product_option_value.price.label',
+                'required' => false,
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => ProductOptionValue::class,
+        ));
+    }
+}

--- a/src/AppBundle/Form/ProductType.php
+++ b/src/AppBundle/Form/ProductType.php
@@ -2,41 +2,142 @@
 
 namespace AppBundle\Form;
 
-use AppBundle\Entity\Product;
-use Doctrine\ORM\EntityRepository;
+use AppBundle\Entity\Sylius\ProductOption;
+use Ramsey\Uuid\Uuid;
+use Sylius\Bundle\TaxationBundle\Form\Type\TaxCategoryChoiceType;
+use Sylius\Component\Product\Factory\ProductVariantFactoryInterface;
+use Sylius\Component\Product\Generator\ProductVariantGeneratorInterface;
+use Sylius\Component\Product\Model\Product;
+use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
-use Symfony\Component\Form\Extension\Core\Type\MoneyType;
-use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Validator\Validation;
-use Symfony\Component\Validator\Constraints;
 
 class ProductType extends AbstractType
 {
+    private $variantGenerator;
+    private $variantFactory;
+    private $variantResolver;
+
+    public function __construct(
+        ProductVariantGeneratorInterface $variantGenerator,
+        ProductVariantFactoryInterface $variantFactory,
+        ProductVariantResolverInterface $variantResolver)
+    {
+        $this->variantGenerator = $variantGenerator;
+        $this->variantFactory = $variantFactory;
+        $this->variantResolver = $variantResolver;
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('recipeCategory', ChoiceType::class, array(
-                'choices'  => array(
-                    'Entrées' => 'Entrées',
-                    'Plats' => 'Plats',
-                    'Desserts' => 'Desserts',
-                ),
-                'label' => 'Category'
-            ))
-            ->add('name', TextType::class)
-            ->add('description', TextareaType::class)
-            ->add('price', MoneyType::class)
-            ;
+            ->add('name', TextType::class, [
+                'label' => 'form.product.name.label'
+            ])
+            ->add('description', TextareaType::class, [
+                'required' => false,
+                'label' => 'form.product.description.label'
+            ])
+            ->add('enabled', CheckboxType::class, [
+                'required' => false,
+                'label' => 'form.product.enabled.label',
+            ]);
+
+        // While price & tax category are defined in ProductVariant,
+        // we display the fields at the Product level
+        // For now, all variants share the same values
+        $builder
+            ->add('price', MoneyType::class, [
+                'mapped' => false,
+                'divisor' => 100,
+                'label' => 'form.product.price.label'
+            ])
+            ->add('taxCategory', TaxCategoryChoiceType::class, [
+                'mapped' => false,
+                'label' => 'form.product.taxCategory.label'
+            ]);
+
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
+
+            $form = $event->getForm();
+            $product = $event->getData();
+
+            $form->add('options', EntityType::class, [
+                'class' => ProductOption::class,
+                'choices' => $product->getRestaurant()->getProductOptions(),
+                'expanded' => true,
+                'multiple' => true,
+            ]);
+
+            if (null !== $product->getId()) {
+
+                if ($product->hasOptions()) {
+                    $this->variantGenerator->generate($product);
+                }
+
+                $variant = $this->variantResolver->getVariant($product);
+
+                // To keep things simple, all variants have the same price & tax category
+                $form->get('price')->setData($variant->getPrice());
+                $form->get('taxCategory')->setData($variant->getTaxCategory());
+
+                foreach ($product->getVariants() as $variant) {
+                    $variant->setName($product->getName());
+                }
+            }
+
+            $form->add('variants', CollectionType::class, [
+                'entry_type' => ProductVariantType::class,
+                'allow_add' => false,
+                'allow_delete' => false,
+                'prototype' => false,
+                'label' => false,
+            ]);
+
+        });
+
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
+
+            $form = $event->getForm();
+            $product = $event->getData();
+
+            if (null === $product->getId()) {
+
+                $uuid = Uuid::uuid4()->toString();
+
+                $product->setCode($uuid);
+                $product->setSlug($uuid);
+
+                if ($product->hasOptions()) {
+                    $this->variantGenerator->generate($product);
+                } else {
+                    $variant = $this->variantFactory->createForProduct($product);
+                    $product->addVariant($variant);
+                }
+
+                $price = $form->get('price')->getData();
+                $taxCategory = $form->get('taxCategory')->getData();
+
+                foreach ($product->getVariants() as $variant) {
+                    $variant->setName($product->getName());
+                    $variant->setCode(Uuid::uuid4()->toString());
+                    $variant->setPrice($price);
+                    $variant->setTaxCategory($taxCategory);
+                }
+
+            }
+        });
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/AppBundle/Form/ProductVariantType.php
+++ b/src/AppBundle/Form/ProductVariantType.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Entity\Sylius\ProductVariant;
+use Ramsey\Uuid\Uuid;
+use Sylius\Bundle\ProductBundle\Form\EventSubscriber\BuildProductVariantFormSubscriber;
+use Sylius\Bundle\ResourceBundle\Form\EventSubscriber\AddCodeFormSubscriber;
+use Sylius\Bundle\TaxationBundle\Form\Type\TaxCategoryChoiceType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class ProductVariantType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name', TextType::class)
+            ->add('price', MoneyType::class, [
+                'divisor' => 100,
+            ])
+            ->add('taxCategory', TaxCategoryChoiceType::class);
+
+        $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event) {
+            $productVariant = $event->getForm()->getData();
+            if (null === $productVariant->getCode()) {
+                $uuid = Uuid::uuid4()->toString();
+                $productVariant->setCode($uuid);
+            }
+        });
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => ProductVariant::class,
+        ));
+    }
+}

--- a/src/AppBundle/Resources/config/doctrine/Restaurant.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Restaurant.orm.yml
@@ -196,7 +196,7 @@ AppBundle\Entity\Restaurant:
             mappedBy: null
             inversedBy: restaurant
             joinColumns:
-                menu_id:
+                legacy_menu_id:
                     referencedColumnName: id
             orphanRemoval: false
         contract:

--- a/src/AppBundle/Resources/config/doctrine/Restaurant.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Restaurant.orm.yml
@@ -134,6 +134,34 @@ AppBundle\Entity\Restaurant:
         owners:
             targetEntity: AppBundle\Entity\ApiUser
             mappedBy: restaurants
+        products:
+            targetEntity: Sylius\Component\Product\Model\ProductInterface
+            cascade:
+                - persist
+            joinTable:
+                name: restaurant_product
+                inverseJoinColumns:
+                    -
+                        name: product_id
+                        referencedColumnName: id
+                joinColumns:
+                    -
+                        name: restaurant_id
+                        referencedColumnName: id
+        productOptions:
+            targetEntity: Sylius\Component\Product\Model\ProductOptionInterface
+            cascade:
+                - persist
+            joinTable:
+                name: restaurant_product_option
+                inverseJoinColumns:
+                    -
+                        name: option_id
+                        referencedColumnName: id
+                joinColumns:
+                    -
+                        name: restaurant_id
+                        referencedColumnName: id
     oneToOne:
         address:
             targetEntity: AppBundle\Entity\Address

--- a/src/AppBundle/Resources/config/doctrine/Restaurant.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Restaurant.orm.yml
@@ -162,6 +162,20 @@ AppBundle\Entity\Restaurant:
                     -
                         name: restaurant_id
                         referencedColumnName: id
+        taxons:
+            targetEntity: Sylius\Component\Taxonomy\Model\TaxonInterface
+            cascade:
+                - persist
+            joinTable:
+                name: restaurant_taxon
+                inverseJoinColumns:
+                    -
+                        name: taxon_id
+                        referencedColumnName: id
+                joinColumns:
+                    -
+                        name: restaurant_id
+                        referencedColumnName: id
     oneToOne:
         address:
             targetEntity: AppBundle\Entity\Address

--- a/src/AppBundle/Resources/config/doctrine/Sylius.Product.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Sylius.Product.orm.yml
@@ -1,0 +1,3 @@
+AppBundle\Entity\Sylius\Product:
+    type: entity
+    table: sylius_product

--- a/src/AppBundle/Resources/config/doctrine/Sylius.ProductOption.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Sylius.ProductOption.orm.yml
@@ -1,0 +1,11 @@
+AppBundle\Entity\Sylius\ProductOption:
+    type: entity
+    table: sylius_product_option
+    fields:
+        strategy:
+            type: string
+            options:
+                default: 'free'
+        price:
+            type: integer
+            nullable: true

--- a/src/AppBundle/Resources/config/doctrine/Sylius.ProductOptionValue.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Sylius.ProductOptionValue.orm.yml
@@ -1,0 +1,7 @@
+AppBundle\Entity\Sylius\ProductOptionValue:
+    type: entity
+    table: sylius_product_option_value
+    fields:
+        price:
+            type: integer
+            nullable: true

--- a/src/AppBundle/Resources/config/doctrine/Sylius.ProductTaxon.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Sylius.ProductTaxon.orm.yml
@@ -1,0 +1,38 @@
+AppBundle\Entity\Sylius\ProductTaxon:
+    type: entity
+    table: sylius_product_taxon
+    uniqueConstraints:
+        sylius_product_taxon_unique:
+            columns:
+                - product_id
+                - taxon_id
+    id:
+        id:
+            type: integer
+            id: true
+            generator:
+                strategy: IDENTITY
+    fields:
+        position:
+            type: integer
+            gedmo:
+                - sortablePosition
+    manyToOne:
+        product:
+            targetEntity: Sylius\Component\Product\Model\ProductInterface
+            joinColumns:
+                product_id:
+                    referencedColumnName: id
+                    nullable: false
+                    onDelete: CASCADE
+        taxon:
+            targetEntity: Sylius\Component\Taxonomy\Model\TaxonInterface
+            inversedBy: taxonProducts
+            orphanRemoval: true
+            joinColumns:
+                taxon_id:
+                    referencedColumnName: id
+                    nullable: false
+                    onDelete: CASCADE
+            gedmo:
+                - sortableGroup

--- a/src/AppBundle/Resources/config/doctrine/Sylius.Taxon.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Sylius.Taxon.orm.yml
@@ -1,0 +1,11 @@
+AppBundle\Entity\Sylius\Taxon:
+    type: entity
+    table: sylius_taxon
+    oneToMany:
+        taxonProducts:
+            targetEntity: AppBundle\Entity\Sylius\ProductTaxon
+            mappedBy: taxon
+            cascade:
+                - all
+            orderBy:
+                position: ASC

--- a/src/AppBundle/Resources/config/routing/admin.yml
+++ b/src/AppBundle/Resources/config/routing/admin.yml
@@ -68,6 +68,10 @@ admin_restaurant:
             success: admin_restaurant
             restaurants: admin_restaurants
             menu: admin_restaurant_menu
+            menu_taxons: admin_restaurant_menu_taxons
+            menu_taxon: admin_restaurant_menu_taxon
+            products: admin_restaurant_products
+            product_options: admin_restaurant_product_options
             dashboard: admin_restaurant_dashboard
             planning: admin_restaurant_planning
     methods: [ GET, POST ]
@@ -96,6 +100,79 @@ admin_restaurant_menu:
             restaurant: admin_restaurant
     methods: [ GET, POST ]
 
+admin_restaurant_menu_taxons:
+    path: /admin/restaurants/{id}/menus
+    defaults:
+        _controller: AppBundle:Admin:restaurantMenuTaxons
+        layout: AppBundle::admin.html.twig
+        template: AppBundle:Restaurant:menuTaxons.html.twig
+        routes:
+            restaurants: admin_restaurants
+            restaurant: admin_restaurant
+            menu: admin_restaurant_menu_taxon
+    methods: [ GET ]
+
+admin_restaurant_menu_taxon:
+    path: /admin/restaurants/{restaurantId}/menus/{menuId}
+    defaults:
+        _controller: AppBundle:Admin:restaurantMenuTaxon
+        layout: AppBundle::admin.html.twig
+        template: AppBundle:Restaurant:menuTaxon.html.twig
+        routes:
+            restaurants: admin_restaurants
+            restaurant: admin_restaurant
+            menu: admin_restaurant_menu_taxon
+            success: admin_restaurant_menu_taxons
+    methods: [ GET, POST ]
+
+admin_restaurant_new_menu_taxon:
+    path: /admin/restaurants/{id}/menus/new
+    defaults:
+        _controller: AppBundle:Admin:newRestaurantMenuTaxon
+        layout: AppBundle::admin.html.twig
+        template: AppBundle:Restaurant:menuTaxon.html.twig
+        routes:
+            restaurants: admin_restaurants
+            restaurant: admin_restaurant
+            menu: admin_restaurant_menu_taxon
+            success: admin_restaurant_menu_taxons
+    methods: [ GET, POST ]
+
+admin_restaurant_products:
+    path: /admin/restaurants/{id}/products
+    defaults:
+        _controller: AppBundle:Admin:restaurantProducts
+        layout: AppBundle::admin.html.twig
+        template: AppBundle:Restaurant:products.html.twig
+        routes:
+            restaurants: admin_restaurants
+            restaurant: admin_restaurant
+            product: admin_restaurant_product
+            new_product: admin_restaurant_product_new
+    methods: [ GET ]
+
+admin_restaurant_product_new:
+    path: /admin/restaurants/{id}/products/new
+    defaults:
+        _controller: AppBundle:Admin:newRestaurantProduct
+        layout: AppBundle::admin.html.twig
+        template: AppBundle:Restaurant:product.html.twig
+        routes:
+            restaurants: admin_restaurants
+            restaurant: admin_restaurant
+            products: admin_restaurant_products
+
+admin_restaurant_product:
+    path: /admin/restaurants/{restaurantId}/products/{productId}
+    defaults:
+        _controller: AppBundle:Admin:restaurantProduct
+        layout: AppBundle::admin.html.twig
+        template: AppBundle:Restaurant:product.html.twig
+        routes:
+            restaurants: admin_restaurants
+            restaurant: admin_restaurant
+            products: admin_restaurant_products
+
 admin_restaurant_planning:
     path: /admin/restaurants/{id}/planning
     defaults:
@@ -106,6 +183,30 @@ admin_restaurant_planning:
             restaurants: admin_restaurants
             restaurant: admin_restaurant
             success: admin_restaurant_planning
+    methods: [ GET, POST ]
+
+admin_restaurant_product_options:
+    path: /admin/restaurants/{id}/product-options
+    defaults:
+        _controller: AppBundle:Admin:restaurantProductOptions
+        layout: AppBundle::admin.html.twig
+        template: AppBundle:Restaurant:productOptions.html.twig
+        routes:
+            restaurants: admin_restaurants
+            restaurant: admin_restaurant
+            product_option: admin_restaurant_product_option
+    methods: [ GET ]
+
+admin_restaurant_product_option:
+    path: /admin/restaurants/{restaurantId}/product-options/{optionId}
+    defaults:
+        _controller: AppBundle:Admin:restaurantProductOption
+        layout: AppBundle::admin.html.twig
+        template: AppBundle:Restaurant:productOption.html.twig
+        routes:
+            restaurants: admin_restaurants
+            restaurant: admin_restaurant
+            product_options: admin_restaurant_product_options
     methods: [ GET, POST ]
 
 admin_restaurant_dashboard:

--- a/src/AppBundle/Resources/config/routing/profile.yml
+++ b/src/AppBundle/Resources/config/routing/profile.yml
@@ -44,6 +44,10 @@ profile_restaurant:
             success: profile_restaurant
             restaurants: profile_restaurants
             menu: profile_restaurant_menu
+            menu_taxons: profile_restaurant_menu_taxons
+            menu_taxon: profile_restaurant_menu_taxon
+            products: profile_restaurant_products
+            product_options: profile_restaurant_product_options
             dashboard: profile_restaurant_dashboard
             planning: profile_restaurant_planning
     methods: [ GET, POST ]
@@ -136,6 +140,79 @@ profile_restaurant_menu:
             restaurant: profile_restaurant
     methods: [ GET, POST ]
 
+profile_restaurant_menu_taxons:
+    path: /profile/restaurants/{id}/menus
+    defaults:
+        _controller: AppBundle:Profile:restaurantMenuTaxons
+        layout: AppBundle::profile.html.twig
+        template: AppBundle:Restaurant:menuTaxons.html.twig
+        routes:
+            restaurants: profile_restaurants
+            restaurant: profile_restaurant
+            menu: profile_restaurant_menu_taxon
+    methods: [ GET ]
+
+profile_restaurant_menu_taxon:
+    path: /profile/restaurants/{restaurantId}/menus/{menuId}
+    defaults:
+        _controller: AppBundle:Profile:restaurantMenuTaxon
+        layout: AppBundle::profile.html.twig
+        template: AppBundle:Restaurant:menuTaxon.html.twig
+        routes:
+            restaurants: profile_restaurants
+            restaurant: profile_restaurant
+            menu: profile_restaurant_menu_taxon
+            success: profile_restaurant_menu_taxons
+    methods: [ GET, POST ]
+
+profile_restaurant_new_menu_taxon:
+    path: /profile/restaurants/{id}/menus/new
+    defaults:
+        _controller: AppBundle:Profile:newRestaurantMenuTaxon
+        layout: AppBundle::profile.html.twig
+        template: AppBundle:Restaurant:menuTaxon.html.twig
+        routes:
+            restaurants: profile_restaurants
+            restaurant: profile_restaurant
+            menu: profile_restaurant_menu_taxon
+            success: profile_restaurant_menu_taxons
+    methods: [ GET, POST ]
+
+profile_restaurant_products:
+    path: /profile/restaurants/{id}/products
+    defaults:
+        _controller: AppBundle:Profile:restaurantProducts
+        layout: AppBundle::profile.html.twig
+        template: AppBundle:Restaurant:products.html.twig
+        routes:
+            restaurants: profile_restaurants
+            restaurant: profile_restaurant
+            product: profile_restaurant_product
+            new_product: profile_restaurant_product_new
+    methods: [ GET ]
+
+profile_restaurant_product_new:
+    path: /profile/restaurants/{id}/products/new
+    defaults:
+        _controller: AppBundle:Profile:newRestaurantProduct
+        layout: AppBundle::profile.html.twig
+        template: AppBundle:Restaurant:product.html.twig
+        routes:
+            restaurants: profile_restaurants
+            restaurant: profile_restaurant
+            products: profile_restaurant_products
+
+profile_restaurant_product:
+    path: /profile/restaurants/{restaurantId}/products/{productId}
+    defaults:
+        _controller: AppBundle:Profile:restaurantProduct
+        layout: AppBundle::profile.html.twig
+        template: AppBundle:Restaurant:product.html.twig
+        routes:
+            restaurants: profile_restaurants
+            restaurant: profile_restaurant
+            products: profile_restaurant_products
+
 profile_restaurant_planning:
     path: /profile/restaurants/{id}/planning
     defaults:
@@ -145,6 +222,30 @@ profile_restaurant_planning:
         routes:
             restaurants: profile_restaurants
             restaurant: profile_restaurant
+    methods: [ GET, POST ]
+
+profile_restaurant_product_options:
+    path: /profile/restaurants/{id}/product-options
+    defaults:
+        _controller: AppBundle:Profile:restaurantProductOptions
+        layout: AppBundle::profile.html.twig
+        template: AppBundle:Restaurant:productOptions.html.twig
+        routes:
+            restaurants: profile_restaurants
+            restaurant: profile_restaurant
+            product_option: profile_restaurant_product_option
+    methods: [ GET ]
+
+profile_restaurant_product_option:
+    path: /profile/restaurants/{restaurantId}/product-options/{optionId}
+    defaults:
+        _controller: AppBundle:Profile:restaurantProductOption
+        layout: AppBundle::profile.html.twig
+        template: AppBundle:Restaurant:productOption.html.twig
+        routes:
+            restaurants: profile_restaurants
+            restaurant: profile_restaurant
+            product_options: profile_restaurant_product_options
     methods: [ GET, POST ]
 
 profile_deliveries_calculate_price:

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -198,11 +198,21 @@ restaurant.closingForm.dates.label: Closing from/to
 
 restaurant.list.manage: Manage
 restaurant.list.orders: Orders
+restaurant.list.products: Products
+restaurant.list.product_options: Options
 restaurant.list.menu: Menu
 restaurant.list.planning: Planning
 restaurant.list.settings: Settings
 restaurant.list.norestaurant: There are no restaurants yet.
 restaurant.list.createNewRestaurant: Create a new restaurant
+
+restaurant.product_options.help: |
+  Options all products to be <strong>configurable</strong>
+  <br>
+  They allow for example to add supplements, or to choose the elements of a menu (accompaniment, drink…)
+  <br>
+  For each option, you can define a list of values
+restaurant.product_options.list.values: Values
 
 restaurant.form.uploadImage: Upload an image
 
@@ -404,6 +414,38 @@ form.menu_item_modifier.name.label: Name
 form.menu_item_modifier.price.label: Price
 form.menu_item_modifier.calculusStrategy.label: Price calculation
 
+form.menu_taxon.name.label: Name
+form.menu_taxon.add_child.label: Add section
+form.menu_taxon.child_name.placeholder: |
+  Example: main courses, desserts…
+
+form.menu_editor.products_panel.title: Products
+form.menu_editor.save.label: Save Changes
+
+form.menu_editor.help: |
+  Use the editor below to compose the menu items
+  <br>
+  Drag and drop the products into the sections on the left
+  <br>
+  Do not forget to click on the « Save Changes » button below
+
+form.product.name.label: Name
+form.product.description.label: Description
+form.product.price.label: Price
+form.product.taxCategory.label: Taxes
+form.product.enabled.label: Enabled
+
+form.product_option.name.label: Name
+form.product_option.strategy.label: Price calculation
+form.product_option.price.label: Price
+
+form.product_option_value.value.label: Value
+form.product_option_value.price.label: Price
+
+product_option.strategy.STRATEGY_FREE: Free
+product_option.strategy.STRATEGY_OPTION: Fixed price whatever the choice
+product_option.strategy.STRATEGY_OPTION_VALUE: Price according to the choice
+
 cart.modal.title: Warning
 cart.modal.content: You started an order in another restaurant. Are you sure you want to start a new order in this restaurant ?
 cart.modal.confirm: Add
@@ -456,3 +498,5 @@ pagination.next: Next
 
 basics.save: Save
 basics.powered_by: Powered by <a href="https://coopcycle.org">CoopCycle</a>
+basics.add: Add
+basics.edit: Edit

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -198,11 +198,21 @@ restaurant.closingForm.dates.label: Cerrado de/hasta
 
 restaurant.list.manage: Gestionar
 restaurant.list.orders: Pedidos
+restaurant.list.products: Productos
+restaurant.list.product_options: Opciones
 restaurant.list.menu: Carta
 restaurant.list.planning: Calendario
 restaurant.list.settings: Ajustes
 restaurant.list.norestaurant: Aún no existen restaurantes.
 restaurant.list.createNewRestaurant: Crear restaurante
+
+restaurant.product_options.help: |
+  Las opciones hacen que los productos sean <strong>configurables</strong>
+  <br>
+  Permiten, por ejemplo, agregar suplementos o elegir los elementos de un menú (acompañamiento, bebida…)
+  <br>
+  Para cada opción, puede definir una lista de valores
+restaurant.product_options.list.values: Valores
 
 restaurant.form.uploadImage: Subir una imagen
 restaurant.form.add: Añadir
@@ -406,6 +416,38 @@ form.menu_item_modifier.name.label: Nombre
 form.menu_item_modifier.price.label: Precio
 form.menu_item_modifier.calculusStrategy.label: Cálculo del precio
 
+form.menu_taxon.name.label: Nombre
+form.menu_taxon.add_child.label: Añadir una sección
+form.menu_taxon.child_name.placeholder: |
+  Ejemplo : platos, postres…
+
+form.menu_editor.products_panel.title: Productos
+form.menu_editor.save.label: Guardar cambios
+
+form.menu_editor.help: |
+  Use el editor a continuación para componer los elementos del menú
+  <br>
+  Arrastra y suelta los productos en las secciones de la izquierda
+  <br>
+  No olvides hacer clic en el botón « Guardar cambios » a continuación
+
+form.product.name.label: Nombre
+form.product.description.label: Descripción
+form.product.price.label: Precio
+form.product.taxCategory.label: Impuestos
+form.product.enabled.label: Activado
+
+form.product_option.name.label: Nombre
+form.product_option.strategy.label: Cálculo del precio
+form.product_option.price.label: Precio
+
+form.product_option_value.value.label: Valor
+form.product_option_value.price.label: Precio
+
+product_option.strategy.STRATEGY_FREE: Gratis
+product_option.strategy.STRATEGY_OPTION: Precio fijo sea cual sea la elección
+product_option.strategy.STRATEGY_OPTION_VALUE: Precio según la elección
+
 cart.modal.title: Atención
 cart.modal.content: Ya has iniciado un pedido en otro restaurante. ¿Seguro que quieres iniciar un pedido nuevo en éste restaurante?
 cart.modal.confirm: Confirmar
@@ -457,3 +499,5 @@ pagination.previous: Anterior
 pagination.next: Siguiente
 
 basics.save: Guardar
+basics.add: Añadir
+basics.edit: Modificar

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -193,11 +193,21 @@ restaurant.closingForm.dates.label: Fermeture de/à
 
 restaurant.list.manage: Gérer
 restaurant.list.orders: Commandes
+restaurant.list.products: Produits
+restaurant.list.product_options: Options
 restaurant.list.menu: Menu
 restaurant.list.planning: Planning
 restaurant.list.settings: Paramètres
 restaurant.list.norestaurant: Pas de restaurant pour le moment
 restaurant.list.createNewRestaurant: Créer un restaurant
+
+restaurant.product_options.help: |
+  Les options permettent de rendre les produits <strong>configurables</strong>
+  <br>
+  Ils permettent par exemple d'ajouter des suppléments, ou de choisir les éléments d'un menu (accompagnement, boisson…)
+  <br>
+  Pour chaque option, vous pouvez définir une liste de valeurs
+restaurant.product_options.list.values: Valeurs
 
 restaurant.form.uploadImage: Uploader une image
 
@@ -429,6 +439,38 @@ form.menu_item_modifier.name.label: Nom du groupe
 form.menu_item_modifier.price.label: Prix
 form.menu_item_modifier.calculusStrategy.label: Coût du supplément
 
+form.menu_taxon.name.label: Nom
+form.menu_taxon.add_child.label: Ajouter une section
+form.menu_taxon.child_name.placeholder: |
+  Exemple : plats, desserts…
+
+form.menu_editor.products_panel.title: Produits
+form.menu_editor.save.label: Enregistrer les modifications
+
+form.menu_editor.help: |
+  Utilisez l'éditeur ci-dessous pour composer les élements du menu
+  <br>
+  Glissez-déposez les produits dans les sections sur la gauche
+  <br>
+  N'oubliez pas de cliquer sur le bouton « Enregistrer les modifications » ci-dessous
+
+form.product.name.label: Nom
+form.product.description.label: Description
+form.product.price.label: Prix
+form.product.taxCategory.label: Taxes
+form.product.enabled.label: Activé
+
+form.product_option.name.label: Nom
+form.product_option.strategy.label: Calcul du prix
+form.product_option.price.label: Prix
+
+form.product_option_value.value.label: Valeur
+form.product_option_value.price.label: Prix
+
+product_option.strategy.STRATEGY_FREE: Gratuit
+product_option.strategy.STRATEGY_OPTION: Prix fixe quelque soit le choix
+product_option.strategy.STRATEGY_OPTION_VALUE: Prix en fonction du choix
+
 cart.modal.title: Attention
 cart.modal.content: Vous avez commencé votre commande dans un autre restaurant. Souhaitez vous commencer une nouvelle commande dans ce restaurant ?
 cart.modal.confirm: Commencer une nouvelle commande
@@ -480,6 +522,8 @@ basics.save: Enregister
 basics.next: Suivant
 basics.continue: Continuer
 basics.powered_by: Propulsé par <a href="https://coopcycle.org">CoopCycle</a>
+basics.edit: Modifier
+basics.add: Ajouter
 
 adminDashboard.embed.title: Intégration
 

--- a/src/AppBundle/Resources/views/Form/menuEditor.html.twig
+++ b/src/AppBundle/Resources/views/Form/menuEditor.html.twig
@@ -1,0 +1,13 @@
+{% extends "form_div_layout.html.twig" %}
+
+{% block _menu_editor_children_entry_widget %}
+  {% set attr = attr|merge({'data-taxon-id': form.vars.value.id }) %}
+  {{ block('form_widget') }}
+{% endblock %}
+
+{% block _menu_editor_children_entry_taxonProducts_entry_row %}
+  <div>
+    {{ form_widget(form.product) }}
+    {{ form_widget(form.position) }}
+  </div>
+{% endblock %}

--- a/src/AppBundle/Resources/views/Form/product.html.twig
+++ b/src/AppBundle/Resources/views/Form/product.html.twig
@@ -1,0 +1,34 @@
+{% extends 'bootstrap_3_layout.html.twig' %}
+
+{% block _product_variants_entry_row %}
+
+  {% set values = [] %}
+  {% for optionValue in form.vars.data.optionValues %}
+    {% set values = values|merge([ optionValue.value ]) %}
+  {% endfor %}
+
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      {% if values|length > 0 %}
+        {{ values|join(' + ') }}
+      {% else %}
+        Default
+      {% endif %}
+      <span class="pull-right">{{ form.vars.data.code }}</span>
+    </div>
+    <div class="panel-body">
+      <div class="row">
+        <div class="col-sm-4">
+          {{ form_row(form.name) }}
+        </div>
+        <div class="col-sm-4">
+          {{ form_row(form.price) }}
+        </div>
+        <div class="col-sm-4">
+          {{ form_row(form.taxCategory) }}
+        </div>
+      </div>
+    </div>
+  </div>
+
+{% endblock %}

--- a/src/AppBundle/Resources/views/Form/productOption.html.twig
+++ b/src/AppBundle/Resources/views/Form/productOption.html.twig
@@ -1,0 +1,22 @@
+{% extends 'bootstrap_3_layout.html.twig' %}
+
+{% block _product_option_values_entry_row %}
+  <div class="row">
+    <div class="col-sm-6">
+      {{ form_row(form.translations, { label: false }) }}
+    </div>
+    <div class="col-sm-6">
+      {{ form_row(form.price) }}
+    </div>
+  </div>
+
+{% endblock %}
+
+{% block _product_option_values_entry_translations_entry_row %}
+  {{ form_widget(form) }}
+{% endblock %}
+
+{% block _product_option_values_widget %}
+  {{ form_widget(form) }}
+  <button type="button" class="btn btn-success" id="add-option-value">Add a value</button>
+{% endblock %}

--- a/src/AppBundle/Resources/views/Restaurant/form.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/form.html.twig
@@ -29,9 +29,25 @@
     <div class="collapse navbar-collapse" id="restaurant-navbar">
       <div class="nav navbar-nav navbar-right">
         {% if restaurant.id is not empty %}
-          <a href="{{ path(menu_route, { id: restaurant.id }) }}" class="btn btn-default navbar-btn">
+          <a href="{{ path(products_route, { id: restaurant.id }) }}" class="btn btn-default navbar-btn">
+            <i class="fa fa-database"></i>  {% trans %}restaurant.list.products{% endtrans %}
+          </a>
+          <a href="{{ path(product_options_route, { id: restaurant.id }) }}" class="btn btn-default navbar-btn">
+            <i class="fa fa-sliders"></i>  {% trans %}restaurant.list.product_options{% endtrans %}
+          </a>
+
+          {% if restaurant.menuTaxon is not null %}
+          <a href="{{ path(menu_taxon_route, { restaurantId: restaurant.id, menuId: restaurant.menuTaxon.id }) }}"
+            class="btn btn-default navbar-btn">
             <i class="fa fa-cutlery"></i>  {% trans %}restaurant.list.menu{% endtrans %}
           </a>
+          {% else %}
+          <a href="{{ path(menu_taxons_route, { id: restaurant.id }) }}"
+            class="btn btn-default navbar-btn">
+            <i class="fa fa-cutlery"></i>  {% trans %}restaurant.list.menu{% endtrans %}
+          </a>
+          {% endif %}
+
           <a href="{{ path(dashboard_route, { restaurantId: restaurant.id }) }}" class="btn btn-default navbar-btn">
             <i class="fa fa-cube"></i>  {% trans %}restaurant.list.orders{% endtrans %}
           </a>

--- a/src/AppBundle/Resources/views/Restaurant/index.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/index.html.twig
@@ -37,12 +37,13 @@
   <div class="row">
 
     <div class="col-xs-12 col-sm-8">
-
-      {% for menuSection in restaurant.menu.sections %}
-        <h2>{{ menuSection.name }}</h2>
+      {% for child in restaurant.menuTaxon.children %}
+        <h2>{{ child.name }}</h2>
         <div class="list-group">
-          {% for menuItem in menuSection.items %}
-            {% if not menuItem.isAvailable %}
+          {% for product in child.products %}
+            {% set variant = product|sylius_resolve_variant %}
+            {# TODO Skip if no variant is defined #}
+            {% if not product.enabled %}
               <a class="list-group-item menu-item menu-item--unavailable">
                 <span class="menu-item-content">{{ menuItem.name }}</span>
                 {% if menuItem.description is not null %}
@@ -52,21 +53,21 @@
               </a>
             {% else %}
               <a  class="list-group-item menu-item"
-                  data-menu-item-id="{{ menuItem.id }}"
-                  data-menu-item-has-modifiers="{{ (menuItem.modifiers.count > 0) ? 'true' : 'false' }}"
-                  {% if menuItem.modifiers.count > 0 %}
-                  data-toggle="modal"
-                  data-target="#{{ menuItem.id }}-modifiersModal"
-                  href="#"
+                  {% if product.simple %}
+                  data-product-code="{{ product.code }}"
+                  href="{{ path('restaurant_add_product_to_cart', { id: restaurant.id, code: product.code }) }}"
                   {% else %}
-                  href="{{ path('restaurant_add_menu_item_to_cart', { restaurantId: restaurant.id, menuItemId: menuItem.id }) }}"
+                  data-toggle="modal"
+                  data-target="#{{ product.code }}-options"
+                  href="#"
                   {% endif %}>
-                <span class="menu-item-content">{{ menuItem.name }}
-                  {% if menuItem.description is not null %}
-                    <small class="menu-item-description">{{ menuItem.description }}</small>
+                <span class="menu-item-content">
+                  {{ product.name }}
+                  {% if product.description is not null %}
+                    <small class="menu-item-description">{{ product.description }}</small>
                   {%  endif %}
                 </span>
-                <span class="menu-item-price">{{ menuItem.price|number_format(2) }} €</span>
+                <span class="menu-item-price">{{ variant.price|price_format }} €</span>
               </a>
             {% endif %}
           {% endfor %}
@@ -87,35 +88,37 @@
 
 {# Modals for modifiers #}
 
-{% for menuSection in restaurant.menu.sections %}
-  {% for menuItem in menuSection.items %}
-    {% if menuItem.isAvailable and menuItem.modifiers.count > 0 %}
-    <div id="{{ menuItem.id }}-modifiersModal" class="modal modifier-modal fade">
+{% for child in restaurant.menuTaxon.children %}
+  {% for product in child.products %}
+    {% if product.enabled and not product.simple %}
+    <div id="{{ product.code }}-options" class="modal modifier-modal fade">
       <div class="modal-dialog" role="document">
         <div class="modal-content">
           <div class="modal-header">
             <button type="button" class="close" data-dismiss="modal" aria-label="Close">
               <span aria-hidden="true">&times;</span>
             </button>
-            <h4 class="modal-title">{{ menuItem.name }}</h4>
+            <h4 class="modal-title">{{ product.name }}</h4>
           </div>
           <div class="modal-body">
             <form
-              action="{{ path('restaurant_add_menu_item_to_cart', { restaurantId: restaurant.id, menuItemId: menuItem.id }) }}"
-              data-menu-item-modifier>
-              {% for modifier in menuItem.modifiers %}
-              <h4>{{ modifier.name }}
-                {% if modifier.calculusStrategy == 'ADD_MODIFIER_PRICE' %} - {{ modifier.price }}€{% endif %}
+              action="{{ path('restaurant_add_product_to_cart', { id: restaurant.id, code: product.code }) }}"
+              data-product-options>
+              {% for option in product.options %}
+              <h4>
+                {{ option.name }}
+                {% if option.strategy == 'option' %} - {{ option.price }}€{% endif %}
               </h4>
               <div class="list-group">
-                {% for choice in modifier.modifierChoices %}
+                {% for option_value in option.values %}
                   <div class="list-group-item menu-item modifier-item">
                     <div class="radio nomargin">
-                      <label for="{{ choice.id }}-choice">
+                      <label>
                         <input
-                          name="modifiers[{{ modifier.id }}][]"
-                          value="{{ choice.id }}" type="radio" id="{{ choice.id }}-choice">
-                        {{ choice.name }}{% if modifier.calculusStrategy == 'ADD_MENUITEM_PRICE' %} - {{ choice.price }}€{% endif %}
+                          name="options[{{ option.code }}]"
+                          value="{{ option_value.code }}" type="radio">
+                        {{ option_value.value }}
+                        {% if option.strategy == 'option_value' %} - {{ option_value.price }}€{% endif %}
                       </label>
                     </div>
                   </div>
@@ -164,19 +167,17 @@ new CoopCycle.OpeningHoursParser(document.querySelector('#opening-hours'), {
   locale: $('html').attr('lang')
 })
 
-$('[data-menu-item-id]').on('click', function(e) {
+$('[data-product-code]').on('click', function(e) {
   e.preventDefault();
   var $target = $(e.currentTarget);
-  if (!$target.data('menuItemHasModifiers')) {
-    window.AppData.CartHelper.addMenuItem($target.attr('href'), 1);
-  }
+  window.AppData.CartHelper.addProduct($target.attr('href'), 1);
 })
 
-$('form[data-menu-item-modifier]').on('submit', function(e) {
+$('form[data-product-options]').on('submit', function(e) {
   e.preventDefault();
   var data = $(this).serializeArray();
   if (data.length > 0) {
-    window.AppData.CartHelper.addMenuItemWithModifiers($(this).attr('action'), data, 1);
+    window.AppData.CartHelper.addProductWithOptions($(this).attr('action'), data, 1);
     $(this).closest('.modal').modal('hide');
   }
 })

--- a/src/AppBundle/Resources/views/Restaurant/menuTaxon.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/menuTaxon.html.twig
@@ -1,0 +1,105 @@
+{% extends layout %}
+
+{% form_theme form 'bootstrap_3_layout.html.twig' %}
+{% form_theme menu_editor_form '@App/Form/menuEditor.html.twig' %}
+
+{% block breadcrumb %}
+  <li><a href="{{ path(restaurants_route) }}">{% trans %}adminDashboard.restaurants.title{% endtrans %}</a></li>
+  <li><a href="{{ path(restaurant_route, { id: restaurant.id }) }}">{{ restaurant.name }}</a></li>
+  <li>{% trans %}Menus{% endtrans %}</li>
+{% endblock %}
+
+{% block content %}
+
+  {% set menu = form.vars.value %}
+
+  {{ form_start(form) }}
+
+    {{ form_errors(form) }}
+
+    <div class="form-group row">
+      <div class="col-md-10">
+        {{ form_row(form.name) }}
+      </div>
+      <div class="col-md-2">
+        <label> </label>
+        <button id="menu_taxon_save" type="submit" class="btn btn-block btn-primary">{{ 'basics.save'|trans }}</button>
+      </div>
+    </div>
+
+    {% if menu.id is not null %}
+      <div class="form-group row">
+        <div class="col-md-10">
+          {{ form_widget(form.childName) }}
+        </div>
+        <div class="col-md-2">
+          {{ form_widget(form.addChild, { attr: { class: 'btn btn-block btn-success' } }) }}
+        </div>
+      </div>
+    {% endif %}
+
+  {{ form_end(form) }}
+
+  {% if menu.id is not null %}
+
+    {{ form_start(menu_editor_form) }}
+
+    <div class="alert alert-info">
+      <i class="fa fa-info-circle"></i> {% trans %}form.menu_editor.help{% endtrans %}
+    </div>
+
+    <div class="menuEditor">
+      <div class="menuEditor__left">
+        {% for child in menu_editor_form.children %}
+          <div class="menuEditor__panel">
+            <h4 class="menuEditor__panel__title">{{ child.vars.value.name }}</h4>
+            <div class="menuEditor__panel__body" data-draggable-target data-taxon-id="{{ child.vars.value.id }}">
+              {% for product in child.vars.value.products %}
+              <div class="menuEditor__product" data-product-id="{{ product.id }}">
+                {{ product.name }}
+              </div>
+              {% endfor %}
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+      <div class="menuEditor__right">
+        <div class="menuEditor__panel menuEditor__productList">
+          <h4 class="menuEditor__panel__title">
+            {{ 'form.menu_editor.products_panel.title'|trans }}
+          </h4>
+          <div class="menuEditor__panel__body" data-draggable-source>
+            {% for product in menu_editor_form.vars.value.products %}
+              <div class="menuEditor__product" data-product-id="{{ product.id }}">
+                {{ product.name }}
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <button type="submit" class="btn btn-block btn-lg btn-primary">
+      {{ 'form.menu_editor.save.label'|trans }}
+    </button>
+
+    {# Useful for debugging #}
+    {% set debug_menu_editor = false %}
+    <div class="{% if not debug_menu_editor %}hidden{% endif %}">
+    {{ form_widget(menu_editor_form.children, { label: false }) }}
+    </div>
+
+    {{ form_end(menu_editor_form) }}
+
+  {% endif %}
+
+{% endblock %}
+
+{% block scripts %}
+<script>
+$('#menu_taxon_save').on('click', function(e) {
+  $('#menu_taxon_childName').removeAttr('required')
+});
+</script>
+<script src="{{ asset('js/restaurant-menu-editor.js') }}"></script>
+{% endblock %}

--- a/src/AppBundle/Resources/views/Restaurant/menuTaxons.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/menuTaxons.html.twig
@@ -1,0 +1,27 @@
+{% extends layout %}
+
+{% block breadcrumb %}
+  <li><a href="{{ path(restaurants_route) }}">{% trans %}adminDashboard.restaurants.title{% endtrans %}</a></li>
+  <li><a href="{{ path(restaurant_route, { id: restaurant.id }) }}">{{ restaurant.name }}</a></li>
+  <li>{% trans %}Menus{% endtrans %}</li>
+{% endblock %}
+
+{% block content %}
+  {% if menus|length > 0 %}
+  <table class="table">
+    <thead>
+      <th>Name</th>
+    </thead>
+    <tbody>
+      {% for menu in menus %}
+      <tr>
+        <td><a href="{{ path(menu_route, { restaurantId: restaurant.id, menuId: menu.id }) }}">{{ menu.name }}</a></td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+    <div class="alert alert-warning">No menus found</div>
+  {% endif %}
+
+{% endblock %}

--- a/src/AppBundle/Resources/views/Restaurant/product.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/product.html.twig
@@ -1,0 +1,50 @@
+{% extends layout %}
+
+{% form_theme form '@App/Form/product.html.twig' %}
+
+{% block breadcrumb %}
+  <li><a href="{{ path(restaurants_route) }}">{% trans %}adminDashboard.restaurants.title{% endtrans %}</a></li>
+  <li><a href="{{ path(restaurant_route, { id: restaurant.id }) }}">{{ restaurant.name }}</a></li>
+  <li><a href="{{ path(products_route, { id: restaurant.id }) }}">{{ 'restaurant.list.products'|trans }}</a></li>
+  <li>{{ product.name }}</li>
+{% endblock %}
+
+{% block content %}
+{{ form_start(form) }}
+
+  {{ form_row(form.name) }}
+  {{ form_row(form.description) }}
+  {{ form_row(form.enabled) }}
+
+  <div class="row">
+    <div class="col-sm-6">
+      {{ form_row(form.price) }}
+    </div>
+    <div class="col-sm-6">
+      {{ form_row(form.taxCategory) }}
+    </div>
+  </div>
+
+  {{ form_row(form.options) }}
+
+  {% set debug_variants = false %}
+  <div class="{% if not debug_variants %}hidden{% endif %}">
+    {{ form_widget(form.variants) }}
+  </div>
+
+  <button type="submit" class="btn btn-block btn-primary">{{ 'basics.save'|trans }}</button>
+{{ form_end(form) }}
+{% endblock %}
+
+{% block scripts %}
+<script>
+$("#product_variants input[name$='[price]']").val($('#product_price').val());
+$("#product_variants input[name$='[taxCategory]']").val($('#product_taxCategory').val());
+$('#product_price').on('change', function(e) {
+  $("#product_variants input[name$='[price]']").val($(this).val());
+});
+$('#product_taxCategory').on('change', function(e) {
+  $("#product_variants select[name$='[taxCategory]']").val($(this).val());
+});
+</script>
+{% endblock %}

--- a/src/AppBundle/Resources/views/Restaurant/productOption.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/productOption.html.twig
@@ -1,0 +1,69 @@
+{% extends layout %}
+
+{% form_theme form '@App/Form/productOption.html.twig' %}
+
+{% block breadcrumb %}
+  <li><a href="{{ path(restaurants_route) }}">{% trans %}adminDashboard.restaurants.title{% endtrans %}</a></li>
+  <li><a href="{{ path(restaurant_route, { id: restaurant.id }) }}">{{ restaurant.name }}</a></li>
+  <li><a href="{{ path(product_options_route, { id: restaurant.id }) }}">{% trans %}restaurant.list.product_options{% endtrans %}</a></li>
+  <li>{{ product_option.name }}</li>
+{% endblock %}
+
+{% block content %}
+{{ form_start(form) }}
+  {{ form_row(form.name) }}
+  {{ form_row(form.strategy) }}
+  {{ form_row(form.price) }}
+  <hr>
+  {{ form_widget(form.values) }}
+  <hr>
+  {# {{ form_widget(form) }} #}
+  <button type="submit" class="btn btn-block btn-primary">Save</button>
+{{ form_end(form) }}
+{% endblock %}
+
+{% block scripts %}
+<script>
+
+if ($('#product_option_strategy').val() !== 'option') {
+  $('#product_option_price').closest('.form-group').hide();
+}
+
+if ($('#product_option_strategy').val() !== 'option_value') {
+  $('#product_option_values').find("input[name$='[price]']").closest('.form-group').hide();
+}
+
+$('#product_option_strategy').on('change', function(e) {
+  var value = $(this).val();
+  if (value === 'option') {
+    $('#product_option_price').closest('.form-group').show();
+  } else {
+    $('#product_option_price').closest('.form-group').hide();
+  }
+  if (value === 'option_value') {
+    $('#product_option_values').find("input[name$='[price]']").closest('.form-group').show();
+  } else {
+    $('#product_option_values').find("input[name$='[price]']").closest('.form-group').hide();
+  }
+});
+
+$('#add-option-value').on('click', function(e) {
+
+  e.preventDefault();
+
+  var prototype = $('#product_option_values').data('prototype');
+  var index = $('#product_option_values').children().length;
+
+  var form = prototype.replace(/__name__/g, index);
+  var $form = $(form);
+
+  if ($('#product_option_strategy').val() !== 'option_value') {
+    $form.find("input[name$='[price]']").closest('.form-group').hide();
+  }
+
+  $('#product_option_values').append($form);
+
+});
+
+</script>
+{% endblock %}

--- a/src/AppBundle/Resources/views/Restaurant/productOptions.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/productOptions.html.twig
@@ -1,0 +1,34 @@
+{% extends layout %}
+
+{% block breadcrumb %}
+  <li><a href="{{ path(restaurants_route) }}">{% trans %}adminDashboard.restaurants.title{% endtrans %}</a></li>
+  <li><a href="{{ path(restaurant_route, { id: restaurant.id }) }}">{{ restaurant.name }}</a></li>
+  <li>{% trans %}restaurant.list.product_options{% endtrans %}</li>
+{% endblock %}
+
+{% block content %}
+<div class="alert alert-info">
+  <i class="fa fa-info-circle"></i> {% trans %}restaurant.product_options.help{% endtrans %}
+</div>
+<table class="table">
+  <thead>
+    <th>{{ 'form.product_option.name.label'|trans }}</th>
+    <th>{{ 'form.product_option.strategy.label'|trans }}</th>
+    <th class="text-right">{{ 'restaurant.product_options.list.values'|trans }}</th>
+    <th></th>
+  </thead>
+  <tbody>
+    {% for option in options %}
+    <tr>
+      <td>{{ option.name }}</td>
+      <td>{{ option.strategy }}</td>
+      <td class="text-right">{{ option.values|length }}</td>
+      <td class="text-right">
+        <a href="{{ path(product_option_route, { restaurantId: restaurant.id, optionId: option.id }) }}"
+          class="btn btn-xs btn-default"><i class="fa fa-pencil"></i> {{ 'basics.edit'|trans }}</a>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/src/AppBundle/Resources/views/Restaurant/products.html.twig
+++ b/src/AppBundle/Resources/views/Restaurant/products.html.twig
@@ -1,0 +1,39 @@
+{% extends layout %}
+
+{% block breadcrumb %}
+  <li><a href="{{ path(restaurants_route) }}">{% trans %}adminDashboard.restaurants.title{% endtrans %}</a></li>
+  <li><a href="{{ path(restaurant_route, { id: restaurant.id }) }}">{{ restaurant.name }}</a></li>
+  <li>{% trans %}restaurant.list.products{% endtrans %}</li>
+{% endblock %}
+
+{% block content %}
+<p class="text-right">
+  <a href="{{ path(new_product_route, { id: restaurant.id }) }}"
+    class="btn btn-success"><i class="fa fa-plus"></i> {{ 'basics.add'|trans }}</a>
+</p>
+<table class="table">
+  <thead>
+    <th>{{ 'form.product.name.label'|trans }}</th>
+    <th class="text-right">Options</th>
+    <th class="text-right">Variants</th>
+    <th class="text-right">{{ 'form.product.enabled.label'|trans }}</th>
+    <th></th>
+  </thead>
+  <tbody>
+    {% for product in products %}
+    <tr>
+      <td>{{ product.name }}</td>
+      <td class="text-right">{{ product.options|length }}</td>
+      <td class="text-right">{{ product.variants|length }}</td>
+      <td class="text-right">
+        {% if product.enabled %}<i class="fa fa-check"></i>{% endif %}
+      </td>
+      <td class="text-right">
+        <a href="{{ path(product_route, { restaurantId: restaurant.id, productId: product.id }) }}"
+          class="btn btn-xs btn-default"><i class="fa fa-pencil"></i> {{ 'basics.edit'|trans }}</a>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/src/AppBundle/Sylius/Product/ProductInterface.php
+++ b/src/AppBundle/Sylius/Product/ProductInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AppBundle\Sylius\Product;
+
+use AppBundle\Entity\Restaurant;
+use Sylius\Component\Product\Model\ProductInterface as BaseProductInterface;
+
+interface ProductInterface extends BaseProductInterface
+{
+    const STRATEGY_FREE = 'free';
+    const STRATEGY_OPTION = 'option';
+    const STRATEGY_OPTION_VALUE = 'option_value';
+
+    /**
+     * @return Restaurant
+     */
+    public function getRestaurant(): ?Restaurant;
+
+    /**
+     * @param Restaurant $restaurant
+     */
+    public function setRestaurant(?Restaurant $restaurant): void;
+}

--- a/src/AppBundle/Sylius/Product/ProductOptionInterface.php
+++ b/src/AppBundle/Sylius/Product/ProductOptionInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace AppBundle\Sylius\Product;
+
+use Sylius\Component\Product\Model\ProductOptionInterface as BaseProductOptionInterface;
+
+interface ProductOptionInterface extends BaseProductOptionInterface
+{
+    const STRATEGY_FREE = 'free';
+    const STRATEGY_OPTION = 'option';
+    const STRATEGY_OPTION_VALUE = 'option_value';
+
+    /**
+     * @return string
+     */
+    public function getStrategy(): string;
+
+    /**
+     * @param string|null $strategy
+     */
+    public function setStrategy(string $strategy): void;
+
+    /**
+     * @return int|null
+     */
+    public function getPrice(): ?int;
+
+    /**
+     * @param int|null $price
+     */
+    public function setPrice(?int $price): void;
+}

--- a/src/AppBundle/Sylius/Product/ProductOptionValueInterface.php
+++ b/src/AppBundle/Sylius/Product/ProductOptionValueInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace AppBundle\Sylius\Product;
+
+use Sylius\Component\Product\Model\ProductOptionValueInterface as BaseProductOptionValueInterface;
+
+interface ProductOptionValueInterface extends BaseProductOptionValueInterface
+{
+    /**
+     * @return int|null
+     */
+    public function getPrice(): ?int;
+
+    /**
+     * @param int|null $price
+     */
+    public function setPrice(?int $price): void;
+}

--- a/src/AppBundle/Twig/CoopCycleExtension.php
+++ b/src/AppBundle/Twig/CoopCycleExtension.php
@@ -11,6 +11,7 @@ class CoopCycleExtension extends \Twig_Extension
             new \Twig_SimpleFilter('seconds_to_minutes', array($this, 'secondsToMinutes')),
             new \Twig_SimpleFilter('price_format', array($this, 'priceFormat')),
             new \Twig_SimpleFilter('order_can_transition', array(OrderStateResolver::class, 'orderCanTransitionFilter')),
+            new \Twig_SimpleFilter('sylius_resolve_variant', array(SyliusVariantResolver::class, 'resolveVariant')),
         );
     }
 

--- a/src/AppBundle/Twig/SyliusVariantResolver.php
+++ b/src/AppBundle/Twig/SyliusVariantResolver.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AppBundle\Twig;
+
+use Sylius\Component\Product\Model\ProductInterface;
+use Sylius\Component\Product\Model\ProductVariantInterface;
+use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
+
+class SyliusVariantResolver
+{
+    private $productVariantResolver;
+
+    public function __construct(ProductVariantResolverInterface $productVariantResolver)
+    {
+        $this->productVariantResolver = $productVariantResolver;
+    }
+
+    public function resolveVariant(ProductInterface $product): ?ProductVariantInterface
+    {
+        return $this->productVariantResolver->getVariant($product);
+    }
+}

--- a/src/AppBundle/Utils/MenuEditor.php
+++ b/src/AppBundle/Utils/MenuEditor.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace AppBundle\Utils;
+
+use AppBundle\Entity\Restaurant;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
+class MenuEditor
+{
+    private $restaurant;
+    private $menu;
+
+    public function __construct(Restaurant $restaurant, $menu)
+    {
+        $this->restaurant = $restaurant;
+        $this->menu = $menu;
+    }
+
+    public function getChildren()
+    {
+        return $this->menu->getChildren();
+    }
+
+    public function getProducts()
+    {
+        $products = new ArrayCollection();
+        foreach ($this->restaurant->getProducts() as $product) {
+            $products->add($product);
+        }
+        foreach ($this->menu->getChildren() as $child) {
+            foreach ($child->getProducts() as $product) {
+                $products->removeElement($product);
+            }
+        }
+
+        return $products;
+    }
+
+    public function setProducts(Collection $products)
+    {
+        $this->products = $products;
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,7 @@ Encore
   .addEntry('js/notifications', './js/app/notifications/index.js')
   .addEntry('js/restaurant-form', './js/app/restaurant/form.jsx')
   .addEntry('js/restaurant-menu', './js/app/restaurant/menu.jsx')
+  .addEntry('js/restaurant-menu-editor', './js/app/restaurant/menu-editor.js')
   .addEntry('js/restaurant-planning', './js/app/restaurant/planning.jsx')
   .addEntry('js/restaurant-panel', './js/app/restaurant/panel.jsx')
   .addEntry('js/restaurants-map', './js/app/restaurants-map/index.jsx')


### PR DESCRIPTION
Another step towards using Sylius to manage all the e-commerce stuff!

Product options have been customized to store price customizations (see #319)
The migrations _should_ recreate everything in the new table system. 

But the main feature is that **menus are now managed with taxonomies**! 🚀

It allows: 
- to decouple products from menus
- to have several menus per restaurant
- to switch between menus without having to remove items

![menu_editor](https://user-images.githubusercontent.com/1162230/40030021-5fef0b58-57e8-11e8-8c54-39755dea09c5.gif)
