### PR TITLE
Refactor API to handle products & options

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -259,9 +259,10 @@ services:
     class: AppBundle\Serializer\JsonLd\OrderNormalizer
     arguments:
       - "@api_platform.jsonld.normalizer.item"
-      - "@api_platform.iri_converter"
       - "@coopcycle.sylius.factory.order"
-      - "@sylius.repository.product_variant"
+      - "@sylius.repository.product"
+      - "@sylius.repository.product_option_value"
+      - "@sylius.product_variant_resolver.default"
       - "@sylius.factory.order_item"
       - "@sylius.order_item_quantity_modifier"
       - "@sylius.order_modifier"
@@ -279,6 +280,13 @@ services:
       - "@serializer.normalizer.object"
       - "@router"
       - "@translator"
+    tags: [ { name: serializer.normalizer, priority: 128 } ]
+
+  coopcycle.normalizer.restaurant_menu.jsonld:
+    class: AppBundle\Serializer\JsonLd\RestaurantMenuNormalizer
+    arguments:
+      - "@api_platform.jsonld.normalizer.item"
+      - "@sylius.locale_provider"
     tags: [ { name: serializer.normalizer, priority: 128 } ]
 
   'AppBundle\Form\DeliveryType':

--- a/features/fixtures/ORM/products.yml
+++ b/features/fixtures/ORM/products.yml
@@ -1,0 +1,83 @@
+Sylius\Component\Taxation\Model\TaxCategory:
+  tva_conso_immediate:
+    code: tva_conso_immediate
+    name: "TVA consommation immédiate"
+  tva_livraison:
+    code: tva_livraison
+    name: "TVA livraison"
+
+Sylius\Component\Taxation\Model\TaxRate:
+  tva_10:
+    name: "TVA 10%"
+    code: tva_10
+    category: "@tva_conso_immediate"
+    amount: 0.10
+    includedInPrice: true
+    calculator: float
+  tva_20:
+    name: "TVA 20%"
+    code: tva_20
+    category: "@tva_livraison"
+    amount: 0.20
+    includedInPrice: true
+    calculator: float
+
+AppBundle\Entity\Sylius\ProductOptionValue:
+  pizza_topping_pepperoni:
+    code: PIZZA_TOPPING_PEPPERONI
+    currentLocale: fr
+    value: Pepperoni
+  pizza_topping_extra_cheese:
+    code: PIZZA_TOPPING_EXTRA_CHEESE
+    currentLocale: fr
+    value: Extra cheese
+
+AppBundle\Entity\Sylius\ProductOption:
+  pizza_topping:
+    code: PIZZA_TOPPING
+    strategy: free
+    currentLocale: fr
+    name: Pizza topping
+    values: [ "@pizza_topping_pepperoni", "@pizza_topping_extra_cheese" ]
+
+AppBundle\Entity\Sylius\ProductVariant:
+  pizza_pepperoni:
+    taxCategory: "@tva_conso_immediate"
+    currentLocale: fr
+    name: Pizza Pepperoni
+    code: PIZZA_PEPPERONI
+    price: 900
+    optionValues: [ "@pizza_topping_pepperoni" ]
+  pizza_extra_cheese:
+    taxCategory: "@tva_conso_immediate"
+    currentLocale: fr
+    name: Pizza Extra Cheese
+    code: PIZZA_EXTRA_CHEESE
+    price: 900
+    optionValues: [ "@pizza_topping_extra_cheese" ]
+  hamburger_default:
+    taxCategory: "@tva_conso_immediate"
+    currentLocale: fr
+    name: Hamburger
+    code: HAMBURGER_DEFAULT
+    price: 900
+
+AppBundle\Entity\Sylius\Product:
+  pizza:
+    code: PIZZA
+    currentLocale: fr
+    name: Pizza
+    slug: pizza
+    enabled: true
+    options: [ "@pizza_topping" ]
+    variants: [ "@pizza_pepperoni", "@pizza_extra_cheese" ]
+  hamburger:
+    code: HAMBURGER
+    currentLocale: fr
+    name: Hamburger
+    slug: hamburger
+    enabled: true
+    variants: [ "@hamburger_default" ]
+  salad:
+    code: SALAD
+    enabled: true

