### PR TITLE
Add endpoint to create deliveries.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ install:
 	@printf "\e[0;32mPopulating schema..\e[0m\n"
 	@docker-compose run php bin/console doctrine:schema:create --env=dev
 	@docker-compose run php bin/demo --env=dev
-	@docker-compose run php bin/console doctrine:migrations:version --add --all
+	@docker-compose run php bin/console doctrine:migrations:version --no-interaction --quiet --add --all
 
 osrm:
 	@mkdir -p var/osrm

--- a/app/DoctrineMigrations/Version20180802111729.php
+++ b/app/DoctrineMigrations/Version20180802111729.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20180802111729 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE TABLE store_token (id SERIAL NOT NULL, store_id INT DEFAULT NULL, token TEXT NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_2309F7225F37A13B ON store_token (token)');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_2309F722B092A811 ON store_token (store_id)');
+        $this->addSql('ALTER TABLE store_token ADD CONSTRAINT FK_2309F722B092A811 FOREIGN KEY (store_id) REFERENCES store (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('DROP TABLE store_token');
+    }
+}

--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -44,6 +44,14 @@ security:
                 authenticators:
                     - lexik_jwt_authentication.jwt_token_authenticator
 
+        api_deliveries_create:
+            pattern:   ^/api/deliveries
+            methods: [ POST ]
+            stateless: true
+            guard:
+                authenticators:
+                    - AppBundle\Security\StoreTokenAuthenticator
+
         api_deliveries:
             pattern:   ^/api/deliveries
             stateless: true

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -205,10 +205,12 @@ services:
     tags:
       - { name: doctrine.orm.entity_listener }
 
-
   my.delivery_normalizer:
     class: AppBundle\Serializer\DeliveryNormalizer
-    arguments: [ "@api_platform.jsonld.normalizer.item" ]
+    arguments:
+      - "@api_platform.jsonld.normalizer.item"
+      - "@coopcycle.geocoder"
+      - "@security.token_storage"
     tags: [ { name: serializer.normalizer, priority: 128 } ]
 
   app.restaurant_normalizer:
@@ -316,6 +318,11 @@ services:
 
   'AppBundle\Form\StoreType':
     arguments: [ '@security.authorization_checker', '@security.token_storage', '%country_iso%' ]
+    tags: [ form.type ]
+
+  'AppBundle\Form\StoreTokenType':
+    arguments:
+      - '@coopcycle.store_token_manager'
     tags: [ form.type ]
 
   'AppBundle\Form\ProductOptionType':
@@ -464,6 +471,13 @@ services:
       - "%apns_certificate_pass_phrase%"
       - "%fcm_server_api_key%"
 
+  coopcycle.geocoder:
+    class: AppBundle\Service\Geocoder
+    arguments:
+      - "@coopcycle.settings_manager"
+      - "%country_iso%"
+      - "%coopcycle.locale%"
+
   'AppBundle\Validator\Constraints\CartValidator':
     arguments: [ '@routing_service' ]
     tags:
@@ -493,6 +507,41 @@ services:
 
   'AppBundle\Action\Settings':
       arguments:
-          - '@coopcycle.settings_manager'
-          - '%country_iso%'
-          - '%coopcycle.locale%'
+        - '@coopcycle.settings_manager'
+        - '%country_iso%'
+        - '%coopcycle.locale%'
+
+  'AppBundle\Security\StoreTokenAuthenticator':
+    parent: lexik_jwt_authentication.jwt_token_authenticator.not_expiring
+    arguments: [ '@doctrine' ]
+
+  # The services below are needed to generate tokens that never expire
+  # @see https://github.com/lexik/LexikJWTAuthenticationBundle/issues/521
+
+  lexik_jwt_authentication.jws_provider.not_expiring:
+    public: true
+    parent: Lexik\Bundle\JWTAuthenticationBundle\Services\JWSProvider\JWSProviderInterface
+    arguments:
+      index_3: ~
+
+  lexik_jwt_authentication.encoder.not_expiring:
+    parent: lexik_jwt_authentication.encoder
+    arguments:
+      index_0: '@lexik_jwt_authentication.jws_provider.not_expiring'
+
+  lexik_jwt_authentication.jwt_manager.not_expiring:
+    parent: lexik_jwt_authentication.jwt_manager
+    arguments:
+      index_0: '@lexik_jwt_authentication.encoder.not_expiring'
+
+  lexik_jwt_authentication.jwt_token_authenticator.not_expiring:
+    parent: lexik_jwt_authentication.jwt_token_authenticator
+    arguments:
+      index_0: '@lexik_jwt_authentication.jwt_manager.not_expiring'
+
+  coopcycle.store_token_manager:
+    class: AppBundle\Security\StoreTokenManager
+    arguments:
+      - '@security.token_storage'
+      - '@lexik_jwt_authentication.jwt_manager.not_expiring'
+      - '@event_dispatcher'

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
         "guzzlehttp/guzzle": "~6.0",
         "csa/guzzle-bundle": "^3.0",
         "myclabs/php-enum": "^1.5",
-        "willdurand/geocoder": "3.*",
         "beberlei/DoctrineExtensions": "^1.0",
         "sentry/sentry-symfony": "^0.8.6",
         "ramsey/uuid-doctrine": "^1.4",
@@ -76,7 +75,13 @@
         "sylius/taxonomy-bundle": "^1.2",
         "sonata-project/seo-bundle": "^2.5",
         "sylius/currency-bundle": "^1.2",
