### PR TITLE
Allow distinguishing pickup & dropoff address in pricing rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,4 +68,4 @@ script:
   # - curl 'http://localhost:5000/route/v1/bicycle/2.3706188,48.877821;2.385706,48.887031?overview=full'
   - phpunit
   - php vendor/bin/behat -f progress
-  - node node_modules/.bin/mocha js/tests/
+  - node node_modules/.bin/mocha --compilers js:babel-core/register js/tests/

--- a/app/DoctrineMigrations/Version20180622100900.php
+++ b/app/DoctrineMigrations/Version20180622100900.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types = 1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180622100900 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $stmt = $this->connection->prepare("SELECT id, expression FROM pricing_rule");
+        $stmt->execute();
+
+        while ($pricingRule = $stmt->fetch()) {
+            if (false !== strpos($pricingRule['expression'], 'deliveryAddress')) {
+                $expression = str_replace('deliveryAddress', 'dropoff.address', $pricingRule['expression']);
+                $this->addSql('UPDATE pricing_rule SET expression = :expression WHERE id = :id', [
+                    'id' => $pricingRule['id'],
+                    'expression' => $expression
+                ]);
+            }
+        }
+
+        $stmt = $this->connection->prepare("SELECT id, delivery_perimeter_expression FROM restaurant");
+        $stmt->execute();
+
+        while ($restaurant = $stmt->fetch()) {
+            if (false !== strpos($restaurant['delivery_perimeter_expression'], 'deliveryAddress')) {
+                $expression = str_replace('deliveryAddress', 'dropoff.address', $restaurant['delivery_perimeter_expression']);
+                $this->addSql('UPDATE restaurant SET delivery_perimeter_expression = :expression WHERE id = :id', [
+                    'id' => $restaurant['id'],
+                    'expression' => $expression
+                ]);
+            }
+        }
+    }
+
+    public function down(Schema $schema)
+    {
+        $stmt = $this->connection->prepare("SELECT id, expression FROM pricing_rule");
+        $stmt->execute();
+
+        while ($pricingRule = $stmt->fetch()) {
+            if (false !== strpos($pricingRule['expression'], 'dropoff.address')) {
+                $expression = str_replace('dropoff.address', 'deliveryAddress', $pricingRule['expression']);
+                $this->addSql('UPDATE pricing_rule SET expression = :expression WHERE id = :id', [
+                    'id' => $pricingRule['id'],
+                    'expression' => $expression
+                ]);
+            }
+        }
+
+        $stmt = $this->connection->prepare("SELECT id, delivery_perimeter_expression FROM restaurant");
+        $stmt->execute();
+
+        while ($restaurant = $stmt->fetch()) {
+            if (false !== strpos($restaurant['delivery_perimeter_expression'], 'dropoff.address')) {
+                $expression = str_replace('dropoff.address', 'deliveryAddress', $restaurant['delivery_perimeter_expression']);
+                $this->addSql('UPDATE restaurant SET delivery_perimeter_expression = :expression WHERE id = :id', [
+                    'id' => $restaurant['id'],
+                    'expression' => $expression
+                ]);
+            }
+        }
+
+    }
+}

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -687,6 +687,7 @@ $order-follow--number-width: 26px;
     &__expression {
       flex: 8;
       padding-right: 15px;
+      width: 0;
     }
     &__price {
       flex: 4;
@@ -707,6 +708,7 @@ $order-follow--number-width: 26px;
     pre {
       margin: 0;
       font-size: 11px;
+      white-space: pre-wrap;
     }
   }
 }

--- a/docker/nodejs/run-tests.sh
+++ b/docker/nodejs/run-tests.sh
@@ -3,4 +3,4 @@
 cd /srv/coopcycle
 
 pm2-docker pm2.config.js --env=test > /dev/null 2>&1 &
-node node_modules/.bin/mocha js/tests/
+node node_modules/.bin/mocha --compilers js:babel-core/register js/tests/