--- a/features/fixtures/ORM/restaurants.yml
+++ b/features/fixtures/ORM/restaurants.yml
@@ -1,27 +1,3 @@
-Sylius\Component\Taxation\Model\TaxCategory:
-  tva_conso_immediate:
-    code: tva_conso_immediate
-    name: "TVA consommation immédiate"
-  tva_livraison:
-    code: tva_livraison
-    name: "TVA livraison"
-
-Sylius\Component\Taxation\Model\TaxRate:
-  tva_10:
-    name: "TVA 10%"
-    code: tva_10
-    category: "@tva_conso_immediate"
-    amount: 0.10
-    includedInPrice: true
-    calculator: float
-  tva_20:
-    name: "TVA 20%"
-    code: tva_20
-    category: "@tva_livraison"
-    amount: 0.20
-    includedInPrice: true
-    calculator: float
-
 AppBundle\Entity\Base\GeoCoordinates:
   geo_1:
     __construct: [ "48.864577", "2.333338" ]
@@ -29,36 +5,6 @@ AppBundle\Entity\Base\GeoCoordinates:
     __construct: [ "48.846656", "2.369052" ]
   geo_3:
     __construct: [ "48.878658", "2.341055" ]
-
-AppBundle\Entity\Menu\MenuItem:
-  menu_item_{1..9}:
-    name: <name()>
-    price: <numberBetween(5, 10)>.99
-    tax_category: "@tva_conso_immediate"
-
-AppBundle\Entity\Menu\MenuSection:
-  menu_section_1:
-    name: "Appetizers"
-    items: [ "@menu_item_1", "@menu_item_2" ]
-  menu_section_2:
-    name: "Dishes"
-    items: [ "@menu_item_3", "@menu_item_4" ]
-  menu_section_3:
-    name: "Appetizers"
-    items: [ "@menu_item_5", "@menu_item_6" ]
-  menu_section_4:
-    name: "Dishes"
-    items: [ "@menu_item_7", "@menu_item_8" ]
-
-AppBundle\Entity\Menu:
-  menu_1:
-    name: Menu
-    sections: [ "@menu_section_1", "@menu_section_2" ]
-  menu_2:
-    name: Menu
-    sections: [ "@menu_section_3", "@menu_section_4" ]
-  menu_3:
-    name: Menu
 
 AppBundle\Entity\Address:
   address_1:
@@ -77,42 +23,39 @@ AppBundle\Entity\Address:
     streetAddress: '17, rue Milton 75009 Paris 9ème'
     geo: "@geo_3"
 
-AppBundle\Entity\Restaurant:
-  restaurant_1:
-    name: 'Nodaiwa'
-    address: "@address_1"
-    hasMenu: "@menu_1"
-    orderingDelayMinutes: 0
-    openingHours: ['Mo-Sa 11:30-14:30']
-    enabled: true
-  restaurant_2:
-    name: 'Café Barjot'
-    address: "@address_2"
-    hasMenu: "@menu_2"
-    openingHours: ['Mo-Sa 11:30-14:30']
-    orderingDelayMinutes: 0
-    enabled: true
-  restaurant_3:
-    name: 'La Cantina Clandestina'
-    orderingDelayMinutes: 0
-    address: "@address_3"
-    hasMenu: "@menu_3"
-    openingHours: ['Mo-Sa 11:30-14:30']
-    enabled: true
-
 AppBundle\Entity\Contract:
   contract_1:
-    restaurant: "@restaurant_1"
     minimumCartAmount: 1500
     flatDeliveryPrice: 350
     feeRate: 0.00
   contract_2:
-    restaurant: "@restaurant_2"
     minimumCartAmount: 1500
     flatDeliveryPrice: 350
     feeRate: 0.00
   contract_3:
-    restaurant: "@restaurant_3"
     minimumCartAmount: 1500
     flatDeliveryPrice: 350
     feeRate: 0.00