-        "ocramius/proxy-manager": "2.1.*"
+        "ocramius/proxy-manager": "2.1.*",
+        "geocoder-php/google-maps-provider": "^4.2",
+        "php-http/guzzle6-adapter": "^1.1",
+        "php-http/message": "^1.6",
+        "geo6/geocoder-php-addok-provider": "^1.0",
+        "geocoder-php/chain-provider": "^4.0",
+        "geocoder-php/nominatim-provider": "^5.0"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e25c042e1a9834d09ccf7615629689f",
+    "content-hash": "081eaaba818446fb5d3c82e2d9e08197",
     "packages": [
         {
             "name": "api-platform/core",
@@ -221,6 +221,305 @@
                 "transliterator"
             ],
             "time": "2017-04-04T11:38:05+00:00"
+        },
+        {
+            "name": "cache/adapter-common",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/adapter-common.git",
+                "reference": "6320bb5f5574cb88438059b59f8708da6b6f1d32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/adapter-common/zipball/6320bb5f5574cb88438059b59f8708da6b6f1d32",
+                "reference": "6320bb5f5574cb88438059b59f8708da6b6f1d32",
+                "shasum": ""
+            },
+            "require": {
+                "cache/tag-interop": "^1.0",
+                "php": "^5.6 || ^7.0",
+                "psr/cache": "^1.0",
+                "psr/log": "^1.0",
+                "psr/simple-cache": "^1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "^0.16",
+                "phpunit/phpunit": "^5.7.21"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\Adapter\\Common\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "Common classes for PSR-6 adapters",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "psr-6",
+                "tag"
+            ],
+            "time": "2018-07-08T13:04:33+00:00"
+        },
+        {
+            "name": "cache/array-adapter",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/array-adapter.git",
+                "reference": "6e9ae7f8bbf1b07bdd6144cb944059f91ae65a14"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/array-adapter/zipball/6e9ae7f8bbf1b07bdd6144cb944059f91ae65a14",
+                "reference": "6e9ae7f8bbf1b07bdd6144cb944059f91ae65a14",
+                "shasum": ""
+            },
+            "require": {
+                "cache/adapter-common": "^1.0",
+                "cache/hierarchical-cache": "^1.0",
+                "php": "^5.6 || ^7.0",
+                "psr/cache": "^1.0",
+                "psr/simple-cache": "^1.0"
+            },
+            "provide": {
+                "psr/cache-implementation": "^1.0",
+                "psr/simple-cache-implementation": "^1.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "^0.16",
+                "phpunit/phpunit": "^5.7.21"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\Adapter\\PHPArray\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "A PSR-6 cache implementation using a php array. This implementation supports tags",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "array",
+                "cache",
+                "psr-6",
+                "tag"
+            ],
+            "time": "2017-11-19T11:08:05+00:00"
+        },
+        {
+            "name": "cache/hierarchical-cache",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/hierarchical-cache.git",
+                "reference": "97173a5115765f72ccdc90dbc01132a3786ef5fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/hierarchical-cache/zipball/97173a5115765f72ccdc90dbc01132a3786ef5fd",
+                "reference": "97173a5115765f72ccdc90dbc01132a3786ef5fd",
+                "shasum": ""
+            },
+            "require": {
+                "cache/adapter-common": "^1.0",
+                "php": "^5.6 || ^7.0",
+                "psr/cache": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.21"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\Hierarchy\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Scherer",
+                    "email": "aequasi@gmail.com",
+                    "homepage": "https://github.com/aequasi"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                }
+            ],
+            "description": "A helper trait and interface to your PSR-6 cache to support hierarchical keys.",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "hierarchical",
+                "hierarchy",
+                "psr-6"
+            ],
+            "time": "2017-07-16T21:58:17+00:00"
+        },
+        {
+            "name": "cache/tag-interop",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-cache/tag-interop.git",
+                "reference": "c7496dd81530f538af27b4f2713cde97bc292832"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-cache/tag-interop/zipball/c7496dd81530f538af27b4f2713cde97bc292832",
+                "reference": "c7496dd81530f538af27b4f2713cde97bc292832",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "psr/cache": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Cache\\TagInterop\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/nyholm"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com",
+                    "homepage": "https://github.com/nicolas-grekas"
+                }
+            ],
+            "description": "Framework interoperable interfaces for tags",
+            "homepage": "http://www.php-cache.com/en/latest/",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr6",
+                "tag"
+            ],
+            "time": "2017-03-13T09:14:27+00:00"
+        },
+        {
+            "name": "clue/stream-filter",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/php-stream-filter.git",
+                "reference": "d80fdee9b3a7e0d16fc330a22f41f3ad0eeb09d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/php-stream-filter/zipball/d80fdee9b3a7e0d16fc330a22f41f3ad0eeb09d0",
+                "reference": "d80fdee9b3a7e0d16fc330a22f41f3ad0eeb09d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.0 || ^4.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\StreamFilter\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "A simple and modern approach to stream filtering in PHP",
+            "homepage": "https://github.com/clue/php-stream-filter",
+            "keywords": [
+                "bucket brigade",
+                "callback",
+                "filter",
+                "php_user_filter",
+                "stream",
+                "stream_filter_append",
+                "stream_filter_register"
+            ],
+            "time": "2017-08-18T09:54:01+00:00"
         },
         {
             "name": "cocur/slugify",
@@ -1942,85 +2241,6 @@
             "time": "2017-05-12T12:56:51+00:00"
         },
         {
-            "name": "egeloen/http-adapter",
-            "version": "0.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/egeloen/ivory-http-adapter.git",
-                "reference": "9641f11487ec26b24c6bbcee4f267cf62f60b855"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/egeloen/ivory-http-adapter/zipball/9641f11487ec26b24c6bbcee4f267cf62f60b855",
-                "reference": "9641f11487ec26b24c6bbcee4f267cf62f60b855",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.8",
-                "zendframework/zend-diactoros": "^1.1"
-            },
-            "require-dev": {
-                "cakephp/cakephp": "^3.0.3",
-                "ext-curl": "*",
-                "guzzle/guzzle": "^3.9.4@dev",
-                "guzzlehttp/guzzle": "^4.1.4|^5.0|^6.0",
-                "kriswallsmith/buzz": "^0.13",
-                "nategood/httpful": "^0.2.17",
-                "phpunit/phpunit": "^4.0",
-                "phpunit/phpunit-mock-objects": "dev-matcher-verify as 2.3.x-dev",
-                "psr/log": "^1.0",
-                "react/dns": "^0.4.1",
-                "react/http-client": "^0.4",
-                "satooshi/php-coveralls": "^0.6",
-                "symfony/event-dispatcher": "^2.0",
-                "zendframework/zend-http": "^2.3.4",
-                "zendframework/zendframework1": ">=1.12.9,<=1.12.14|^1.12.16"
-            },
-            "suggest": {
-                "ext-curl": "Allows you to use the cURL adapter",
-                "ext-http": "Allows you to use the PECL adapter",
-                "guzzle/guzzle": "Allows you to use the Guzzle 3 adapter",
-                "guzzlehttp/guzzle": "Allows you to use the Guzzle 4 adapter",
-                "kriswallsmith/buzz": "Allows you to use the Buzz adapter",
-                "nategood/httpful": "Allows you to use the httpful adapter",
-                "psr/log": "Allows you to use the logger event subscriber",
-                "symfony/event-dispatcher": "Allows you to use the event lifecycle",
-                "symfony/stopwatch": "Allows you to use the stopwatch http adapter and event subscriber",
-                "zendframework/zend-http": "Allows you to use the Zend 2 adapter",
-                "zendframework/zendframework1": "Allows you to use the Zend 1 adapter"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.8-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Ivory\\HttpAdapter\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Eric GELOEN",
-                    "email": "geloen.eric@gmail.com"
-                }
-            ],
-            "description": "Issue HTTP request for PHP 5.3+.",
-            "keywords": [
-                "http",
-                "http-adapter",
-                "http-client",
-                "psr-7"
-            ],
-            "abandoned": "php-http/httplug",
-            "time": "2015-08-12T09:35:40+00:00"
-        },
-        {
             "name": "emcconville/google-map-polyline-encoding-tool",
             "version": "v1.3",
             "source": {
@@ -2379,6 +2599,290 @@
             "time": "2018-05-08T12:28:40+00:00"
         },
         {
+            "name": "geo6/geocoder-php-addok-provider",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/geo6/geocoder-php-addok-provider.git",
+                "reference": "6fe7a2b9c35e010e2416de5075aabf6bc9179e25"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/geo6/geocoder-php-addok-provider/zipball/6fe7a2b9c35e010e2416de5075aabf6bc9179e25",
+                "reference": "6fe7a2b9c35e010e2416de5075aabf6bc9179e25",
+                "shasum": ""
+            },
+            "require": {
+                "geocoder-php/common-http": "^4.0",
+                "php": "^7.0",
+                "willdurand/geocoder": "^4.0"
+            },
+            "provide": {
+                "geocoder-php/provider-implementation": "1.0"
+            },
+            "require-dev": {
+                "geocoder-php/provider-integration-tests": "^1.0",
+                "nyholm/psr7": "^0.2.2",
+                "php-http/curl-client": "^1.7",
+                "php-http/message": "^1.0",
+                "phpunit/phpunit": "6.3.*|6.5.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Geocoder\\Provider\\Addok\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Beliën",
+                    "email": "jbe@geo6.be"
+                }
+            ],
+            "description": "Geocoder addok adapter",
+            "time": "2018-02-12T16:53:19+00:00"
+        },
+        {
+            "name": "geocoder-php/chain-provider",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/geocoder-php/chain-provider.git",
+                "reference": "c327807dc455c2fee8c951d8fadbb5a60cfdcd48"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/geocoder-php/chain-provider/zipball/c327807dc455c2fee8c951d8fadbb5a60cfdcd48",
+                "reference": "c327807dc455c2fee8c951d8fadbb5a60cfdcd48",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "psr/log": "^1.0",
+                "willdurand/geocoder": "^4.0"
+            },
+            "provide": {
+                "geocoder-php/provider-implementation": "1.0"
+            },
+            "require-dev": {
+                "nyholm/nsa": "^1.1",
+                "nyholm/psr7": "^0.2.2",
+                "php-http/curl-client": "^1.7",
+                "php-http/message": "^1.0",
+                "phpunit/phpunit": "^6.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Geocoder\\Provider\\Chain\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "William Durand",
+                    "email": "william.durand1@gmail.com"
+                }
+            ],
+            "description": "Geocoder chain adapter",
+            "homepage": "http://geocoder-php.org/Geocoder/",
+            "time": "2017-08-01T07:23:53+00:00"
+        },
+        {
+            "name": "geocoder-php/common-http",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/geocoder-php/php-common-http.git",
+                "reference": "99db54307a4b12e4cb4a8c3fbafc41c395c97d65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/geocoder-php/php-common-http/zipball/99db54307a4b12e4cb4a8c3fbafc41c395c97d65",
+                "reference": "99db54307a4b12e4cb4a8c3fbafc41c395c97d65",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "php-http/client-implementation": "^1.0",
+                "php-http/discovery": "^1.4",
+                "php-http/httplug": "^1.0",
+                "php-http/message-factory": "^1.0.2",
+                "psr/http-message": "^1.0",
+                "psr/http-message-implementation": "^1.0",
+                "willdurand/geocoder": "^4.0"
+            },
+            "require-dev": {
+                "nyholm/psr7": "^0.2.2",
+                "php-http/message": "^1.0",
+                "php-http/mock-client": "^1.0",
+                "phpunit/phpunit": "6.3.*",
+                "symfony/stopwatch": "~2.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Geocoder\\Http\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                }
+            ],
+            "description": "Common files for HTTP based Geocoders",
+            "homepage": "http://geocoder-php.org",
+            "keywords": [
+                "http geocoder"
+            ],
+            "time": "2018-06-28T09:46:39+00:00"
+        },
+        {
+            "name": "geocoder-php/google-maps-provider",
+            "version": "4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/geocoder-php/google-maps-provider.git",
+                "reference": "f5ce45372f705c1ce6338ae07b9fc7eb1a7bcb05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/geocoder-php/google-maps-provider/zipball/f5ce45372f705c1ce6338ae07b9fc7eb1a7bcb05",
+                "reference": "f5ce45372f705c1ce6338ae07b9fc7eb1a7bcb05",
+                "shasum": ""
+            },
+            "require": {
+                "geocoder-php/common-http": "^4.0",
+                "php": "^7.0",
+                "willdurand/geocoder": "^4.0"
+            },
+            "provide": {
+                "geocoder-php/provider-implementation": "1.0"
+            },
+            "require-dev": {
+                "geocoder-php/provider-integration-tests": "^1.0",
+                "nyholm/psr7": "^0.2.2",
+                "php-http/curl-client": "^1.7",
+                "php-http/message": "^1.0",
+                "phpunit/phpunit": "6.3.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Geocoder\\Provider\\GoogleMaps\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "William Durand",
+                    "email": "william.durand1@gmail.com"
+                }
+            ],
+            "description": "Geocoder GoogleMaps adapter",
+            "homepage": "http://geocoder-php.org/Geocoder/",
+            "time": "2018-03-03T14:37:50+00:00"
+        },
+        {
+            "name": "geocoder-php/nominatim-provider",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/geocoder-php/nominatim-provider.git",
+                "reference": "38d9299ae3cb95cd5eb354008dc19884d00f7edc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/geocoder-php/nominatim-provider/zipball/38d9299ae3cb95cd5eb354008dc19884d00f7edc",
+                "reference": "38d9299ae3cb95cd5eb354008dc19884d00f7edc",
+                "shasum": ""
+            },
+            "require": {
+                "geocoder-php/common-http": "^4.1",
+                "php": "^7.0",
+                "willdurand/geocoder": "^4.0"
+            },
+            "provide": {
+                "geocoder-php/provider-implementation": "1.0"
+            },
+            "require-dev": {
+                "geocoder-php/provider-integration-tests": "^1.0",
+                "nyholm/psr7": "^0.2.2",
+                "php-http/curl-client": "^1.7",
+                "php-http/message": "^1.0",
+                "phpunit/phpunit": "6.3.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Geocoder\\Provider\\Nominatim\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "William Durand",
+                    "email": "william.durand1@gmail.com"
+                }
+            ],
+            "description": "Geocoder Nominatim adapter",
+            "homepage": "http://geocoder-php.org/Geocoder/",
+            "time": "2018-07-08T11:28:45+00:00"
+        },
+        {
             "name": "gesdinet/jwt-refresh-token-bundle",
             "version": "v0.2.1",
             "source": {
@@ -2728,51 +3232,6 @@
                 "url"
             ],
             "time": "2017-03-20T17:10:46+00:00"
-        },
-        {
-            "name": "igorw/get-in",
-            "version": "v1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/igorw/get-in.git",
-                "reference": "170ded831f49abc6a6061f655aba9bdbcf7b8111"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/igorw/get-in/zipball/170ded831f49abc6a6061f655aba9bdbcf7b8111",
-                "reference": "170ded831f49abc6a6061f655aba9bdbcf7b8111",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/get_in.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Igor Wiedler",
-                    "email": "igor@wiedler.ch"
-                }
-            ],
-            "description": "Functions for for hash map (assoc array) traversal.",
-            "keywords": [
-                "assoc-array",
-                "hash-map"
-            ],
-            "time": "2014-12-15T23:03:51+00:00"
         },
         {
             "name": "illuminate/cache",
@@ -3988,35 +4447,35 @@
         },
         {
             "name": "league/geotools",
-            "version": "0.7.0",
+            "version": "0.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/geotools.git",
-                "reference": "011c9649aed56e355de0fb7d51c9ccde0343da8e"
+                "reference": "ed02a15c76bbf793a87932d8c55b83a3783429ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/geotools/zipball/011c9649aed56e355de0fb7d51c9ccde0343da8e",
-                "reference": "011c9649aed56e355de0fb7d51c9ccde0343da8e",
+                "url": "https://api.github.com/repos/thephpleague/geotools/zipball/ed02a15c76bbf793a87932d8c55b83a3783429ea",
+                "reference": "ed02a15c76bbf793a87932d8c55b83a3783429ea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
+                "cache/array-adapter": "^1.0",
+                "php": "^7.0",
+                "php-http/discovery": "^1.0",
+                "psr/cache": "^1.0",
                 "react/event-loop": "0.4.*",
-                "react/promise": "~2.2",
-                "symfony/console": "~2.7|~3.0",
-                "symfony/property-access": "~2.7|~3.0",
-                "symfony/serializer": "~2.7|~3.0",
-                "willdurand/geocoder": "~3.2"
+                "react/promise": "^2.2",
+                "symfony/console": "^2.7 || ^3.0 || ^4.0",
+                "symfony/property-access": "^2.7 || ^3.0 || ^4.0",
+                "symfony/serializer": "^2.7 || ^3.0 || ^4.0",
+                "willdurand/geocoder": "^4.2"
             },
             "replace": {
                 "toin0u/geotools": "*"
             },
             "require-dev": {
-                "guzzle/guzzle": "~3.7",
-                "kriswallsmith/buzz": "~0.10",
-                "predis/predis": "~1.0",
-                "zendframework/zend-http": "~2.2"
+                "phpunit/phpunit": "^6.5.5 || ^7.0"
             },
             "bin": [
                 "bin/geotools"
@@ -4045,7 +4504,7 @@
                     "role": "Developer"
                 }
             ],
