### PR TITLE
Manage task complete "the right way"

### DIFF
--- a/js/app/task/modal.js
+++ b/js/app/task/modal.js
@@ -125,16 +125,24 @@ window.CoopCycle.TaskModal = (formName, tagsURL) => {
   if ($(`form[name="${formName}"]`).data('ajax') === true) {
 
     $(document)
-      .off('click', `#${formName}_save`)
-      .on('click', `#${formName}_save`, function(e) {
+      .off('click', `form[name="${formName}"] button[type="submit"]`)
+      .on('click', `form[name="${formName}"] button[type="submit"]`, function(e) {
         e.preventDefault()
 
         const $form = $(`form[name="${formName}"]`)
 
+        const data = $form.serializeArray()
+
+        // We add the name of the button that was actually clicked
+        data.push({
+          name: $(e.target).attr('name'),
+          value: ""
+        })
+
         fetch($form.attr('action'), {
           credentials: 'include',
           method: 'POST',
-          body: new URLSearchParams($form.serialize()),
+          body: new URLSearchParams($.param(data)),
         })
         .then(res => {
           if (res.ok) {

--- a/src/AppBundle/Entity/TaskEvent.php
+++ b/src/AppBundle/Entity/TaskEvent.php
@@ -54,6 +54,11 @@ class TaskEvent
         return $this->notes;
     }
 
+    public function setNotes($notes)
+    {
+        $this->notes = $notes;
+    }
+
     public function getCreatedAt()
     {
         return $this->createdAt;

--- a/src/AppBundle/Exception/PreviousTaskNotCompletedException.php
+++ b/src/AppBundle/Exception/PreviousTaskNotCompletedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace AppBundle\Exception;
+
+class PreviousTaskNotCompletedException extends \Exception
+{
+}

--- a/src/AppBundle/Form/TaskEventType.php
+++ b/src/AppBundle/Form/TaskEventType.php
@@ -2,45 +2,32 @@
 
 namespace AppBundle\Form;
 
-use AppBundle\Entity\ApiUser;
-use AppBundle\Entity\Task;
+use AppBundle\Entity\TaskEvent;
 use Doctrine\ORM\EntityRepository;
-use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
-use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvents;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class TaskCompleteType extends AbstractType
+class TaskEventType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
             ->add('notes', TextareaType::class, [
-                'mapped' => false,
                 'required' => false,
                 'attr' => [
                     'placeholder' => 'form.task_event.notes.placeholder',
                     'rows' => 2,
                 ]
-            ])
-            ->add('done', SubmitType::class, [
-                'label' => 'form.task_complete.done.label'
-            ])
-            ->add('fail', SubmitType::class, [
-                'label' => 'form.task_complete.fail.label'
             ]);
     }
 
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'data_class' => Task::class,
+            'data_class' => TaskEvent::class,
         ));
     }
 }

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -72,11 +72,6 @@ adminDashboard.orders.invoice.totalIncludingTax: Total including tax
 adminDashboard.restaurants.title: Restaurants
 adminDashboard.restaurants.createNew: Create a new restaurant
 
-adminDashboard.task.form.courier: Courier
-adminDashboard.task.form.status: Status
-adminDashboard.task.form.notes: Notes
-adminDashboard.task.form.notes.placeholder: Enter details about task's end
-
 adminDashboard.users.title: Users
 adminDashboard.users.edit: Edit
 adminDashboard.users.save: Save
@@ -304,11 +299,19 @@ task.form.edit: Modify task %id%
 task.form.dateRange: Date range
 task.form.finish: Finish task
 task.form.details: Task details
-task.form.finish.info: Task is finished with status %status%. You can change the note that was written at completion.
+task.form.finish.DONE.info: The task was successfully completed
+task.form.finish.FAIL.info: The task could not be completed
 
 task.status.done: Success
 task.status.failed: Failure
 task.status.todo: To do
+
+form.task.courier.label: Courier
+form.task.status.label: Status
+
+form.task_event.notes.placeholder: |
+  Ex: address not found, no problem…
+form.task_event.notes.help: You can edit the comment
 
 form.task_upload.file: File
 form.task_complete.done.label: Complete

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -72,11 +72,6 @@ adminDashboard.orders.invoice.totalIncludingTax: Total con impuestos
 adminDashboard.restaurants.title: Restaurantes
 adminDashboard.restaurants.createNew: Crear restaurante
 
-adminDashboard.task.form.courier: Courier
-adminDashboard.task.form.status: Status
-adminDashboard.task.form.notes: Notes
-adminDashboard.task.form.notes.placeholder: Enter details about task's end
-
 adminDashboard.users.title: Usuarios
 adminDashboard.users.edit: Editar
 adminDashboard.users.save: Guardar
@@ -305,12 +300,19 @@ task.form.edit: Modify task %id%
 task.form.dateRange: Date range
 task.form.finish: Finish task
 task.form.details: Task details
-task.form.finish.info: Task is finished with status %status%. You can change the note that was written at completion.
-
+task.form.finish.DONE.info: La tarea se completó con éxito
+task.form.finish.FAIL.info: La tarea no pudo ser completada
 
 task.status.done: Success
 task.status.failed: Failure
 task.status.todo: To do
+
+form.task.courier.label: Mensajero
+form.task.status.label: Estado
+
+form.task_event.notes.placeholder: |
+  Ejemplo : dirección no encontrada, no hay problema…
+form.task_event.notes.help: Puedes editar el comentario
 
 form.task_upload.file: Archivo
 form.task_complete.done.label: Completada

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -71,11 +71,6 @@ adminDashboard.orders.invoice.totalIncludingTax: Total TTC
 adminDashboard.restaurants.title: Restaurants
 adminDashboard.restaurants.createNew: Créer un restaurant
 
-adminDashboard.task.form.courier: Coursier
-adminDashboard.task.form.status: Statut
-adminDashboard.task.form.notes: Note de fin
-adminDashboard.task.form.notes.placeholder: Spécifiez les détails de fin de tâche
-
 adminDashboard.users.title: Utilisateurs
 adminDashboard.users.edit: Modifier
 adminDashboard.users.save: Enregistrer
@@ -306,11 +301,19 @@ task.form.modal.moreOptions: Plus d'options
 task.form.dateRange: Créneau pour la réalisation
 task.form.finish: Terminer la tâche
 task.form.details: Détails de la tâche
-task.form.finish.info: La tâche est finie avec le statut %status%. Vous pouvez changer la note écrite à la fin de la tâche.
+task.form.finish.DONE.info: La tâche a été réalisée avec succès
+task.form.finish.FAILED.info: La tâche n'a pas pu être réalisée
 
 task.status.done: Succès
 task.status.failed: Échec
 task.status.todo: À faire
+
+form.task.courier.label: Coursier
+form.task.status.label: Status
+
+form.task_event.notes.placeholder: |
+  Ex : adresse introuvable, aucun problème…
+form.task_event.notes.help: Vous pouvez modifier le commentaire
 
 form.task_upload.file: Fichier
 form.task_complete.done.label: Terminer

--- a/src/AppBundle/Resources/views/Form/taskModal.html.twig
+++ b/src/AppBundle/Resources/views/Form/taskModal.html.twig
@@ -71,3 +71,8 @@
 {% block _task_edit_tagsAsString_widget %}
 {{ block('_task_tagsAsString_widget') }}
 {% endblock %}
+
+{% block _task_edit_lastEvent_notes_widget %}
+  {{ block('textarea_widget') }}
+  <small class="help-block">{% trans %}form.task_event.notes.help{% endtrans %}</small>
+{% endblock %}

--- a/src/AppBundle/Resources/views/_partials/Task/form.html.twig
+++ b/src/AppBundle/Resources/views/_partials/Task/form.html.twig
@@ -31,7 +31,7 @@
       </button>
       <h4 class="modal-title">
         {{ modal_title }}
-        {%  if form.status is defined %}
+        {% if form.complete is defined %}
           <a class="pull-right margin-right-md" id="show-task-finish">{% trans %}task.form.finish{%  endtrans %}</a>
           <a class="pull-right margin-right-md" id="show-task-details" style="display:none;">{% trans %}task.form.details{%  endtrans %}</a>
         {% endif %}
@@ -39,18 +39,19 @@
     </div>
     <div class="modal-body">
 
-      {%  if form.status is defined %}
+      {{ form_errors(form) }}
+
+      {% if form.complete is defined %}
         <div id="task-finish" style="display:none;">
-          {{ form_row(form.status) }}
-          {{ form_row(form.notes) }}
+          {{ form_row(form.complete.notes) }}
         </div>
       {% endif %}
 
       <div id="task-details">
 
-        {% if task.isFinished and form.notes is defined %}
-          <p>{{ 'task.form.finish.info' | trans({ '%status%': task.status }) }}</p>
-          {{ form_row(form.notes) }}
+        {% if form.lastEvent is defined %}
+          <p>{{ ('task.form.finish.' ~ task.status ~ '.info')|trans }}</p>
+          {{ form_row(form.lastEvent.notes, { label: false }) }}
         {% endif %}
 
         {{ form_row(form.type) }}
@@ -95,6 +96,10 @@
       {% endif %}
       <button type="button" class="btn btn-default" data-dismiss="modal">{% trans %}task.form.cancel{% endtrans %}</button>
       {{ form_widget(form.save, { attr: { class: 'btn btn-primary' } }) }}
+      {% if form.complete is defined %}
+        {{ form_widget(form.complete.done, { attr: { class: 'btn btn-success', style: 'display: none;' } }) }}
+        {{ form_widget(form.complete.fail, { attr: { class: 'btn btn-danger', style: 'display: none;' } }) }}
+      {% endif %}
     </div>
   {{ form_end(form) }}
 </div>
@@ -106,11 +111,17 @@
     var $modal = $(event.target).closest('.modal-dialog');
     $(event.target).hide(400, function () {$modal.find("#show-task-details").fadeIn()});
     $modal.find("#task-details").hide(400, function () {$modal.find("#task-finish").fadeIn()});
+    $('#task_edit_save').hide();
+    $('#task_edit_complete_done').show();
+    $('#task_edit_complete_fail').show();
   });
   $('#show-task-details').on('click', function (event) {
     var $modal = $(event.target).closest('.modal-dialog');
     $(event.target).hide(400, function () {$modal.find("#show-task-finish").fadeIn()});
     $modal.find("#task-finish").hide(400, function () {$modal.find("#task-details").fadeIn()});
+    $('#task_edit_complete_done').hide();
+    $('#task_edit_complete_fail').hide();
+    $('#task_edit_save').show();
   });
 </script>
 {% endif %}

--- a/src/AppBundle/Service/TaskManager.php
+++ b/src/AppBundle/Service/TaskManager.php
@@ -7,6 +7,7 @@ use AppBundle\Event\TaskDoneEvent;
 use AppBundle\Event\TaskFailedEvent;
 use AppBundle\Event\TaskAssignEvent;
 use AppBundle\Event\TaskUnassignEvent;
+use AppBundle\Exception\PreviousTaskNotCompletedException;
 use FOS\UserBundle\Model\UserInterface;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -43,7 +44,7 @@ class TaskManager
     public function markAsDone(Task $task, $notes = null)
     {
         if ($task->hasPrevious() && $task->getPrevious()->getStatus() === Task::STATUS_TODO) {
-            throw new \Exception('task.previous_task_not_completed_yet');
+            throw new PreviousTaskNotCompletedException('Previous task must be completed first');
         }
 
         $task->setStatus(Task::STATUS_DONE);


### PR DESCRIPTION
The current method is hacky & does not manage errors correctly.
This PR reuses `TaskCompleteType` with several submit buttons.

**TODO**

- [x] Allow editing the last event notes

![task_complete](https://user-images.githubusercontent.com/1162230/40397865-4d5facc4-5e35-11e8-960b-746899a2903f.gif)