### PR TITLE
Introduce users search with ElasticSearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ services:
   - postgresql
   - docker
   - redis-server
+  - elasticsearch
 
 addons:
   postgresql: '9.4'

--- a/app/config/config_test.yml
+++ b/app/config/config_test.yml
@@ -1,6 +1,9 @@
 imports:
     - { resource: config_dev.yml }
 
+parameters:
+    elasticsearch_prefix: '%database_name%_test'
+
 framework:
     test: ~
     session:

--- a/app/config/elastica.yml
+++ b/app/config/elastica.yml
@@ -1,0 +1,27 @@
+settings:
+    index:
+        number_of_shards: 1
+        number_of_replicas: 0
+mappings:
+    user:
+        dynamic: false
+        properties:
+            username:
+                type: text
+                analyzer: english
+            firstname:
+                type: text
+                fields:
+                  keyword:
+                    type: text
+                    analyzer: keyword
+                  completion:
+                    type: completion
+            lastname:
+                type: text
+                fields:
+                  keyword:
+                    type: text
+                    analyzer: keyword
+                  completion:
+                    type: completion

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -60,3 +60,6 @@ parameters:
     fcm_server_api_key: ""
     apns_certificate_file: ""
     apns_certificate_pass_phrase: ""
+
+    elasticsearch_host: elasticsearch
+    elasticsearch_prefix: %database_name%

--- a/app/config/parameters.yml.gitlab
+++ b/app/config/parameters.yml.gitlab
@@ -38,3 +38,5 @@ parameters:
     fcm_server_api_key: ''
     apns_certificate_file: ''
     apns_certificate_pass_phrase: ''
+    elasticsearch_host: elasticsearch
+    elasticsearch_prefix: %database_name%

--- a/app/config/parameters.yml.travis
+++ b/app/config/parameters.yml.travis
@@ -13,6 +13,8 @@ parameters:
     mailer_password:   ~
     mailer_port:       ~
     mailer_encryption: ~
+    mailjet.api_key: ~
+    mailjet.secret_key: ~
     secret: ThisTokenIsNotSoSecretChangeIt
     cors_allow_origin: 'http://localhost'
     jwt_private_key_path: '%kernel.root_dir%/../var/jwt/private.pem'
@@ -30,8 +32,11 @@ parameters:
     piwik_site_id: ~
     is_demo: false
     sentry_dsn: "https://********@sentry.io/********"
+    sentry_public_dsn: "https://<public>@sentry.io/********"
     statsd_host: localhost
     statsd_port: '8125'
     fcm_server_api_key: ''
     apns_certificate_file: ''
     apns_certificate_pass_phrase: ''
+    elasticsearch_host: 127.0.0.1
+    elasticsearch_prefix: %database_name%

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -478,6 +478,14 @@ services:
       - "%country_iso%"
       - "%coopcycle.locale%"
 
+  coopcycle.search_manager:
+    class: AppBundle\Service\SearchManager
+    arguments:
+      - '@Elastica\Client'
+      - '@fos_user.user_manager'
+      - '%elasticsearch_prefix%'
+      - '%kernel.root_dir%/config/elastica.yml'
+
   'AppBundle\Validator\Constraints\CartValidator':
     arguments: [ '@routing_service' ]
     tags:
@@ -552,3 +560,9 @@ services:
       - '@security.token_storage'
       - '@lexik_jwt_authentication.jwt_manager.not_expiring'
       - '@event_dispatcher'
+
+  'Elastica\Client':
+    arguments:
+      - host: '%elasticsearch_host%'
+      - ~
+      - '@logger'

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,8 @@
         "php-http/message": "^1.6",
         "geo6/geocoder-php-addok-provider": "^1.0",
         "geocoder-php/chain-provider": "^4.0",