-            "description": "Geo-related tools PHP 5.4+ library (use 0.4 if you're using PHP 5.3)",
+            "description": "Geo-related tools PHP 7.0+ library",
             "homepage": "http://geotools-php.org/",
             "keywords": [
                 "async",
@@ -4058,7 +4517,7 @@
                 "geometry",
                 "geotools"
             ],
-            "time": "2016-02-03T16:31:33+00:00"
+            "time": "2018-02-22T05:37:51+00:00"
         },
         {
             "name": "lexik/jwt-authentication-bundle",
@@ -5056,6 +5515,356 @@
                 "random"
             ],
             "time": "2018-07-04T16:31:37+00:00"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "9a6cb24de552bfe1aa9d7d1569e2d49c5b169a33"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/9a6cb24de552bfe1aa9d7d1569e2d49c5b169a33",
+                "reference": "9a6cb24de552bfe1aa9d7d1569e2d49c5b169a33",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^2.0.2",
+                "php-http/httplug": "^1.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^2.4",
+                "puli/composer-plugin": "1.0.0-beta10"
+            },
+            "suggest": {
+                "php-http/message": "Allow to use Guzzle, Diactoros or Slim Framework factories",
+                "puli/composer-plugin": "Sets up Puli which is recommended for Discovery to work. Check http://docs.php-http.org/en/latest/discovery.html for more details."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds installed HTTPlug implementations and PSR-7 message factories",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr7"
+            ],
+            "time": "2018-02-06T10:55:24+00:00"
+        },
+        {
+            "name": "php-http/guzzle6-adapter",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/guzzle6-adapter.git",
+                "reference": "a56941f9dc6110409cfcddc91546ee97039277ab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/guzzle6-adapter/zipball/a56941f9dc6110409cfcddc91546ee97039277ab",
+                "reference": "a56941f9dc6110409cfcddc91546ee97039277ab",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.0",
+                "php": ">=5.5.0",
+                "php-http/httplug": "^1.0"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "1.0",
+                "php-http/client-implementation": "1.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "php-http/adapter-integration-tests": "^0.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Adapter\\Guzzle6\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "David de Boer",
+                    "email": "david@ddeboer.nl"
+                }
+            ],
+            "description": "Guzzle 6 HTTP Adapter",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "Guzzle",
+                "http"
+            ],
+            "time": "2016-05-10T06:13:32+00:00"
+        },
+        {
+            "name": "php-http/httplug",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/httplug.git",
+                "reference": "1c6381726c18579c4ca2ef1ec1498fdae8bdf018"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/httplug/zipball/1c6381726c18579c4ca2ef1ec1498fdae8bdf018",
+                "reference": "1c6381726c18579c4ca2ef1ec1498fdae8bdf018",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "php-http/promise": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eric GELOEN",
+                    "email": "geloen.eric@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "HTTPlug, the HTTP client abstraction for PHP",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "http"
+            ],
+            "time": "2016-08-31T08:30:17+00:00"
+        },
+        {
+            "name": "php-http/message",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/message.git",
+                "reference": "2edd63bae5f52f79363c5f18904b05ce3a4b7253"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/message/zipball/2edd63bae5f52f79363c5f18904b05ce3a4b7253",
+                "reference": "2edd63bae5f52f79363c5f18904b05ce3a4b7253",
+                "shasum": ""
+            },
+            "require": {
+                "clue/stream-filter": "^1.3",
+                "php": ">=5.4",
+                "php-http/message-factory": "^1.0.2",
+                "psr/http-message": "^1.0"
+            },
+            "provide": {
+                "php-http/message-factory-implementation": "1.0"
+            },
+            "require-dev": {
+                "akeneo/phpspec-skip-example-extension": "^1.0",
+                "coduo/phpspec-data-provider-extension": "^1.0",
+                "ext-zlib": "*",
+                "guzzlehttp/psr7": "^1.0",
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4",
+                "slim/slim": "^3.0",
+                "zendframework/zend-diactoros": "^1.0"
+            },
+            "suggest": {
+                "ext-zlib": "Used with compressor/decompressor streams",
+                "guzzlehttp/psr7": "Used with Guzzle PSR-7 Factories",
+                "slim/slim": "Used with Slim Framework PSR-7 implementation",
+                "zendframework/zend-diactoros": "Used with Diactoros Factories"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Message\\": "src/"
+                },
+                "files": [
+                    "src/filters.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "HTTP Message related tools",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7"
+            ],
+            "time": "2017-07-05T06:40:53+00:00"
+        },
+        {
+            "name": "php-http/message-factory",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/message-factory.git",
+                "reference": "a478cb11f66a6ac48d8954216cfed9aa06a501a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/message-factory/zipball/a478cb11f66a6ac48d8954216cfed9aa06a501a1",
+                "reference": "a478cb11f66a6ac48d8954216cfed9aa06a501a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Factory interfaces for PSR-7 HTTP Message",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "stream",
+                "uri"
+            ],
+            "time": "2015-12-19T14:08:53+00:00"
+        },
+        {
+            "name": "php-http/promise",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/promise.git",
+                "reference": "dc494cdc9d7160b9a09bd5573272195242ce7980"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/promise/zipball/dc494cdc9d7160b9a09bd5573272195242ce7980",
+                "reference": "dc494cdc9d7160b9a09bd5573272195242ce7980",
+                "shasum": ""
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^1.0",
+                "phpspec/phpspec": "^2.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                },
+                {
+                    "name": "Joel Wurtz",
+                    "email": "joel.wurtz@gmail.com"
+                }
+            ],
+            "description": "Promise used for asynchronous HTTP requests",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-01-26T13:27:02+00:00"
         },
         {
             "name": "phpcollection/phpcollection",
@@ -9128,43 +9937,42 @@
         },
         {
             "name": "willdurand/geocoder",
-            "version": "v3.3.2",
+            "version": "4.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/geocoder-php/php-common.git",
-                "reference": "ccc178e2984c0af24881faa0ffe515f20e5e8c23"
+                "reference": "5e97b3c3d830fe47474cb331a05b4c63e16217b9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/geocoder-php/php-common/zipball/ccc178e2984c0af24881faa0ffe515f20e5e8c23",
-                "reference": "ccc178e2984c0af24881faa0ffe515f20e5e8c23",
+                "url": "https://api.github.com/repos/geocoder-php/php-common/zipball/5e97b3c3d830fe47474cb331a05b4c63e16217b9",
+                "reference": "5e97b3c3d830fe47474cb331a05b4c63e16217b9",
                 "shasum": ""
             },
             "require": {
-                "egeloen/http-adapter": "~0.8",
-                "igorw/get-in": "~1.0",
-                "php": ">=5.4.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "geoip2/geoip2": "~2.0",
+                "nyholm/nsa": "^1.1",
+                "phpunit/phpunit": "6.3.*",
                 "symfony/stopwatch": "~2.5"
             },
             "suggest": {
-                "ext-geoip": "Enabling the geoip extension allows you to use the MaxMindProvider.",
-                "geoip/geoip": "If you are going to use the MaxMindBinaryProvider (conflict with geoip extension).",
-                "geoip2/geoip2": "If you are going to use the GeoIP2DatabaseProvider.",
                 "symfony/stopwatch": "If you want to use the TimedGeocoder"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Geocoder": "src/"
-                }
+                "psr-4": {
+                    "Geocoder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -9176,7 +9984,7 @@
                     "email": "william.durand1@gmail.com"
                 }
             ],