+
+AppBundle\Entity\Restaurant:
+  restaurant_1:
+    name: 'Nodaiwa'
+    address: "@address_1"
+    orderingDelayMinutes: 0
+    openingHours: ['Mo-Sa 11:30-14:30']
+    enabled: true
+    contract: "@contract_1"
+  restaurant_2:
+    name: 'Café Barjot'
+    address: "@address_2"
+    openingHours: ['Mo-Sa 11:30-14:30']
+    orderingDelayMinutes: 0
+    enabled: true
+    contract: "@contract_2"
+  restaurant_3:
+    name: 'La Cantina Clandestina'
+    orderingDelayMinutes: 0
+    address: "@address_3"
+    openingHours: ['Mo-Sa 11:30-14:30']
+    enabled: true
+    contract: "@contract_3"

--- a/features/fixtures/ORM/sylius_locales.yml
+++ b/features/fixtures/ORM/sylius_locales.yml
@@ -1,0 +1,3 @@
+Sylius\Component\Locale\Model\Locale:
+  fr:
+    code: fr

--- a/features/orders.feature
+++ b/features/orders.feature
@@ -3,7 +3,12 @@ Feature: Orders
   Scenario: Create order
     Given the database is empty
     And the current time is "2017-09-02 11:00:00"
+    And the fixtures file "products.yml" is loaded
     And the fixtures file "restaurants.yml" is loaded
+    And the restaurant with id "1" has products:
+      | code      |
+      | PIZZA     |
+      | HAMBURGER |
     And the setting "brand_name" has value "CoopCycle"
     And the setting "default_tax_category" has value "tva_livraison"
     And the user "bob" is loaded:
@@ -23,10 +28,13 @@ Feature: Orders
         "shippingAddress": "/api/addresses/4",
         "shippedAt": "2017-09-02 12:30:00",
         "items": [{
-          "menuItem": "/api/menu_items/1",
-          "quantity": 1
+          "product": "PIZZA",
+          "quantity": 1,
+          "options": [
+            "PIZZA_TOPPING_PEPPERONI"
+          ]
         }, {
-          "menuItem": "/api/menu_items/2",
+          "product": "HAMBURGER",
           "quantity": 2
         }]
       }
@@ -91,6 +99,7 @@ Feature: Orders
   Scenario: Refuse order when restaurant is closed
     Given the database is empty
     And the current time is "2017-09-02 12:00:00"
+    And the fixtures file "products.yml" is loaded
     And the fixtures file "restaurants.yml" is loaded
     And the user "bob" is loaded:
       | email    | bob@coopcycle.org |
@@ -108,10 +117,13 @@ Feature: Orders
         "shippingAddress": "/api/addresses/4",
         "shippedAt": "2017-09-03 12:00:00",
         "items": [{
-          "menuItem": "/api/menu_items/1",
-          "quantity": 1
+          "product": "PIZZA",
+          "quantity": 1,
+          "options": [
+            "PIZZA_TOPPING_PEPPERONI"
+          ]
         }, {
-          "menuItem": "/api/menu_items/2",
+          "product": "HAMBURGER",
           "quantity": 2
         }]
       }
@@ -137,6 +149,7 @@ Feature: Orders
   Scenario: Delivery exceeds max distance
     Given the database is empty
     And the current time is "2017-09-02 11:00:00"
+    And the fixtures file "products.yml" is loaded
     And the fixtures file "restaurants.yml" is loaded
     And the user "bob" is loaded:
       | email    | bob@coopcycle.org |
@@ -154,10 +167,13 @@ Feature: Orders
         "shippingAddress": "/api/addresses/4",
         "shippedAt": "2017-09-02 12:30:00",
         "items": [{
-          "menuItem": "/api/menu_items/1",
-          "quantity": 1
+          "product": "PIZZA",
+          "quantity": 1,
+          "options": [
+            "PIZZA_TOPPING_PEPPERONI"
+          ]
         }, {
-          "menuItem": "/api/menu_items/2",
+          "product": "HAMBURGER",
           "quantity": 2
         }]
       }
@@ -231,6 +247,7 @@ Feature: Orders
   Scenario: the delivery is in the past
     Given the database is empty
     And the current time is "2017-09-03 12:00:00"
+    And the fixtures file "products.yml" is loaded
     And the fixtures file "restaurants.yml" is loaded
     And the user "bob" is loaded:
       | email    | bob@coopcycle.org |