-        "geocoder-php/nominatim-provider": "^5.0"
+        "geocoder-php/nominatim-provider": "^5.0",
+        "ruflin/elastica": "^6.0"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "081eaaba818446fb5d3c82e2d9e08197",
+    "content-hash": "6d7302a713b72ca7de96bc3688e31880",
     "packages": [
         {
             "name": "api-platform/core",
@@ -2241,6 +2241,63 @@
             "time": "2017-05-12T12:56:51+00:00"
         },
         {
+            "name": "elasticsearch/elasticsearch",
+            "version": "v6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/elastic/elasticsearch-php.git",
+                "reference": "b8e3bc9d1fc54d6a18692df0b74956efe7fe241a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/b8e3bc9d1fc54d6a18692df0b74956efe7fe241a",
+                "reference": "b8e3bc9d1fc54d6a18692df0b74956efe7fe241a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": ">=1.3.7",
+                "guzzlehttp/ringphp": "~1.0",
+                "php": "^7.0",
+                "psr/log": "~1.0"
+            },
+            "require-dev": {
+                "cpliakas/git-wrapper": "~1.0",
+                "doctrine/inflector": "^1.1",
+                "mockery/mockery": "0.9.4",
+                "phpstan/phpstan-shim": "0.8.3",
+                "phpunit/phpunit": "6.3.0",
+                "squizlabs/php_codesniffer": "3.0.2",
+                "symfony/finder": "^2.8",
+                "symfony/yaml": "^2.8"
+            },
+            "suggest": {
+                "ext-curl": "*",
+                "monolog/monolog": "Allows for client-level logging and tracing"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Elasticsearch\\": "src/Elasticsearch/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Zachary Tong"
+                }
+            ],
+            "description": "PHP Client for Elasticsearch",
+            "keywords": [
+                "client",
+                "elasticsearch",
+                "search"
+            ],
+            "time": "2017-12-05T14:15:58+00:00"
+        },
+        {
             "name": "emcconville/google-map-polyline-encoding-tool",
             "version": "v1.3",
             "source": {
@@ -3232,6 +3289,107 @@
                 "url"
             ],
             "time": "2017-03-20T17:10:46+00:00"
+        },
+        {
+            "name": "guzzlehttp/ringphp",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/RingPHP.git",
+                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/5e2a174052995663dd68e6b5ad838afd47dd615b",
+                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/streams": "~3.0",
+                "php": ">=5.4.0",
+                "react/promise": "~2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Ring\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "time": "2018-07-31T13:22:33+00:00"
+        },
+        {
+            "name": "guzzlehttp/streams",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/streams.git",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple abstraction over streams of data",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "stream"
+            ],
+            "time": "2014-10-12T19:18:40+00:00"
         },
         {
             "name": "illuminate/cache",
@@ -6674,6 +6832,64 @@
                 "promises"
             ],
             "time": "2018-06-13T15:59:06+00:00"