-            "description": "The almost missing Geocoder PHP 5.4 library.",
+            "description": "Common files for PHP Geocoder",
             "homepage": "http://geocoder-php.org",
             "keywords": [
                 "abstraction",
@@ -9184,7 +9992,7 @@
                 "geocoding",
                 "geoip"
             ],
-            "time": "2015-12-06T20:17:20+00:00"
+            "time": "2018-02-10T13:22:58+00:00"
         },
         {
             "name": "willdurand/hateoas",
@@ -9548,69 +10356,6 @@
                 "zf2"
             ],
             "time": "2017-10-20T15:21:32+00:00"
-        },
-        {
-            "name": "zendframework/zend-diactoros",
-            "version": "1.8.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-diactoros.git",
-                "reference": "273c18bf6aaab20be9667a3aa4e7702e1e4e7ced"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/273c18bf6aaab20be9667a3aa4e7702e1e4e7ced",
-                "reference": "273c18bf6aaab20be9667a3aa4e7702e1e4e7ced",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0",
-                "psr/http-message": "^1.0"
-            },
-            "provide": {
-                "psr/http-message-implementation": "1.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "phpunit/phpunit": "^5.7.16 || ^6.0.8",
-                "zendframework/zend-coding-standard": "~1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.8.x-dev",
-                    "dev-develop": "1.9.x-dev",
-                    "dev-release-2.0": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/functions/create_uploaded_file.php",
-                    "src/functions/marshal_headers_from_sapi.php",
-                    "src/functions/marshal_method_from_sapi.php",
-                    "src/functions/marshal_protocol_version_from_sapi.php",
-                    "src/functions/marshal_uri_from_sapi.php",
-                    "src/functions/normalize_server.php",
-                    "src/functions/normalize_uploaded_files.php",
-                    "src/functions/parse_cookie_header.php"
-                ],
-                "psr-4": {
-                    "Zend\\Diactoros\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "description": "PSR HTTP Message implementations",
-            "homepage": "https://github.com/zendframework/zend-diactoros",
-            "keywords": [
-                "http",
-                "psr",
-                "psr-7"
-            ],
-            "time": "2018-07-19T18:38:31+00:00"
         },
         {
             "name": "zendframework/zend-eventmanager",

--- a/features/deliveries.feature
+++ b/features/deliveries.feature
@@ -1,0 +1,130 @@
+Feature: Deliveries
+
+  Scenario: Create delivery with pickup & dropoff
+    Given the database is empty
+    And the fixtures file "stores.yml" is loaded
+    And the user "bob" is loaded:
+      | email      | bob@coopcycle.org |
+      | password   | 123456            |
+    And the store with name "Acme" belongs to user "bob"
+    And the store with name "Acme" is authenticated as "bob"
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "POST" request to "/api/deliveries" with body:
+      """
+      {
+        "pickup": {
+          "address": "24, Rue de la Paix",
+          "doneBefore": "tomorrow 13:00"
+        },
+        "dropoff": {
+          "address": "48, Rue de Rivoli",
+          "doneBefore": "tomorrow 13:30"
+        }
+      }
+      """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context":"/api/contexts/Delivery",
+        "@id":"@string@.startsWith('/api/deliveries')",
+        "@type":"http://schema.org/ParcelDelivery",
+        "id":@integer@,
+        "status":null,
+        "pickup":{
+          "address":{
+            "@context":"/api/contexts/Address",
+            "@id":"@string@.startsWith('/api/addresses')",
+            "@type":"http://schema.org/Place",
+            "geo":{
+              "latitude":@double@,
+              "longitude":@double@
+            },
+            "streetAddress":@string@,
+            "telephone":null,
+            "name":null
+          }
+        },
+        "dropoff":{
+          "address":{
+            "@context":"/api/contexts/Address",
+            "@id":"@string@.startsWith('/api/addresses')",
+            "@type":"http://schema.org/Place",
+            "geo":{
+              "latitude":@double@,
+              "longitude":@double@
+            },
+            "streetAddress":@string@,
+            "telephone":null,
+            "name":null
+          }
+        },
+        "color":@string@
+      }
+      """
+
+  Scenario: Create delivery with implicit pickup
+    Given the database is empty
+    And the fixtures file "stores.yml" is loaded
+    And the user "bob" is loaded:
+      | email      | bob@coopcycle.org |
+      | password   | 123456            |
+    And the store with name "Acme" belongs to user "bob"
+    And the store with name "Acme" is authenticated as "bob"
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "POST" request to "/api/deliveries" with body:
+      """
+      {
+        "pickup": {
+          "doneBefore": "tomorrow 13:00"
+        },
+        "dropoff": {
+          "address": "48, Rue de Rivoli",
+          "doneBefore": "tomorrow 13:30"
+        }
+      }
+      """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context":"/api/contexts/Delivery",
+        "@id":"@string@.startsWith('/api/deliveries')",
+        "@type":"http://schema.org/ParcelDelivery",
+        "id":@integer@,
+        "status":null,
+        "pickup":{
+          "address":{
+            "@context":"/api/contexts/Address",
+            "@id":"@string@.startsWith('/api/addresses')",
+            "@type":"http://schema.org/Place",
+            "geo":{
+              "latitude":@double@,
+              "longitude":@double@
+            },
+            "streetAddress":@string@,
+            "telephone":null,
+            "name":null
+          }
+        },
+        "dropoff":{
+          "address":{
+            "@context":"/api/contexts/Address",
+            "@id":"@string@.startsWith('/api/addresses')",
+            "@type":"http://schema.org/Place",
+            "geo":{
+              "latitude":@double@,
+              "longitude":@double@
+            },
+            "streetAddress":@string@,
+            "telephone":null,
+            "name":null
+          }
+        },
+        "color":@string@
+      }
+      """