@@ -248,10 +265,13 @@ Feature: Orders
         "shippingAddress": "/api/addresses/4",
         "shippedAt": "2017-09-02 12:30:00",
         "items": [{
-          "menuItem": "/api/menu_items/1",
-          "quantity": 1
+          "product": "PIZZA",
+          "quantity": 1,
+          "options": [
+            "PIZZA_TOPPING_PEPPERONI"
+          ]
         }, {
-          "menuItem": "/api/menu_items/2",
+          "product": "HAMBURGER",
           "quantity": 2
         }]
       }
@@ -277,6 +297,7 @@ Feature: Orders
   Scenario: Amount is not sufficient
     Given the database is empty
     And the current time is "2017-09-02 11:00:00"
+    And the fixtures file "products.yml" is loaded
     And the fixtures file "restaurants.yml" is loaded
     And the setting "brand_name" has value "CoopCycle"
     And the setting "default_tax_category" has value "tva_livraison"
@@ -297,7 +318,7 @@ Feature: Orders
         "shippingAddress": "/api/addresses/4",
         "shippedAt": "2017-09-02 12:30:00",
         "items": [{
-          "menuItem": "/api/menu_items/1",
+          "product": "HAMBURGER",
           "quantity": 1
         }]
       }

--- a/features/restaurants.feature
+++ b/features/restaurants.feature
@@ -57,7 +57,17 @@ Feature: Manage restaurants
 
   Scenario: Retrieve a restaurant
     Given the database is empty
+    And the fixtures file "sylius_locales.yml" is loaded
+    And the fixtures file "products.yml" is loaded
     And the fixtures file "restaurants.yml" is loaded
+    And the restaurant with id "1" has products:
+      | code      |
+      | PIZZA     |
+      | HAMBURGER |
+    And the restaurant with id "1" has menu:
+      | section | product   |
+      | Pizzas  | PIZZA     |
+      | Burger  | HAMBURGER |
     When I add "Accept" header equal to "application/ld+json"
     And I send a "GET" request to "/api/restaurants/1"
     Then the response status code should be 200