--- a/js/app/components/RulePicker.jsx
+++ b/js/app/components/RulePicker.jsx
@@ -39,7 +39,6 @@ class RulePicker extends React.Component {
   }
 
   render () {
-    console.log(this.state.lines)
     return (
       <div className="rule-picker">
         { this.state.lines.map((line, index) => <RulePickerLine key={index} index={index} rulePicker={this} line={line} />) }

--- a/js/app/components/RulePickerLine.jsx
+++ b/js/app/components/RulePickerLine.jsx
@@ -1,11 +1,13 @@
 import React from 'react'
+import parsePricingRule from '../delivery/pricing-rule-parser'
 
 /*
 
   A component to edit a rule which will be evaluated as Symfony's expression language.
 
   Variables :
-    - deliveryAddress : L'adresse de livraison
+    - pickup.address : L'adresse de retrait
+    - dropoff.address : L'adresse de dépôt
     - distance : La distance entre le point de retrait et le point de dépôt
     - weight : Le poids du colis transporté en grammes
     - vehicle : Le type de véhicule (bike ou cargo_bike)
@@ -13,15 +15,16 @@ import React from 'react'
   Examples :
     * distance in 0..3000
     * weight > 1000
-    * in_zone(deliveryAddress, "paris_est")
+    * in_zone(pickup.address, "paris_est")
     * vehicle == "cargo_bike"
 */
 
 const typeToOperators = {
   'distance': ['<', '>', 'in'],
   'weight': ['<', '>', 'in'],
-  'zone': ['in_zone'],
   'vehicle': ['=='],
+  'pickup.address': ['in_zone', 'out_zone'],
+  'dropoff.address': ['in_zone', 'out_zone'],
 }
 
 
@@ -30,23 +33,21 @@ class RulePickerLine extends React.Component {
   constructor (props) {
     super(props)
 
-    let { line } = this.props,
-      typeValue, // the variable the rule is built upon
-      operatorValue, // the operator/function used to build the rule
-      boundValues // the value(s) which complete the rule
+    const { line } = this.props
+
+    let type, operator, value
 
     if (line) {
-      [typeValue, operatorValue, boundValues] = this.parseInitialLine()
-    } else {
-      operatorValue = ''
-      typeValue = ''
-      boundValues = ['', '']
+      const [ result ] = parsePricingRule(line)
+      type = result.left
+      operator = result.operator
+      value = result.right
     }
 
     this.state = {
-      boundValues: boundValues,
-      operatorValue: operatorValue,
-      typeValue: typeValue
+      type: type || '',         // the variable the rule is built upon
+      operator: operator || '', // the operator/function used to build the rule
+      value: value || '',       // the value(s) which complete the rule
     }
 
     this.onTypeSelect = this.onTypeSelect.bind(this)
@@ -54,34 +55,10 @@ class RulePickerLine extends React.Component {
     this.renderBoundPicker = this.renderBoundPicker.bind(this)
     this.handleFirstBoundChange = this.handleFirstBoundChange.bind(this)
     this.handleSecondBoundChange = this.handleSecondBoundChange.bind(this)
+    this.handleValueChange = this.handleValueChange.bind(this)
     this.buildLine = this.buildLine.bind(this)
     this.delete = this.delete.bind(this)
   }
-
-  parseInitialLine () {
-    /*
-      Parse the initial line - not the cleanest code ever..
-     */
-
-    // zone
-    let zoneTest = /in_zone\(deliveryAddress, ['|"](.+)['|"]\)/.exec(this.props.line)
-    if (zoneTest) {
-      return ['zone', 'in_zone', [zoneTest[1]]]
-    }
-
-    // bike type
-    let bikeTest = /(vehicle) == "(cargo_bike|bike)"/.exec(this.props.line)
-    if (bikeTest) {
-      return [bikeTest[1], '==', [bikeTest[2]]]
-    }
-
-    // in, > or < type
-    let comparatorTest = /([\w]+) (in|<|>) ([\d]+)(\.\.([\d]+))?/.exec(this.props.line)
-    if (comparatorTest) {
-      return [comparatorTest[1], comparatorTest[2], [comparatorTest[3], comparatorTest[5]]]
-    }
-  }
-
 
   buildLine (state) {
     /*
@@ -90,56 +67,65 @@ class RulePickerLine extends React.Component {
       We pass explicitely the  state so we can compare previous & next state. Returns nothing if we can't build the line.
      */
 
-    if (state.boundValues[0] && state.boundValues[1] && state.operatorValue == 'in') {
-      return state.typeValue + ' in ' + state.boundValues[0] + '..' + state.boundValues[1]
+    if (state.operator === 'in' && Array.isArray(state.value) && state.value.length === 2) {
+      return `${state.type} in ${state.value[0]}..${state.value[1]}`
     }
-    else if (state.boundValues[0]) {
-      switch (state.operatorValue) {
-        case '>':
-          return state.typeValue + ' > ' + state.boundValues[0]
-        case '<':
-          return state.typeValue + ' < ' + state.boundValues[0]
-        case 'in_zone':
-          return 'in_zone(deliveryAddress, "' + state.boundValues[0] + '")'
-        case '==':
-          return state.typeValue + ' == "' + state.boundValues[0] + '"'
-      }
+
+    switch (state.operator) {
+      case '<':
+      case '>':
+        return `${state.type} ${state.operator} ${state.value}`
+      case 'in_zone':
+      case 'out_zone':
+        return `${state.operator}(${state.type}, "${state.value}")`
+      case '==':
+        return `${state.type}  == "${state.value}"`
     }
   }
 
   componentDidUpdate (prevProps, prevState) {
     let line = this.buildLine(this.state)
+
     if (this.buildLine(prevState) !== line) {
       this.props.rulePicker.updateLine(this.props.index, line)
     }
   }
 
   handleFirstBoundChange (ev) {
-    let boundValues = this.state.boundValues.slice()
-    boundValues[0] = ev.target.value
-    this.setState({boundValues})
+    let value = this.state.value.slice()
+    value[0] = ev.target.value
+    this.setState({ value })
   }
 
   handleSecondBoundChange (ev) {
-    let boundValues = this.state.boundValues.slice()
-    boundValues[1] = ev.target.value
-    this.setState({boundValues})
+    let value = this.state.value.slice()
+    value[1] = ev.target.value
+    this.setState({ value })
+  }
+
+  handleValueChange (ev) {
+    const { value } = this.state
+    if (Array.isArray(value)) {
+
+    } else {
+      this.setState({ value: ev.target.value })
+    }
   }
 
   onTypeSelect (ev) {
     ev.preventDefault()
-    let typeValue = ev.target.value,
-        operatorValue = typeToOperators[typeValue].length === 1 ? typeToOperators[typeValue][0] : ''
+    let type = ev.target.value,
+        operator = typeToOperators[type].length === 1 ? typeToOperators[type][0] : ''
     this.setState({
-      typeValue: typeValue,
-      operatorValue: operatorValue,
-      boundValues: ['', '']
+      type,
+      operator,
+      value: ''
     })
   }
 
   onOperatorSelect (ev) {
     ev.preventDefault()
-    this.setState({operatorValue: ev.target.value})
+    this.setState({ operator: ev.target.value })
   }
 
   delete (evt) {
@@ -151,11 +137,12 @@ class RulePickerLine extends React.Component {
     /*
      * Return the displayed input for bound selection
      */
-    switch (this.state.operatorValue) {
+    switch (this.state.operator) {
       // zone
       case 'in_zone':
+      case 'out_zone':
         return (
-          <select onChange={this.handleFirstBoundChange} value={this.state.boundValues[0]} className="form-control input-sm">
+          <select onChange={this.handleValueChange} value={this.state.value} className="form-control input-sm">
               <option value="">-</option>
               { this.props.rulePicker.props.zones.map((item, index) => {
                   return (<option value={item} key={index}>{item}</option>)
@@ -166,7 +153,7 @@ class RulePickerLine extends React.Component {
       // vehicle
       case '==':
         return (
-          <select onChange={this.handleFirstBoundChange} value={this.state.boundValues[0]} className="form-control input-sm">
+          <select onChange={this.handleValueChange} value={this.state.value} className="form-control input-sm">
             <option value="">-</option>
             <option value="bike">Vélo</option>
             <option value="cargo_bike">Vélo Cargo</option>
@@ -177,20 +164,17 @@ class RulePickerLine extends React.Component {
         return (
           <div className="row">
             <div className="col-md-6">
-              <input className="form-control input-sm" value={this.state.boundValues[0]} onChange={this.handleFirstBoundChange} type="number"></input>
+              <input className="form-control input-sm" value={this.state.value[0]} onChange={this.handleFirstBoundChange} type="number"></input>
             </div>
             <div className="col-md-6">
-              <input className="form-control input-sm" value={this.state.boundValues[1]} onChange={this.handleSecondBoundChange} type="number"></input>
+              <input className="form-control input-sm" value={this.state.value[1]} onChange={this.handleSecondBoundChange} type="number"></input>
             </div>
           </div>
         )
+      case '<':
       case '>':
         return (
-          (<input className="form-control input-sm" value={this.state.boundValues[0]} onChange={this.handleFirstBoundChange} type="number"></input>)
-        )
-      case '<':
-        return (
-          (<input className="form-control input-sm" value={this.state.boundValues[0]} onChange={this.handleFirstBoundChange} type="number"></input>)
+          (<input className="form-control input-sm" value={this.state.value} onChange={this.handleValueChange} type="number"></input>)
         )
     }
   }
@@ -200,20 +184,21 @@ class RulePickerLine extends React.Component {
     return (
       <div className="row">
         <div className="col-md-3 form-group">
-          <select value={this.state.typeValue} onChange={this.onTypeSelect} className="form-control input-sm">
+          <select value={this.state.type} onChange={this.onTypeSelect} className="form-control input-sm">
             <option value="">-</option>
             <option value="distance">Distance (m)</option>
             <option value="weight">Poids (g)</option>
-            <option value="zone">Zone</option>
             <option value="vehicle">Type de vélo</option>
+            <option value="pickup.address">Adresse de retrait</option>
+            <option value="dropoff.address">Adresse de dépôt</option>
           </select>
         </div>
         <div className="col-md-3">
           {
-            this.state.typeValue && (
-              <select value={this.state.operatorValue} onChange={this.onOperatorSelect} className="form-control input-sm">
+            this.state.type && (
+              <select value={this.state.operator} onChange={this.onOperatorSelect} className="form-control input-sm">
                 <option value="">-</option>
-                { typeToOperators[this.state.typeValue].map(function(operator, index) {
+                { typeToOperators[this.state.type].map(function(operator, index) {
                     return (<option key={index} value={operator}>{operator}</option>)
                   })
                 }
@@ -223,7 +208,7 @@ class RulePickerLine extends React.Component {
         </div>
         <div className="col-md-5">
           {
-            this.state.operatorValue && this.renderBoundPicker()
+            this.state.operator && this.renderBoundPicker()
           }
         </div>
         <div className="col-md-1" onClick={this.delete}>

--- a/js/app/delivery/pricing-rule-parser.js
+++ b/js/app/delivery/pricing-rule-parser.js
@@ -1,0 +1,49 @@
+const zoneRegexp = /(in_zone|out_zone)\(([^,]+), ['|"](.+)['|"]\)/
+const vehicleRegexp = /(vehicle) == "(cargo_bike|bike)"/
+const inRegexp = /([\w]+) in ([\d]+)\.\.([\d]+)/
+const comparatorRegexp = /([\w]+) (<|>) ([\d]+)/
+
+const parseToken = token => {
+
+  const zoneTest = zoneRegexp.exec(token)
+  if (zoneTest) {
+    return {
+      left: zoneTest[2],
+      operator: zoneTest[1],
+      right: zoneTest[3]
+    }
+  }
+
+  const vehicleTest = vehicleRegexp.exec(token)
+  if (vehicleTest) {
+    return {
+      left: vehicleTest[1],
+      operator: '==',
+      right: vehicleTest[2]
+    }
+  }
+
+  const inRegexpTest = inRegexp.exec(token)
+  if (inRegexpTest) {
+    return {
+      left: inRegexpTest[1],
+      operator: 'in',
+      right: [
+        parseInt(inRegexpTest[2], 10),
+        parseInt(inRegexpTest[3], 10)
+      ]
+    }
+  }
+
+  const comparatorTest = comparatorRegexp.exec(token)
+  if (comparatorTest) {
+    return {
+      left: comparatorTest[1],
+      operator: comparatorTest[2],
+      right: parseInt(comparatorTest[3], 10)
+    }
+  }
+}
+
+export default expression =>
+  expression.split('and').map(token => token.trim()).map(token => parseToken(token))

--- a/js/tests/pricing-rule-parser.js
+++ b/js/tests/pricing-rule-parser.js
@@ -1,0 +1,78 @@
+import parsePricingRule from '../app/delivery/pricing-rule-parser'
+import chai from 'chai'
+
+const expect = chai.expect
+
+describe('Pricing rule parser', function() {
+
+  it('should parse in_zone', function() {
+    const expression = 'in_zone(pickup.address, "bordeaux_centre_ville")'
+    const result = parsePricingRule(expression)
+    expect(result).to.deep.equal([{
+      left: 'pickup.address',
+      operator: 'in_zone',
+      right: 'bordeaux_centre_ville'
+    }])
+  })
+
+  it('should parse out_zone', function() {
+    const expression = 'out_zone(pickup.address, "bordeaux_centre_ville")'
+    const result = parsePricingRule(expression)
+    expect(result).to.deep.equal([{
+      left: 'pickup.address',
+      operator: 'out_zone',
+      right: 'bordeaux_centre_ville'
+    }])
+  })
+
+  it('should parse vehicle', function() {
+    const expression = 'vehicle == "cargo_bike"'
+    const result = parsePricingRule(expression)
+    expect(result).to.deep.equal([{
+      left: 'vehicle',
+      operator: '==',
+      right: 'cargo_bike'
+    }])
+  })
+
+  it('should parse distance with bounds', function() {
+    const expression = 'distance in 0..3000'
+    const result = parsePricingRule(expression)
+    expect(result).to.deep.equal([{
+      left: 'distance',
+      operator: 'in',
+      right: [ 0, 3000 ]
+    }])
+  })
+
+  it('should parse distance with comparison', function() {
+    const expression = 'distance < 3000'
+    const result = parsePricingRule(expression)
+    expect(result).to.deep.equal([{
+      left: 'distance',
+      operator: '<',
+      right: 3000
+    }])
+  })
+
+  it('should parse weight with bounds', function() {
+    const expression = 'weight in 4000..6000'
+    const result = parsePricingRule(expression)
+    expect(result).to.deep.equal([{
+      left: 'weight',
+      operator: 'in',
+      right: [ 4000, 6000 ]
+    }])
+  })
+
+  it('should parse weight with comparison', function() {
+    const expression = 'weight > 4000'
+    const result = parsePricingRule(expression)
+    expect(result).to.deep.equal([{
+      left: 'weight',
+      operator: '>',
+      right: 4000
+    }])
+  })
+
+})

--- a/js/tests/utils.js
+++ b/js/tests/utils.js
@@ -276,6 +276,8 @@ TestUtils.prototype.createRandomOrder = function(username, restaurant, taxCatego
 
 };
 
+let timeoutId;
+
 TestUtils.prototype.waitServerUp = function (host, port, timeout) {
   /*
     Wait for the connection to be open at the specified host/port

--- a/package-lock.json
+++ b/package-lock.json
@@ -665,6 +665,12 @@
       "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
       "dev": true
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -2221,6 +2227,20 @@
         "lazy-cache": "1.0.4"
       }
     },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
+      }
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -2233,6 +2253,12 @@
         "strip-ansi": "3.0.1",
         "supports-color": "2.0.0"
       }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "2.0.3",
@@ -3161,6 +3187,15 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -5403,6 +5438,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-stdin": {
@@ -8243,6 +8284,12 @@
       "requires": {
         "pify": "3.0.0"
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.16",
@@ -12066,6 +12113,12 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-func": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "babel-preset-stage-3": "^6.24.1",
     "beautifymarker": "git+https://git@github.com/alexsegura/BeautifyMarker.git",
     "bootstrap-sass": "^3.3.7",
+    "chai": "^4.1.2",
     "copy-webpack-plugin": "^4.5.1",
     "database-cleaner": "^1.2.0",
     "dom-autoscroller": "^2.3.4",

--- a/src/AppBundle/Entity/Restaurant.php
+++ b/src/AppBundle/Entity/Restaurant.php
@@ -541,9 +541,12 @@ class Restaurant extends FoodEstablishment
             $language = new ExpressionLanguage();
         }
 
+        $dropoff = new \stdClass();
+        $dropoff->address = $address;
+
         return $language->evaluate($this->deliveryPerimeterExpression, [
             'distance' => $distance,
-            'deliveryAddress' => $address,
+            'dropoff' => $dropoff,
         ]);
     }
 }

--- a/src/AppBundle/ExpressionLanguage/ZoneExpressionLanguageProvider.php
+++ b/src/AppBundle/ExpressionLanguage/ZoneExpressionLanguageProvider.php
@@ -21,12 +21,12 @@ class ZoneExpressionLanguageProvider implements ExpressionFunctionProviderInterf
     {
         $zoneRepository = $this->zoneRepository;
 
-        $compiler = function (Address $address, $zoneName) use ($zoneRepository) {
+        $inZoneCompiler = function (Address $address, $zoneName) use ($zoneRepository) {
             // FIXME Need to test compilation
             return sprintf('($zone = $zoneRepository->findOneBy([\'name\' => %1$s]) && $zone->containsAddress($address))', $zoneName);
         };
 
-        $evaluator = function ($arguments, Address $address, $zoneName) use ($zoneRepository) {
+        $inZoneEvaluator = function ($arguments, Address $address, $zoneName) use ($zoneRepository) {
 
             if ($zone = $zoneRepository->findOneBy(['name' => $zoneName])) {
                 return $zone->containsAddress($address);
@@ -35,8 +35,23 @@ class ZoneExpressionLanguageProvider implements ExpressionFunctionProviderInterf
             return false;
         };
 
+        $outZoneCompiler = function (Address $address, $zoneName) use ($zoneRepository) {
+            // FIXME Need to test compilation
+            return sprintf('($zone = $zoneRepository->findOneBy([\'name\' => %1$s]) && !$zone->containsAddress($address))', $zoneName);
+        };
+
+        $outZoneEvaluator = function ($arguments, Address $address, $zoneName) use ($zoneRepository) {
+
+            if ($zone = $zoneRepository->findOneBy(['name' => $zoneName])) {
+                return !$zone->containsAddress($address);
+            }
+
+            return true;
+        };
+
         return array(
-            new ExpressionFunction('in_zone', $compiler, $evaluator)
+            new ExpressionFunction('in_zone', $inZoneCompiler, $inZoneEvaluator),
+            new ExpressionFunction('out_zone', $outZoneCompiler, $outZoneEvaluator),
         );
     }
 }

--- a/tests/AppBundle/Entity/Delivery/PricingRuleTest.php
+++ b/tests/AppBundle/Entity/Delivery/PricingRuleTest.php
@@ -2,9 +2,13 @@
 
 namespace AppBundle\Entity\Delivery;
 
+use AppBundle\Entity\Address;
+use AppBundle\Entity\Base\GeoCoordinates;
 use AppBundle\Entity\Delivery;
 use AppBundle\Entity\Delivery\PricingRule;
+use AppBundle\Entity\Task;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class PricingRuleTest extends TestCase
 {
@@ -64,5 +68,40 @@ class PricingRuleTest extends TestCase
 
         // 15€ + 3€ per km = 15 + 2,5 * 3
         $this->assertEquals(22.5, $rule->evaluatePrice($delivery));
+    }
+
+    public function testToExpressionLanguageValues()
+    {
+        $pickupAddress = new Address();
+        $pickupAddress->setGeo(new GeoCoordinates(48.842049, 2.331181));
+
+        $pickup = new Task();
+        $pickup->setType(Task::TYPE_PICKUP);
+        $pickup->setAddress($pickupAddress);
+
+        $dropoffAddress = new Address();
+        $dropoffAddress->setGeo(new GeoCoordinates(48.842049, 2.331181));
+
+        $dropoff = new Task();
+        $dropoff->setType(Task::TYPE_DROPOFF);
+        $dropoff->setAddress($dropoffAddress);
+
+        $delivery = new Delivery();
+        $delivery->setDistance(2500);
+        $delivery->addTask($pickup);
+        $delivery->addTask($dropoff);
+
+        $values = PricingRule::toExpressionLanguageValues($delivery);
+
+        $this->assertArrayHasKey('distance', $values);
+        $this->assertArrayHasKey('weight', $values);
+        $this->assertArrayHasKey('vehicle', $values);
+        $this->assertArrayHasKey('pickup', $values);
+        $this->assertArrayHasKey('dropoff', $values);
+
+        $language = new ExpressionLanguage();
+
+        $this->assertEquals($pickupAddress, $language->evaluate('pickup.address', $values));
+        $this->assertEquals($dropoffAddress, $language->evaluate('dropoff.address', $values));
     }
 }

--- a/tests/AppBundle/ExpressionLanguage/ZoneExpressionLanguageProviderTest.php
+++ b/tests/AppBundle/ExpressionLanguage/ZoneExpressionLanguageProviderTest.php
@@ -49,6 +49,20 @@ class ZoneExpressionLanguageProviderTest extends TestCase
         $this->assertTrue($this->language->evaluate('in_zone(address, "paris_south_area")', [
             'address' => $address,
         ]));
+
+        // Test with dot notation
+
+        $pickup = new \stdClass();
+        $pickup->address = $address;
+
+        $this->assertTrue($this->language->evaluate('in_zone(pickup.address, zone)', [
+            'pickup' => $pickup,
+            'zone' => 'paris_south_area',
+        ]));
+
+        $this->assertTrue($this->language->evaluate('in_zone(pickup.address, "paris_south_area")', [
+            'pickup' => $pickup,
+        ]));
     }
 
     public function testInZoneReturnsFalse()

--- a/tests/AppBundle/ExpressionLanguage/ZoneExpressionLanguageProviderTest.php
+++ b/tests/AppBundle/ExpressionLanguage/ZoneExpressionLanguageProviderTest.php
@@ -34,7 +34,7 @@ class ZoneExpressionLanguageProviderTest extends TestCase
             ->willReturn(null);
     }
 
-    public function testIsInsideZone()
+    public function testInZoneReturnsTrue()
     {
         $this->language->registerProvider(new ZoneExpressionLanguageProvider($this->zoneRepository->reveal()));
 
@@ -51,7 +51,7 @@ class ZoneExpressionLanguageProviderTest extends TestCase
         ]));
     }
 
-    public function testIsOutsideZone()
+    public function testInZoneReturnsFalse()
     {
         $this->language->registerProvider(new ZoneExpressionLanguageProvider($this->zoneRepository->reveal()));
 
@@ -64,6 +64,55 @@ class ZoneExpressionLanguageProviderTest extends TestCase
         ]));
 
         $this->assertFalse($this->language->evaluate('in_zone(address, "paris_south_area")', [
+            'address' => $address,
+        ]));
+    }
+
+    public function testOutZoneReturnsTrue()
+    {
+        $this->language->registerProvider(new ZoneExpressionLanguageProvider($this->zoneRepository->reveal()));
+
+        // Métro Porte de la Chapelle
+        $address = new Address();
+        $address->setGeo(new GeoCoordinates(48.897950, 2.359177));
+
+        $this->assertTrue($this->language->evaluate('out_zone(address, zone)', [
+            'address' => $address,
+            'zone' => 'paris_south_area',
+        ]));
+
+        $this->assertTrue($this->language->evaluate('out_zone(address, "paris_south_area")', [
+            'address' => $address,
+        ]));
+
+        // Test with dot notation
+
+        $pickup = new \stdClass();
+        $pickup->address = $address;
+
+        $this->assertTrue($this->language->evaluate('out_zone(pickup.address, zone)', [
+            'pickup' => $pickup,
+            'zone' => 'paris_south_area',
+        ]));
+
+        $this->assertTrue($this->language->evaluate('out_zone(pickup.address, "paris_south_area")', [
+            'pickup' => $pickup,
+        ]));
+    }
+
+    public function testOutZoneReturnsFalse()
+    {
+        $this->language->registerProvider(new ZoneExpressionLanguageProvider($this->zoneRepository->reveal()));
+
+        $address = new Address();
+        $address->setGeo(new GeoCoordinates(48.842049, 2.331181));
+
+        $this->assertFalse($this->language->evaluate('out_zone(address, zone)', [
+            'address' => $address,
+            'zone' => 'paris_south_area',
+        ]));
+
+        $this->assertFalse($this->language->evaluate('out_zone(address, "paris_south_area")', [
             'address' => $address,
         ]));
     }


### PR DESCRIPTION
Fixes #384 

I also add a new `out_zone` function, which allows smart combinations like below, to detect when a delivery is between 2 zones

<img width="656" alt="capture d ecran 2018-06-19 a 21 29 48" src="https://user-images.githubusercontent.com/1162230/41619844-f9a370fa-7407-11e8-8a93-6a3847630da9.png">

**TODO**

- [x] Add migration to replace `in_zone(deliveryAddress` by `in_zone(dropoff.address`
- [x] Apply changes to restaurant delivery perimeter 
- [x] Extract expression language parsing & add Mocha tests