--- a/features/fixtures/ORM/stores.yml
+++ b/features/fixtures/ORM/stores.yml
@@ -1,0 +1,17 @@
+AppBundle\Entity\Base\GeoCoordinates:
+  geo_1:
+    __construct: [ "48.864577", "2.333338" ]
+
+AppBundle\Entity\Address:
+  address_1:
+    addressLocality: 'Paris'
+    postalCode: 75001
+    streetAddress: '272, rue Saint Honoré 75001 Paris 1er'
+    geo: "@geo_1"
+
+AppBundle\Entity\Store:
+  store_1:
+    name: 'Acme'
+    address: "@address_1"
+    openingHours: ['Mo-Sa 11:30-14:30']
+    enabled: true

--- a/js/app/common.js
+++ b/js/app/common.js
@@ -2,6 +2,8 @@
 const $ = require('jquery')
 global.$ = global.jQuery = $
 
+global.ClipboardJS = require('clipboard')
+
 // polyfill for `startsWith` not implemented in IE11
 if (!String.prototype.startsWith) {
   String.prototype.startsWith = function(searchString, position) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2361,6 +2361,17 @@
         "rimraf": "2.6.2"
       }
     },
+    "clipboard": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.1.tgz",
+      "integrity": "sha512-7yhQBmtN+uYZmfRjjVjKa0dZdWuabzpSKGtyQZN+9C8xlC788SSJjOHWh7tzurfwTqTD5UDYAhIv5fRJg3sHjQ==",
+      "dev": true,
+      "requires": {
+        "good-listener": "1.2.2",
+        "select": "1.1.2",
+        "tiny-emitter": "2.0.2"
+      }
+    },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -2734,11 +2745,11 @@
       "requires": {
         "form-data": "2.3.2",
         "isomorphic-fetch": "2.2.1",
-        "localforage": "1.7.1",
+        "localforage": "1.7.2",
         "lodash": "4.17.10",
         "lodash.groupby": "4.6.0",
         "object-hash": "1.3.0",
-        "react-scroll": "1.7.9"
+        "react-scroll": "1.7.10"
       }
     },
     "copy-concurrently": {
@@ -3333,6 +3344,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -5581,6 +5598,15 @@
         "minimatch": "3.0.4"
       }
     },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
+      "requires": {
+        "delegate": "3.2.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -6841,9 +6867,9 @@
       }
     },
     "localforage": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.1.tgz",
-      "integrity": "sha1-5JJ+BCMCuGTbMPMhHxO1xvDell0=",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.2.tgz",
+      "integrity": "sha1-+kRCYC+Abt0rympUq05lbwMfEhw=",
       "requires": {
         "lie": "3.1.1"
       }
@@ -10134,9 +10160,9 @@
       }
     },
     "react-scroll": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.7.9.tgz",
-      "integrity": "sha512-baTwyz2FxaZWZ/4yEAWQEGE4CMZzGj/AjvLu/x4xmAisFgSAq3D0QED3deI6D4zeJTSEmeuy8Hm01IS+IDbKIg==",
+      "version": "1.7.10",
+      "resolved": "https://registry.npmjs.org/react-scroll/-/react-scroll-1.7.10.tgz",
+      "integrity": "sha512-7K1caXF19PQ/jck+QRCdRMytqWei1ktv7jtcsgMap2s55pGOUc/a5phr4loajZRFRx3qKj9Tz12KDtELp91xMg==",
       "requires": {
         "lodash.throttle": "4.1.1",
         "prop-types": "15.6.2"
@@ -10854,6 +10880,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/section-iterator/-/section-iterator-2.0.0.tgz",
       "integrity": "sha1-v0RNev7rlK1Dw5rS+yYVFifMuio=",
+      "dev": true
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
       "dev": true
     },
     "select-hose": {
@@ -12142,6 +12174,12 @@
       "requires": {
         "setimmediate": "1.0.5"
       }
+    },
+    "tiny-emitter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
+      "dev": true
     },
     "tinycolor2": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "beautifymarker": "git+https://git@github.com/alexsegura/BeautifyMarker.git",
     "bootstrap-sass": "^3.3.7",
     "chai": "^4.1.2",
+    "clipboard": "^2.0.1",
     "copy-webpack-plugin": "^4.5.2",
     "database-cleaner": "^1.2.0",
     "dom-autoscroller": "^2.3.4",

--- a/src/AppBundle/Action/Me.php
+++ b/src/AppBundle/Action/Me.php
@@ -5,6 +5,7 @@ namespace AppBundle\Action;
 use AppBundle\Action\Utils\TokenStorageTrait;
 use AppBundle\Entity\ApiUser;
 use AppBundle\Entity\Delivery;
+use AppBundle\Entity\Restaurant;
 use AppBundle\Entity\Task;
 use AppBundle\Entity\TaskList;
 use Doctrine\Common\Persistence\ManagerRegistry as DoctrineRegistry;
@@ -155,5 +156,19 @@ class Me
         ]));
 
         return new JsonResponse([]);
+    }
+
+    /**
+     * @Route(path="/me/restaurants", name="me_restaurants",
+     *   defaults={
+     *     "_api_resource_class"=Restaurant::class,
+     *     "_api_collection_operation_name"="me_restaurants",
+     *   }
+     * )
+     * @Method("GET")
+     */
+    public function restaurantsAction(Request $request)
+    {
+        return $this->getUser()->getRestaurants();
     }
 }