@@ -83,24 +93,49 @@ Feature: Manage restaurants
         "name":null
       },
       "hasMenu":{
-        "@id":"@string@.startsWith('/api/menus')",
-        "@type":"http://schema.org/Menu",
         "hasMenuSection":[
           {
-            "@id":"@string@.startsWith('/api/menu_sections')",
-            "@type":"http://schema.org/MenuSection",
-            "hasMenuItem":@array@,
-            "name":@string@
+            "name":"Pizzas",
+            "hasMenuItem":[
+              {
+                "@type":"MenuItem",
+                "name":"Pizza",
+                "description":null,
+                "identifier":"PIZZA",
+                "menuAddOn":[
+                  {
+                    "@type":"MenuSection",
+                    "name":"Pizza topping",
+                    "identifier":"PIZZA_TOPPING",
+                    "hasMenuItem":[
+                      {
+                        "@type":"MenuItem",
+                        "name":"Extra cheese",
+                        "identifier":"PIZZA_TOPPING_EXTRA_CHEESE"
+                      },
+                      {
+                        "@type":"MenuItem",
+                        "name":"Pepperoni",
+                        "identifier":"PIZZA_TOPPING_PEPPERONI"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
           },
           {
-            "@id":"@string@.startsWith('/api/menu_sections')",
-            "@type":"http://schema.org/MenuSection",
-            "hasMenuItem":@array@,
-            "name":@string@
+            "name":"Burger",
+            "hasMenuItem":[
+              {
+                "@type":"MenuItem",
+                "name":"Hamburger",
+                "description":null,
+                "identifier":"HAMBURGER"
+              }
+            ]
           }
-        ],
-        "description":null,
-        "name":"Menu"
+        ]
       },
       "openingHours":@array@,
       "availabilities":@array@,

--- a/src/AppBundle/Action/Restaurant/Menu.php
+++ b/src/AppBundle/Action/Restaurant/Menu.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AppBundle\Action\Restaurant;
+
+use AppBundle\Entity\Restaurant;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
+
+class Menu
+{
+    /**
+     * @Route(
+     *   name="api_restaurant_menu",
+     *   path="/restaurants/{id}/menu",
+     *   defaults={
+     *     "_api_resource_class"=Restaurant::class,
+     *     "_api_item_operation_name"="restaurant_menu"
+     *   }
+     * )
+     * @Method("GET")
+     */
+    public function __invoke(Restaurant $data, Request $request)
+    {
+        $restaurant = $data;
+
+        return $restaurant->getMenuTaxon();
+    }
+}

--- a/src/AppBundle/Entity/Restaurant.php
+++ b/src/AppBundle/Entity/Restaurant.php
@@ -35,7 +35,8 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
  *     "get"={"method"="GET"}
  *   },
  *   itemOperations={
- *     "get"={"method"="GET"}
+ *     "get"={"method"="GET"},
+ *     "restaurant_menu"={"route_name"="api_restaurant_menu"},
  *   }
  * )
  * @Vich\Uploadable
@@ -151,9 +152,6 @@ class Restaurant extends FoodEstablishment
 
     /**
      * @var string The menu of the restaurant.
-     *
-     * @ApiProperty(iri="https://schema.org/Menu")
-     * @Groups({"restaurant"})
      */
     private $hasMenu;
 
@@ -176,6 +174,9 @@ class Restaurant extends FoodEstablishment
 
     private $productOptions;
 
+    /**
+     * @Groups({"restaurant"})
+     */
     private $taxons;
 
     /**

--- a/src/AppBundle/Entity/Sylius/Taxon.php
+++ b/src/AppBundle/Entity/Sylius/Taxon.php
@@ -2,11 +2,15 @@
 
 namespace AppBundle\Entity\Sylius;
 
+use ApiPlatform\Core\Annotation\ApiResource;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Product\Model\ProductInterface;
 use Sylius\Component\Taxonomy\Model\Taxon as BaseTaxon;
 
+/**
+ * @ApiResource
+ */
 class Taxon extends BaseTaxon
 {
     private $taxonProducts;
@@ -26,6 +30,15 @@ class Taxon extends BaseTaxon
     public function setTaxonProducts(Collection $taxonProducts)
     {
         $this->taxonProducts = $taxonProducts;
+    }
+
+    public function addProduct(ProductInterface $product)
+    {
+        $productTaxon = new ProductTaxon();
+        $productTaxon->setTaxon($this);
+        $productTaxon->setProduct($product);
+
+        $this->taxonProducts->add($productTaxon);
     }
 
     public function getProducts()

--- a/src/AppBundle/Resources/config/serialization.yml
+++ b/src/AppBundle/Resources/config/serialization.yml
@@ -9,6 +9,11 @@ AppBundle\Entity\ApiUser:
     telephone:
       groups: ['order']
 
+AppBundle\Entity\Sylius\Taxon:
+  attributes:
+    code:
+      groups: ['restaurant']
+
 AppBundle\Entity\Base\MenuItem:
   attributes:
     offers:

--- a/src/AppBundle/Serializer/JsonLd/RestaurantMenuNormalizer.php
+++ b/src/AppBundle/Serializer/JsonLd/RestaurantMenuNormalizer.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace AppBundle\Serializer\JsonLd;
+
+use ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer;
+use AppBundle\Entity\Sylius\Taxon;
+use Sylius\Component\Locale\Provider\LocaleProvider;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * FIXME
+ * Understand why the locale is not set correctly
+ * We shouldn't need to call setCurrentLocale
+ * It may happen only in Behat context
+ */
+class RestaurantMenuNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    private $normalizer;
+
+    public function __construct(ItemNormalizer $normalizer, LocaleProvider $localeProvider)
+    {
+        $this->normalizer = $normalizer;
+        $this->localeProvider = $localeProvider;
+    }
+
+    private function normalizeOptions($options)
+    {
+        $data = [];
+
+        foreach ($options as $option) {
+
+            $option->setCurrentLocale($this->localeProvider->getDefaultLocaleCode());
+
+            $data[] = [
+                '@type' => 'MenuSection',
+                'name' => $option->getName(),
+                'identifier' => $option->getCode(),
+                'hasMenuItem' => $this->normalizeOptionValues($option->getValues()),
+            ];
+        }
+
+        return $data;
+    }
+
+    private function normalizeOptionValues($optionValues)
+    {
+        $data = [];
+
+        foreach ($optionValues as $optionValue) {
+
+            $optionValue->setCurrentLocale($this->localeProvider->getDefaultLocaleCode());
+
+            $data[] = [
+                '@type' => 'MenuItem',
+                'name' => $optionValue->getValue(),
+                'identifier' => $optionValue->getCode(),
+            ];
+        }
+
+        // Sort option values by name
+        usort($data, function($a, $b) {
+            return $a['name'] < $b['name'] ? -1 : 1;
+        });
+
+        return $data;
+    }
+
+    public function normalize($object, $format = null, array $context = array())
+    {
+        // $data = $this->normalizer->normalize($object, $format, $context);
+
+        $data = [];
+
+        $object->setCurrentLocale($this->localeProvider->getDefaultLocaleCode());
+
+        $sections = [];
+        foreach ($object->getChildren() as $child) {
+            $section = [
+                'name' => $child->getName(),
+                'hasMenuItem' => [],
+            ];
+
+            foreach ($child->getProducts() as $product) {
+
+                $product->setCurrentLocale($this->localeProvider->getDefaultLocaleCode());
+
+                $item = [
+                    '@type' => 'MenuItem',
+                    'name' => $product->getName(),
+                    'description' => $product->getDescription(),
+                    'identifier' => $product->getCode(),
+                ];
+                if ($product->hasOptions()) {
+                    $item['menuAddOn'] = $this->normalizeOptions($product->getOptions());
+                }
+                $section['hasMenuItem'][] = $item;
+            }
+
+            $data['hasMenuSection'][] = $section;
+        }
+
+        return $data;
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        return $this->normalizer->supportsNormalization($data, $format) && $data instanceof Taxon;
+    }
+
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        return null;
+    }
+
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return false;
+    }
+}

--- a/src/AppBundle/Serializer/RestaurantNormalizer.php
+++ b/src/AppBundle/Serializer/RestaurantNormalizer.php
@@ -20,6 +20,13 @@ class RestaurantNormalizer implements NormalizerInterface, DenormalizerInterface
     {
         $data =  $this->normalizer->normalize($object, $format, $context);
 
+        if (isset($data['taxons'])) {
+            // FIXME Return active menu instead of the first one
+            $taxon = current($data['taxons']);
+            $data['hasMenu'] = $taxon;
+            unset($data['taxons']);
+        }
+
         $data['availabilities'] = $object->getAvailabilities();
         $data['minimumCartAmount'] = $object->getMinimumCartAmount();
         $data['flatDeliveryPrice'] = $object->getFlatDeliveryPrice();


### PR DESCRIPTION
The menu is now serialized with options, to be able to display them on the app. 
It uses the [`menuAddOn`](http://pending.schema.org/menuAddOn) property. 

```json
{
  "hasMenuSection":[
    {
      "name":"Pizzas",
      "hasMenuItem":[
        {
          "@type":"MenuItem",
          "name":"Pizza",
          "description":null,
          "identifier":"PIZZA",
          "menuAddOn":[
            {
              "@type":"MenuSection",
              "name":"Pizza topping",
              "identifier":"PIZZA_TOPPING",
              "hasMenuItem":[
                {
                  "@type":"MenuItem",
                  "name":"Pepperoni",
                  "identifier":"PIZZA_TOPPING_PEPPERONI"
                },
                {
                  "@type":"MenuItem",
                  "name":"Extra cheese",
                  "identifier":"PIZZA_TOPPING_EXTRA_CHEESE"
                }
              ]
            }
          ]
        }
      ]
    },
    {
      "name":"Burger",
      "hasMenuItem":[
        {
          "@type":"MenuItem",
          "name":"Hamburger",
          "description":null,
          "identifier":"HAMBURGER"
        }
      ]
    }
  ]
}
```

Also, it is now possible to specify product options when creating an order through the API.

```json
{
  "restaurant": "/api/restaurants/1",
  "shippingAddress": "/api/addresses/4",
  "shippedAt": "2017-09-02 12:30:00",
  "items": [{
    "product": "PIZZA",
    "quantity": 1,
    "options": [
      "PIZZA_TOPPING_PEPPERONI"
    ]
  }, {
    "product": "HAMBURGER",
    "quantity": 2
  }]
}
```