+        },
+        {
+            "name": "ruflin/elastica",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ruflin/Elastica.git",
+                "reference": "8a6a3b2e71fdf7c96ad92fd2622bcc5904696fcf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ruflin/Elastica/zipball/8a6a3b2e71fdf7c96ad92fd2622bcc5904696fcf",
+                "reference": "8a6a3b2e71fdf7c96ad92fd2622bcc5904696fcf",
+                "shasum": ""
+            },
+            "require": {
+                "elasticsearch/elasticsearch": "^6.0",
+                "php": "^7.0",
+                "psr/log": "~1.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "~3.0",
+                "guzzlehttp/guzzle": "~6.0"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow using IAM authentication with Amazon ElasticSearch Service",
+                "egeloen/http-adapter": "Allow using httpadapter transport",
+                "guzzlehttp/guzzle": "Allow using guzzle 6 as the http transport",
+                "monolog/monolog": "Logging request"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Elastica\\": "lib/Elastica/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Ruflin",
+                    "homepage": "http://ruflin.com/"
+                }
+            ],
+            "description": "Elasticsearch Client",
+            "homepage": "http://elastica.io/",
+            "keywords": [
+                "client",
+                "search"
+            ],
+            "time": "2018-05-29T08:31:52+00:00"
         },
         {
             "name": "sensio/distribution-bundle",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       - osrm
       - graphite
       - stripe_mock
+      - elasticsearch
     links:
       - osrm
       - graphite
@@ -112,7 +113,23 @@ services:
     ports:
       - '12111:12111'
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+    environment:
+      - cluster.name=coopcycle
+      - bootstrap.memory_lock=true
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    ports:
+        - 9200:9200
+
 volumes:
   node_modules:
   pg_data:
   php_cache:
+  esdata:

--- a/src/AppBundle/Command/SearchIndexCommand.php
+++ b/src/AppBundle/Command/SearchIndexCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace AppBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * @see https://afsy.fr/avent/2017/20-elasticsearch-6-et-symfony-4
+ */
+class SearchIndexCommand extends ContainerAwareCommand
+{
+    private $userManager;
+    private $searchManager;
+
+    protected function configure()
+    {
+        $this
+            ->setName('coopcycle:search:index')
+            ->setDescription('Build search indexes.');
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output)
+    {
+        $this->userManager = $this->getContainer()->get('fos_user.user_manager');
+        $this->searchManager = $this->getContainer()->get('coopcycle.search_manager');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $output->writeln('<info>Indexing users…</info>');
+        $this->indexUsers($io);
+    }
+
+    private function indexUsers(SymfonyStyle $io)
+    {
+        $index = $this->searchManager->getUsersIndex();
+
+        $users = $this->userManager->findUsers();
+
+        $documents = [];
+        foreach ($users as $user) {
+            $documents[] = $this->searchManager->createDocumentFromUser($user);
+        }
+
+        $index->addDocuments($documents);
+        $index->refresh();
+
+        $io->success(sprintf('%d users indexed', count($documents)));
+    }
+}

--- a/src/AppBundle/Service/SearchManager.php
+++ b/src/AppBundle/Service/SearchManager.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace AppBundle\Service;
+
+use AppBundle\Entity\ApiUser;
+use Elastica\Client;
+use Elastica\Document;
+use Elastica\Query;
+use Elastica\Query\MultiMatch;
+use Elastica\Query\BoolQuery;
+use FOS\UserBundle\Doctrine\UserManager;
+use Symfony\Component\Yaml\Yaml;
+
+class SearchManager
+{
+    private $client;
+    private $userManager;
+    private $prefix;
+    private $settingsFilename;
+    private $settings;
+
+    const USER_DOCUMENT_TYPE = 'user';
+
+    public function __construct(
+        Client $client,
+        UserManager $userManager,
+        $prefix,
+        $settingsFilename)
+    {
+        $this->client = $client;
+        $this->userManager = $userManager;
+        $this->prefix = $prefix;
+        $this->settingsFilename = $settingsFilename;
+    }
+
+    public function createDocumentFromUser(ApiUser $user)
+    {
+        // FIXME Types are deprecated, to be removed in Elastic 7
+        return new Document($user->getId(), [
+            'username' => $user->getUsername(),
+            'firstname' => $user->getGivenName(),
+            'lastname' => $user->getFamilyName(),
+        ], self::USER_DOCUMENT_TYPE);
+    }
+
+    public function getUsersIndex()
+    {
+        if (!$this->settings) {
+            $this->settings = Yaml::parse(file_get_contents($this->settingsFilename));
+        }
+
+        $index = $this->client->getIndex(sprintf('%s:users', $this->prefix));
+
+        if (!$index->exists()) {
+            $index->create($this->settings, true);
+        }
+
+        return $index;
+    }
+
+    public function searchUsers($q)
+    {
+        $match = new MultiMatch();
+        $match->setQuery($q);
+        $match->setFields(['lastname', 'firstname', 'username']);
+        $match->setFuzziness('AUTO');
+
+        $bool = new BoolQuery();
+        $bool->addShould($match);
+
+        $elasticaQuery = new Query($bool);
+        $elasticaQuery->setSize(10);
+
+        return $this->getUsersIndex()->search($elasticaQuery);
+    }
+}

--- a/tests/AppBundle/Service/SearchManagerTest.php
+++ b/tests/AppBundle/Service/SearchManagerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\AppBundle\Service;
+
+use AppBundle\Entity\ApiUser;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class DeliveryManagerTest extends KernelTestCase
+{
+    private $client;
+    private $searchManager;
+    private $usersIndex;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        self::bootKernel();
+
+        $this->client = static::$kernel->getContainer()->get('Elastica\Client');
+        $this->searchManager = static::$kernel->getContainer()->get('coopcycle.search_manager');
+
+        $this->usersIndex = $this->searchManager->getUsersIndex();
+    }
+
+    private static function createUser($id, $username, $firstName, $lastName)
+    {
+        $user = new ApiUser();
+        $user->setUsername($username);
+        $user->setGivenName($firstName);
+        $user->setFamilyName($lastName);
+
+        $class = new \ReflectionClass($user);
+        $property = $class->getProperty('id');
+        $property->setAccessible(true);
+        $property->setValue($user, $id);
+
+        return $user;
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->usersIndex->delete();
+    }
+
+    public function testCreateDocumentFromUser()
+    {
+        $user = self::createUser(1, 'john', 'John', 'Doe');
+
+        $document = $this->searchManager->createDocumentFromUser($user);
+
+        $this->assertEquals('user', $document->getType());
+        $this->assertEquals(1, $document->getId());
+
+        $this->assertEquals('john', $document->get('username'));
+        $this->assertEquals('John', $document->get('firstname'));
+        $this->assertEquals('Doe', $document->get('lastname'));
+    }
+
+    public function testSearchUsers()
+    {
+        $bonnie = self::createUser(1, 'bonnie', 'Bonnie', 'Parker');
+        $clyde = self::createUser(2, 'clyde', 'Clyde', 'Barrow');
+
+        $documents = [
+            $this->searchManager->createDocumentFromUser($bonnie),
+            $this->searchManager->createDocumentFromUser($clyde),
+        ];
+
+        $this->usersIndex->addDocuments($documents);
+        $this->usersIndex->refresh();
+
+        $expectations = [
+            'bonn' => 'bonnie',
+            'bonnie' => 'bonnie',
+            'parker' => 'bonnie'
+        ];
+
+        foreach ($expectations as $q => $username) {
+
+            $matches = $this->searchManager->searchUsers($q);
+            $this->assertEquals(1, count($matches), sprintf('Query "%s" returned no results', $q));
+
+            $documents = $matches->getDocuments();
+            $this->assertEquals($username, $documents[0]->get('username'));
+        }
+    }
+}


### PR DESCRIPTION
For another branch, I need a quick & reliable way of searching users easily (i.e., by typing the first letters of their firstname, lastname, email... or whatever). 
Using `LIKE` queries is not reliable, and does not handle typos. 

This is why I finally decided to introduce ElasticSearch 🚀
I think it will have a small memory footprint, with a few thousands of documents. 

So let's begin with users search, so that we can learn how ElasticSearch works (I don't know much of it myself, it is quite complex). 

In production, we can run it easily using Docker, with only one node. 
When we have more money and experience, we can create a real cluster with several nodes and lots of RAM 😁