--- a/src/AppBundle/Action/Register.php
+++ b/src/AppBundle/Action/Register.php
@@ -9,7 +9,7 @@ use FOS\UserBundle\Util\UserManipulator;
 use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
 use Lexik\Bundle\JWTAuthenticationBundle\Events;
 use Lexik\Bundle\JWTAuthenticationBundle\Response\JWTAuthenticationSuccessResponse;
-use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTManager;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\FormFactoryInterface;
@@ -27,7 +27,7 @@ class Register
     public function __construct(
         UserManipulator $userManipulator,
         UserManagerInterface $userManager,
-        JWTManager $jwtManager,
+        JWTTokenManagerInterface $jwtManager,
         EventDispatcherInterface $dispatcher,
         FormFactoryInterface $formFactory
     )

--- a/src/AppBundle/Controller/Utils/StoreTrait.php
+++ b/src/AppBundle/Controller/Utils/StoreTrait.php
@@ -4,6 +4,7 @@ namespace AppBundle\Controller\Utils;
 
 use AppBundle\Entity\Delivery;
 use AppBundle\Entity\Store;
+use AppBundle\Form\StoreTokenType;
 use AppBundle\Form\StoreType;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -57,6 +58,7 @@ trait StoreTrait
             'form' => $form->createView(),
             'stores_route' => $routes['stores'],
             'store_delivery_route' => $routes['store_delivery'],
+            'store_api_keys_route' => $routes['store_api_keys'],
         ]);
     }
 
@@ -110,5 +112,38 @@ trait StoreTrait
         $store = $this->getDoctrine()->getRepository(Store::class)->find($id);
 
         return $this->renderStoreForm($store, $request);
+    }
+
+    public function apiKeysAction($id, Request $request)
+    {
+        $store = $this->getDoctrine()
+            ->getRepository(Store::class)
+            ->find($id);
+
+        $token = $store->getToken();
+
+        $routes = $request->attributes->get('routes');
+
+        $form = $this->createForm(StoreTokenType::class, $store);
+
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+
+            $store = $form->getData();
+
+            $this->getDoctrine()
+                ->getManagerForClass(Store::class)
+                ->flush();
+
+            return $this->redirectToRoute($routes['success'], ['id' => $store->getId()]);
+        }
+
+        return $this->render('@App/Store/apiKeys.html.twig', [
+            'layout' => $request->attributes->get('layout'),
+            'store' => $store,
+            'token' => $token,
+            'form' => $form->createView(),
+            'stores_route' => $routes['stores'],
+        ]);
     }
 }

--- a/src/AppBundle/Entity/Delivery.php
+++ b/src/AppBundle/Entity/Delivery.php
@@ -15,7 +15,9 @@ use Symfony\Component\Serializer\Annotation\Groups;
  * @see http://schema.org/ParcelDelivery Documentation on Schema.org
  *
  * @ApiResource(iri="http://schema.org/ParcelDelivery",
- *   collectionOperations={},
+ *   collectionOperations={
+ *     "post"={"method"="POST"}
+ *   },
  *   itemOperations={
  *     "get"={"method"="GET"}
  *   },
@@ -51,18 +53,6 @@ class Delivery extends TaskCollection implements TaskCollectionInterface
      * @Groups({"delivery"})
      */
     protected $id;
-
-    /**
-     * @Groups({"place", "order"})
-     * @ApiProperty(iri="https://schema.org/Place")
-     */
-    private $originAddress;
-
-    /**
-     * @Groups({"order_create", "place", "order"})
-     * @ApiProperty(iri="https://schema.org/Place")
-     */
-    private $deliveryAddress;
 
     private $order;
 

--- a/src/AppBundle/Entity/Restaurant.php
+++ b/src/AppBundle/Entity/Restaurant.php
@@ -33,7 +33,8 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
  *     "normalization_context"={"groups"={"restaurant", "place", "order"}}
  *   },
  *   collectionOperations={
- *     "get"={"method"="GET"}
+ *     "get"={"method"="GET"},
+ *     "me_restaurants"={"route_name"="me_restaurants"}
  *   },
  *   itemOperations={
  *     "get"={"method"="GET"},

--- a/src/AppBundle/Entity/Store.php
+++ b/src/AppBundle/Entity/Store.php
@@ -5,6 +5,7 @@ namespace AppBundle\Entity;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
 use AppBundle\Entity\Base\LocalBusiness;
+use AppBundle\Entity\Store\Token as StoreToken;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\Serializer\Annotation\Groups;
@@ -89,8 +90,13 @@ class Store extends LocalBusiness
 
     private $deliveries;
 
+    private $token;
+
+    private $owners;
+
     public function __construct() {
         $this->deliveries = new ArrayCollection();
+        $this->owners = new ArrayCollection();
     }
 
     /**
@@ -252,4 +258,28 @@ class Store extends LocalBusiness
         $this->deliveries = $deliveries;
     }
 
+    public function getToken()
+    {
+        return $this->token;
+    }
+
+    public function setToken($token)
+    {
+        if (!($token instanceof StoreToken)) {
+            $tmp = $token;
+            $token = new StoreToken();
+            $token->setToken($tmp);
+        }
+
+        $token->setStore($this);
+
+        $this->token = $token;
+
+        return $this;
+    }
+
+    public function getOwners()
+    {
+        return $this->owners;
+    }
 }

--- a/src/AppBundle/Entity/Store/Token.php
+++ b/src/AppBundle/Entity/Store/Token.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace AppBundle\Entity\Store;
+
+class Token
+{
+    private $id;
+    private $store;
+    private $token;
+    private $createdAt;
+    private $updatedAt;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getStore()
+    {
+        return $this->store;
+    }
+
+    public function setStore($store)
+    {
+        $this->store = $store;
+
+        return $this;
+    }
+
+    public function getToken()
+    {
+        return $this->token;
+    }
+
+    public function setToken($token)
+    {
+        $this->token = $token;
+
+        return $this;
+    }
+}

--- a/src/AppBundle/Form/StoreTokenType.php
+++ b/src/AppBundle/Form/StoreTokenType.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Entity\Store;
+use AppBundle\Security\StoreTokenManager;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class StoreTokenType extends AbstractType
+{
+    private $tokenManager;
+
+    public function __construct(StoreTokenManager $tokenManager)
+    {
+        $this->tokenManager = $tokenManager;
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
+
+            $form = $event->getForm();
+            $store = $event->getData();
+
+            if (null === $store->getToken()) {
+                $form
+                    ->add('generate', SubmitType::class, [
+                        'label' => 'form.store_token.generate.label'
+                    ]);
+            } else {
+                $form
+                    ->add('token', TextType::class, [
+                        'label' => 'form.store_token.token.label',
+                        'mapped' => false,
+                        'data' => $store->getToken()->getToken()
+                    ]);
+            }
+        });
+
+        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) {
+
+            $form = $event->getForm();
+            $store = $event->getData();
+
+            if ($form->getClickedButton() && 'generate' === $form->getClickedButton()->getName()) {
+                $jwt = $this->tokenManager->create($store);
+                $store->setToken($jwt);
+            }
+        });
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => Store::class,
+        ));
+    }
+}

--- a/src/AppBundle/Resources/config/doctrine/Store.Token.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Store.Token.orm.yml
@@ -1,0 +1,32 @@
+AppBundle\Entity\Store\Token:
+    type: entity
+    table: store_token
+    id:
+        id:
+            type: integer
+            id: true
+            generator:
+                strategy: IDENTITY
+    fields:
+        token:
+            type: text
+            unique: true
+        createdAt:
+            type: datetime
+            column: created_at
+            gedmo:
+                timestampable:
+                    on: create
+        updatedAt:
+            type: datetime
+            column: updated_at
+            gedmo:
+                timestampable:
+                    on: create
+    oneToOne:
+        store:
+            targetEntity: AppBundle\Entity\Store
+            inversedBy: token
+            joinColumns:
+                store_id:
+                    referencedColumnName: id

--- a/src/AppBundle/Resources/config/doctrine/Store.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Store.orm.yml
@@ -63,6 +63,11 @@ AppBundle\Entity\Store:
             joinColumns:
                 address_id:
                     referencedColumnName: id
+        token:
+            targetEntity: AppBundle\Entity\Store\Token
+            mappedBy: store
+            cascade:
+                - all
     manyToOne:
         stripeAccount:
             targetEntity: AppBundle\Entity\StripeAccount
@@ -82,3 +87,7 @@ AppBundle\Entity\Store:
             targetEntity: AppBundle\Entity\Delivery
             fetch: LAZY
             mappedBy: store
+    manyToMany:
+        owners:
+            targetEntity: AppBundle\Entity\ApiUser
+            mappedBy: stores

--- a/src/AppBundle/Resources/config/routing/admin.yml
+++ b/src/AppBundle/Resources/config/routing/admin.yml
@@ -336,6 +336,7 @@ admin_store:
         routes:
             stores: admin_stores
             store_delivery: admin_store_delivery
+            store_api_keys: admin_store_api_keys
     methods:  [ GET, POST ]
 
 admin_store_delivery:
@@ -348,6 +349,16 @@ admin_store_delivery:
             store: admin_store
             success: admin_orders
             calculate_price: admin_deliveries_calculate_price
+    methods:  [ GET, POST ]
+
+admin_store_api_keys:
+    path: /admin/stores/{id}/api-keys
+    defaults:
+        _controller: AppBundle:Admin:apiKeys
+        layout: AppBundle::admin.html.twig
+        routes:
+            stores: admin_stores
+            success: admin_store_api_keys
     methods:  [ GET, POST ]
 
 admin_tag_new:

--- a/src/AppBundle/Resources/config/routing/profile.yml
+++ b/src/AppBundle/Resources/config/routing/profile.yml
@@ -299,6 +299,7 @@ profile_store:
         routes:
             stores: profile_stores
             store_delivery: profile_store_delivery
+            store_api_keys: profile_store_api_keys
     methods:  [ GET, POST ]
 
 profile_store_delivery:
@@ -311,4 +312,14 @@ profile_store_delivery:
             store: profile_store
             success: profile_orders
             calculate_price: profile_deliveries_calculate_price
+    methods:  [ GET, POST ]
+
+profile_store_api_keys:
+    path: /profile/stores/{id}/api-keys
+    defaults:
+        _controller: AppBundle:Profile:apiKeys
+        layout: AppBundle::profile.html.twig
+        routes:
+            stores: profile_stores
+            success: profile_store_api_keys
     methods:  [ GET, POST ]

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -439,6 +439,10 @@ form.product_option.additional.help: The customer can choose several values, wit
 form.product_option_value.value.label: Value
 form.product_option_value.price.label: Price
 
+form.store_token.generate.alert: You haven't generated a token yet
+form.store_token.generate.label: Generate
+form.store_token.token.label: Token
+
 product_option.strategy.free: Free
 product_option.strategy.option: Fixed price whatever the choice
 product_option.strategy.option_value: Price according to the choice
@@ -473,6 +477,8 @@ stores.manage: Manage
 stores.settings: Settings
 stores.createNewDelivery: Create new delivery
 stores.list.noStores: There are no stores yet
+
+store.api_keys: API keys
 
 zones.help: <a href="%link%">Get help about zones.</a>
 

--- a/src/AppBundle/Resources/views/Form/storeToken.html.twig
+++ b/src/AppBundle/Resources/views/Form/storeToken.html.twig
@@ -1,0 +1,20 @@
+{% extends 'bootstrap_3_layout.html.twig' %}
+
+{% block _store_token_generate_widget %}
+  <div class="alert alert-warning">
+    {% trans %}form.store_token.generate.alert{% endtrans %}
+    {{ form_widget(form, { attr: { class: 'btn btn-xs btn-success pull-right' } }) }}
+  </div>
+
+{% endblock %}
+
+{% block _store_token_token_widget %}
+  <div class="input-group">
+    {{ block('form_widget_simple') }}
+    <span class="input-group-btn">
+      <button class="btn btn-default" type="button" data-clipboard-target="#{{ form.vars.id }}" id="copy">
+        <i class="fa fa-copy"></i>
+      </button>
+    </span>
+  </div>
+{% endblock %}

--- a/src/AppBundle/Resources/views/Store/apiKeys.html.twig
+++ b/src/AppBundle/Resources/views/Store/apiKeys.html.twig
@@ -1,0 +1,22 @@
+{% extends layout %}
+
+{% form_theme form '@App/Form/storeToken.html.twig' %}
+
+{% block breadcrumb %}
+<li><a href="{{ path(stores_route) }}">{% trans %}adminDashboard.stores.title{% endtrans %}</a></li>
+<li>{{ store.name }}</li>
+{% endblock %}
+
+{% block content %}
+
+{{ form_start(form) }}
+  {{ form_widget(form) }}
+{{ form_end(form) }}
+
+{% endblock %}
+
+{% block scripts %}
+<script>
+new ClipboardJS('#copy');
+</script>
+{% endblock %}

--- a/src/AppBundle/Resources/views/Store/form.html.twig
+++ b/src/AppBundle/Resources/views/Store/form.html.twig
@@ -25,6 +25,9 @@
     </div>
     <div class="collapse navbar-collapse" id="store-navbar">
       <div class="nav navbar-nav navbar-right">
+        <a href="{{ path(store_api_keys_route, { id: store.id }) }}" class="btn btn-default navbar-btn">
+          <i class="fa fa-key"></i>  {% trans %}store.api_keys{% endtrans %}
+        </a>
         <a href="{{ path(store_delivery_route, { id: store.id }) }}" class="btn btn-default navbar-btn">
           <i class="fa fa-bicycle"></i>  {% trans %}delivery.createNew{% endtrans %}
         </a>

--- a/src/AppBundle/Security/StoreTokenAuthenticator.php
+++ b/src/AppBundle/Security/StoreTokenAuthenticator.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace AppBundle\Security;
+
+use AppBundle\Entity\Store;
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Authentication\Token\PreAuthenticationJWTUserToken;
+use Lexik\Bundle\JWTAuthenticationBundle\Security\Guard\JWTTokenAuthenticator;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Lexik\Bundle\JWTAuthenticationBundle\TokenExtractor\TokenExtractorInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+
+class StoreTokenAuthenticator extends JWTTokenAuthenticator
+{
+    private $storeRepository;
+    private $preAuthenticationTokenStorage;
+
+    public function __construct(
+        JWTTokenManagerInterface $jwtManager,
+        EventDispatcherInterface $dispatcher,
+        TokenExtractorInterface $tokenExtractor,
+        $doctrine
+    ) {
+        parent::__construct($jwtManager, $dispatcher, $tokenExtractor);
+
+        $this->storeRepository = $doctrine->getRepository(Store::class);
+        $this->preAuthenticationTokenStorage = new TokenStorage();
+    }
+
+    private function getStore(PreAuthenticationJWTUserToken $preAuthToken)
+    {
+        $payload = $preAuthToken->getPayload();
+
+        return $this->storeRepository->find($payload['store']);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUser($credentials, UserProviderInterface $userProvider)
+    {
+        $user = parent::getUser($credentials, $userProvider);
+
+        $this->preAuthenticationTokenStorage->setToken($credentials);
+
+        return $user;
+    }
+
+    /*.
+     * {@inheritdoc}
+     */
+    public function checkCredentials($credentials, UserInterface $user)
+    {
+        // TODO Verify that the token has not been revoked, i.e stored in database
+
+        if (!$credentials instanceof PreAuthenticationJWTUserToken) {
+            throw new \InvalidArgumentException(
+                sprintf('The first argument of the "%s()" method must be an instance of "%s".', __METHOD__, PreAuthenticationJWTUserToken::class)
+            );
+        }
+
+        $store = $this->getStore($credentials);
+
+        if (!$user->getStores()->contains($store)) {
+            return false;
+        }
+
+        return parent::checkCredentials($credentials, $user);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createAuthenticatedToken(UserInterface $user, $providerKey)
+    {
+        $authToken = parent::createAuthenticatedToken($user, $providerKey);
+
+        $preAuthToken = $this->preAuthenticationTokenStorage->getToken();
+        $authToken->setAttribute('store', $this->getStore($preAuthToken));
+        $this->preAuthenticationTokenStorage->setToken(null);
+
+        return $authToken;
+    }
+}

--- a/src/AppBundle/Security/StoreTokenManager.php
+++ b/src/AppBundle/Security/StoreTokenManager.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace AppBundle\Security;
+
+use AppBundle\Entity\Store;
+use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
+use Lexik\Bundle\JWTAuthenticationBundle\Events;
+use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class StoreTokenManager
+{
+    private $tokenStorage;
+    private $jwtManager;
+    private $dispatcher;
+
+    public function __construct(
+        TokenStorageInterface $tokenStorage,
+        JWTTokenManagerInterface $jwtManager,
+        EventDispatcherInterface $dispatcher)
+    {
+        $this->tokenStorage = $tokenStorage;
+        $this->jwtManager = $jwtManager;
+        $this->dispatcher = $dispatcher;
+    }
+
+    public function create(Store $store, UserInterface $user = null)
+    {
+        $onJWTCreated = function (JWTCreatedEvent $event) use ($store) {
+            $payload = $event->getData();
+            $payload['store'] = $store->getId();
+            $event->setData($payload);
+        };
+
+        $this->dispatcher->addListener(Events::JWT_CREATED, $onJWTCreated);
+        $jwt = $this->jwtManager->create($user ? $user : $this->getUser($store));
+        $this->dispatcher->removeListener(Events::JWT_CREATED, $onJWTCreated);
+
+        return $jwt;
+    }
+
+    private function getUser(Store $store)
+    {
+        $owners = $store->getOwners();
+
+        if ($token = $this->tokenStorage->getToken()) {
+            if ($user = $token->getUser()) {
+                if ($owners->contains($user)) {
+                    return $user;
+                }
+            }
+
+            // FIXME We should be able to choose the user
+            return $owners->first();
+        }
+
+        throw new \RuntimeException('No user found to generate JWT');
+    }
+}

--- a/src/AppBundle/Serializer/DeliveryNormalizer.php
+++ b/src/AppBundle/Serializer/DeliveryNormalizer.php
@@ -3,18 +3,43 @@
 namespace AppBundle\Serializer;
 
 use ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer;
+use AppBundle\Entity\Address;
 use AppBundle\Entity\Delivery;
+use AppBundle\Entity\Task;
+use AppBundle\Service\Geocoder;
 use Symfony\Component\Routing\Router;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class DeliveryNormalizer implements NormalizerInterface, DenormalizerInterface
 {
     private $normalizer;
+    private $geocoder;
+    private $tokenStorage;
 
-    public function __construct(ItemNormalizer $normalizer)
+    public function __construct(
+        ItemNormalizer $normalizer,
+        Geocoder $geocoder,
+        TokenStorageInterface $tokenStorage)
     {
         $this->normalizer = $normalizer;
+        $this->geocoder = $geocoder;
+        $this->tokenStorage = $tokenStorage;
+    }
+
+    private function normalizeTask(Task $task)
+    {
+        $address = $this->normalizer->normalize($task->getAddress(), 'jsonld', [
+            'resource_class' => Address::class,
+            'operation_type' => 'item',
+            'item_operation_name' => 'get',
+            'groups' => ['place']
+        ]);
+
+        return [
+            'address' => $address
+        ];
     }
 
     public function normalize($object, $format = null, array $context = array())
@@ -24,6 +49,9 @@ class DeliveryNormalizer implements NormalizerInterface, DenormalizerInterface
         if (isset($data['items'])) {
             unset($data['items']);
         }
+
+        $data['pickup'] = $this->normalizeTask($object->getPickup());
+        $data['dropoff'] = $this->normalizeTask($object->getDropoff());
 
         $data['color'] = $object->getColor();
 
@@ -35,13 +63,50 @@ class DeliveryNormalizer implements NormalizerInterface, DenormalizerInterface
         return $this->normalizer->supportsNormalization($data, $format) && $data instanceof Delivery;
     }
 
+    private function denormalizeTask($data, Task $task)
+    {
+        if (isset($data['doneBefore'])) {
+            $task->setDoneBefore(new \DateTime($data['doneBefore']));
+        }
+
+        if (isset($data['address'])) {
+            $address = $this->geocoder->geocode($data['address']);
+            $task->setAddress($address);
+        }
+    }
+
     public function denormalize($data, $class, $format = null, array $context = array())
     {
-        return $this->normalizer->denormalize($data, $class, $format, $context);
+        $delivery = $this->normalizer->denormalize($data, $class, $format, $context);
+
+        $pickup = $delivery->getPickup();
+        $dropoff = $delivery->getDropoff();
+
+        if (isset($data['pickup'])) {
+
+            $this->denormalizeTask($data['pickup'], $pickup);
+
+            // If no pickup address is specified, use the store address
+            if (null === $pickup->getAddress()) {
+                if (null === $token = $this->tokenStorage->getToken()) {
+                    // TODO Throw Exception
+                }
+                if (null === $store = $token->getAttribute('store')) {
+                    // TODO Throw Exception
+                }
+                $pickup->setAddress($store->getAddress());
+            }
+        }
+
+        if (isset($data['dropoff'])) {
+            $this->denormalizeTask($data['dropoff'], $dropoff);
+        }
+
+        return $delivery;
     }
 
     public function supportsDenormalization($data, $type, $format = null)
     {
-        return $this->normalizer->supportsDenormalization($data, $type, $format) && $type instanceof Delivery;
+        return $this->normalizer->supportsDenormalization($data, $type, $format) && $type === Delivery::class;
     }
 }

--- a/src/AppBundle/Service/Geocoder.php
+++ b/src/AppBundle/Service/Geocoder.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace AppBundle\Service;
+
+use AppBundle\Entity\Address;
+use AppBundle\Entity\Base\GeoCoordinates;
+use AppBundle\Service\SettingsManager;
+use Geocoder\Provider\Addok\Addok as AddokProvider;
+use Geocoder\Provider\Chain\Chain as ChainProvider;
+use Geocoder\Provider\GoogleMaps\GoogleMaps as GoogleMapsProvider;
+use Geocoder\Provider\Nominatim\Nominatim as NominatimProvider;
+use Geocoder\Query\GeocodeQuery;
+use Geocoder\StatefulGeocoder;
+use Http\Adapter\Guzzle6\Client;
+
+class Geocoder
+{
+    private $geocoder;
+
+    public function __construct(SettingsManager $settingsManager, $country, $locale)
+    {
+        $httpClient = new Client();
+
+        $providers = [];
+
+        // For France only, use https://adresse.data.gouv.fr/
+        if ('fr' === $country) {
+            $providers[] = AddokProvider::withBANServer($httpClient);
+        }
+
+        // Add Google provider only if api key is configured
+        $apiKey = $settingsManager->get('google_api_key');
+        if (!empty($apiKey)) {
+            $region = strtoupper($country);
+            $providers[] = new GoogleMapsProvider($httpClient, $region, $apiKey);
+        }
+
+        $this->geocoder = new StatefulGeocoder(new ChainProvider($providers), $locale);
+    }
+
+    /**
+     * @return Address
+     */
+    public function geocode($value)
+    {
+        $results = $this->geocoder->geocode($value);
+
+        if (count($results) > 0) {
+            $result = $results->first();
+
+            [ $longitude, $latitude ] = $result->getCoordinates()->toArray();
+
+            $address = new Address();
+            $address->setGeo(new GeoCoordinates($latitude, $longitude));
+            $address->setStreetAddress(sprintf('%s %s', $result->getStreetNumber(), $result->getStreetName()));
+            $address->setAddressLocality($result->getLocality());
+            $address->setPostalCode($result->getPostalCode());
+
+            return $address;
+        }
+    }
+}

--- a/src/AppBundle/Service/Geocoder.php
+++ b/src/AppBundle/Service/Geocoder.php
@@ -25,6 +25,7 @@ class Geocoder
 
         // For France only, use https://adresse.data.gouv.fr/
         if ('fr' === $country) {
+            // TODO Create own provider to get results with a high score
             $providers[] = AddokProvider::withBANServer($httpClient);
         }
 


### PR DESCRIPTION
Fixes #374 

This is the first draft to add an endpoint to create deliveries. 
As explained in the original issue, each store has a token associated, which allows to identify the originator. (Please note this Pull Request does not take care of creating or displaying store tokens). 

The payload is really simple: 

```
{
  "pickup": {
     // Optional, if not pickup address is provided, use store address
    "address": "24, Rue de la Paix",
    "doneBefore": "tomorrow 13:00"
  },
  "dropoff": {
    "address": "48, Rue de Rivoli",
    "doneBefore": "tomorrow 13:30"
  }
}
```

What do you think? This is just a starting point, we can iterate from this.