### PR TITLE
Maintenance mode

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -23,6 +23,16 @@ services:
     tags:
       - { name: kernel.event_listener, event: kernel.request }
 
+  coopcycle.listener.maintenance:
+    class: AppBundle\EventListener\MaintenanceListener
+    arguments:
+      - '@security.authorization_checker'
+      - '@security.token_storage'
+      - '@snc_redis.default'
+      - '@templating'
+    tags:
+      - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest }
+
   sylius.context.locale.request_based:
     class: Sylius\Bundle\LocaleBundle\Context\RequestBasedLocaleContext
     arguments: ['@request_stack', '@sylius.locale_provider']

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -452,6 +452,14 @@ services:
     tags:
       - { name: twig.runtime }
 
+  coopcycle.twig.runtime.maintenance_resolver:
+    class: AppBundle\Twig\MaintenanceResolver
+    arguments:
+      - '@snc_redis.default'
+    public: false
+    tags:
+      - { name: twig.runtime }
+
   swiftmailer.transport.eventdispatcher.mailjet:
     class: Swift_Events_SimpleEventDispatcher
 

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -27,6 +27,11 @@ h1, h2, h3, h4, h5, h6 {
   flex-direction: column;
 }
 
+.container--center {
+  align-items: center;
+  justify-content: center;
+}
+
 .row--full-height {
   display: flex;
   flex-wrap: wrap;
@@ -68,6 +73,13 @@ h1, h2, h3, h4, h5, h6 {
   & ~ .table > tbody > tr:first-child > td {
     border-top: none;
   }
+}
+
+.maintenance {
+  @extend .alert;
+  @extend .alert-danger;
+  text-align: center;
+  padding: 40px;
 }
 
 // ------------------ Admin ------------------

--- a/js/app/widgets/Switch.js
+++ b/js/app/widgets/Switch.js
@@ -1,0 +1,49 @@
+import React, { Component } from 'react'
+import { render } from 'react-dom'
+import { Switch } from 'antd'
+
+class SwitchWrapper extends Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      checked: this.props.checked,
+    }
+  }
+
+  toggle() {
+    const checked = !this.state.checked
+    this.setState({ checked })
+  }
+
+  uncheck() {
+    this.setState({ checked: false })
+  }
+
+  check() {
+    this.setState({ checked: true })
+  }
+
+  render () {
+    return (
+      <Switch
+        { ...this.props }
+        checked={ this.state.checked }
+        onClick={ this.toggle.bind(this) } />
+    )
+  }
+}
+
+export default (el, options) => {
+
+  const props = {
+    checked: options.checked
+  }
+
+  const component = render(<SwitchWrapper { ...props } onChange={ options.onChange } />, el)
+
+  return {
+    check: () => component.check(),
+    uncheck: () => component.uncheck()
+  }
+}

--- a/js/app/widgets/Switch.js
+++ b/js/app/widgets/Switch.js
@@ -37,7 +37,8 @@ class SwitchWrapper extends Component {
 export default (el, options) => {
 
   const props = {
-    checked: options.checked
+    checked: options.checked,
+    disabled: options.disabled || false,
   }
 
   const component = render(<SwitchWrapper { ...props } onChange={ options.onChange } />, el)

--- a/js/app/widgets/index.js
+++ b/js/app/widgets/index.js
@@ -7,6 +7,7 @@ import OpeningHoursInput from './OpeningHoursInput'
 import OpeningHoursParser from './OpeningHoursParser'
 import OrderTimeline from './OrderTimeline'
 import StripePaymentForm from './StripePaymentForm'
+import Switch from './Switch'
 import RulePicker from './RulePicker'
 import Search from './Search'
 import Timeline from './Timeline'
@@ -23,6 +24,7 @@ window.CoopCycle.OpeningHoursInput = OpeningHoursInput
 window.CoopCycle.OpeningHoursParser = OpeningHoursParser
 window.CoopCycle.OrderTimeline = OrderTimeline
 window.CoopCycle.StripePaymentForm = StripePaymentForm
+window.CoopCycle.Switch = Switch
 window.CoopCycle.RulePicker = RulePicker
 window.CoopCycle.Search = Search
 window.CoopCycle.Timeline = Timeline

--- a/src/AppBundle/EventListener/MaintenanceListener.php
+++ b/src/AppBundle/EventListener/MaintenanceListener.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace AppBundle\EventListener;
+
+use Predis\Client as Redis;
+use Symfony\Bridge\Twig\TwigEngine;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+class MaintenanceListener
+{
+    private $authorizationChecker;
+    private $tokenStorage;
+    private $redis;
+    private $templating;
+
+    public function __construct(
+        AuthorizationCheckerInterface $authorizationChecker,
+        TokenStorageInterface $tokenStorage,
+        Redis $redis,
+        TwigEngine $templating)
+    {
+        $this->authorizationChecker = $authorizationChecker;
+        $this->tokenStorage = $tokenStorage;
+        $this->redis = $redis;
+        $this->templating = $templating;
+    }
+
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (null === $token = $this->tokenStorage->getToken()) {
+            return;
+        }
+
+        $maintenance = $this->redis->get('maintenance');
+
+        if ($maintenance && !$this->authorizationChecker->isGranted('ROLE_ADMIN')) {
+            $content = $this->templating->render('@App/maintenance.html.twig');
+            $event->setResponse(new Response($content, 503));
+            $event->stopPropagation();
+        }
+    }
+}

--- a/src/AppBundle/Form/MaintenanceType.php
+++ b/src/AppBundle/Form/MaintenanceType.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AppBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+
+class MaintenanceType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('enable', SubmitType::class, [
+                'label' => 'form.maintenace.enable.label'
+            ])
+            ->add('disable', SubmitType::class, [
+                'label' => 'form.maintenace.disable.label'
+            ]);
+    }
+}

--- a/src/AppBundle/Form/MaintenanceType.php
+++ b/src/AppBundle/Form/MaintenanceType.php
@@ -12,10 +12,10 @@ class MaintenanceType extends AbstractType
     {
         $builder
             ->add('enable', SubmitType::class, [
-                'label' => 'form.maintenace.enable.label'
+                'label' => 'form.maintenance.enable.label'
             ])
             ->add('disable', SubmitType::class, [
-                'label' => 'form.maintenace.disable.label'
+                'label' => 'form.maintenance.disable.label'
             ]);
     }
 }

--- a/src/AppBundle/Form/SettingsType.php
+++ b/src/AppBundle/Form/SettingsType.php
@@ -69,15 +69,6 @@ class SettingsType extends AbstractType
                 'required' => false,
                 'label' => 'form.settings.stripe_connect_client_id.label'
             ])
-            ->add('stripe_livemode', ChoiceType::class, [
-                'choices'  => [
-                    'No' => 'no',
-                    'Yes' => 'yes',
-                ],
-                'expanded' => true,
-                'multiple' => false,
-                'label' => 'form.settings.stripe_livemode.label'
-            ])
             ->add('google_api_key', TextType::class, [
                 'label' => 'form.settings.google_api_key.label'
             ])

--- a/src/AppBundle/Form/StripeLivemodeType.php
+++ b/src/AppBundle/Form/StripeLivemodeType.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AppBundle\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+
+class StripeLivemodeType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('enable', SubmitType::class, [
+                'label' => 'form.stripe_livemode.enable.label'
+            ])
+            ->add('disable', SubmitType::class, [
+                'label' => 'form.stripe_livemode.disable.label'
+            ])
+            ->add('disable_and_enable_maintenance', SubmitType::class, [
+                'label' => 'form.stripe_livemode.disable_and_enable_maintenance.label'
+            ]);
+    }
+}

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -290,6 +290,7 @@ task.type.DROPOFF: Dropoff
 
 demo.disclaimer: <i class="fa fa-bullhorn"></i>  Welcome on the demo of the <a target="_blank" href="https://coopcycle.org">CoopCycle</a> platform.
 demo.disclaimer.subtitle: <a target="_blank" href="https://coopcycle.org/en/help/how-to-use-the-demo/"><i class="fa fa-info-circle"></i>  How to use this demo?</a>
+maintenance.disclaimer: Maintenance mode is enabled
 
 cart.widget.title: Your delivery details
 cart.widget.button: Order

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -364,6 +364,10 @@ form.settings.default_tax_category.label: VAT rate for deliveries
 form.settings.default_tax_category.help: Specify the VAT rate to use for deliveries
 form.settings.administrator_email.label: Administrator email
 form.settings.administrator_email.help: Notifications will be sent to this email
+form.maintenace.enable.label: Enable maintenance
+form.maintenace.disable.label: Disable maintenance
+form.maintenace.enable.alert: 'You are going to enable maintenance mode.<br>Only administrators will have access to the site.'
+form.maintenace.disable.alert: You are going to disable maintenance mode
 form.settings.currency_code.label: Currency
 
 form.registration.username.help: |
@@ -490,6 +494,7 @@ basics.powered_by: Powered by <a href="https://coopcycle.org">CoopCycle</a>
 basics.add: Add
 basics.edit: Edit
 basics.delete: Delete
+basics.cancel: Cancel
 
 authentication.forgot_password: Forgot password?
 authentication.not_registered_yet: Not registered yet?

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -339,11 +339,12 @@ form.settings.stripe.help: '
   to configure this section, as well as Stripe Connect. Stripe takes a fee of 0.25cts + 1.4% per payment
   (up-to-date pricings <a href="https://stripe.com/fr/pricing">here</a>), to be paid by the shop owner.
 '
-form.settings.stripe.mode.help: '
-  If you pick ''No'' Stripe will be in test mode. You will have to use <a href="https://stripe.com/docs/testing">test credit cards</a> number to pay
-  on the platform (typically 4242 4242 4242 4242).
+form.settings.stripe_testmode.help: '
+  In « test » mode, you will have to use <a href="https://stripe.com/docs/testing">test credit cards</a> numbers to pay
+  on the platform.
   <strong>No money will be exchanged.</strong>
 '
+form.settings.stripe_enable_livemode.help: 'To enable « live » mode, you need to configure « live » keys first.'
 form.settings.stripe_publishable_key.label: Stripe publishable key
 form.settings.stripe_publishable_key.help: |
   Create a Stripe account to obtain your <a href="https://stripe.com/docs/dashboard#api-keys">publishable key</a>
@@ -353,7 +354,6 @@ form.settings.stripe_secret_key.help: |
 form.settings.stripe_connect_client_id.label: Stripe Connect identifier
 form.settings.stripe_connect_client_id.help: |
   Get the identifier on the <a href="https://dashboard.stripe.com/account/applications/settings">parameters page</a>
-form.settings.stripe_livemode.label: Use Stripe in « live » mode
 
 form.settings.google_api_key.label: Google API key
 form.settings.google_api_key.help: |
@@ -369,6 +369,12 @@ form.maintenance.enable.label: Enable maintenance
 form.maintenance.disable.label: Disable maintenance
 form.maintenance.enable.alert: 'You are going to enable maintenance mode.<br>Only administrators will have access to the site.'
 form.maintenance.disable.alert: You are going to disable maintenance mode
+form.stripe_livemode.enable.label: Use Stripe in « live » mode
+form.stripe_livemode.enable.alert: In « live » mode, credit cards will be charged.
+form.stripe_livemode.disable.label: Use Stripe in « test » mode
+form.stripe_livemode.disable.alert: In « test » mode, credit cards will not be charged.
+form.stripe_livemode.disable_and_enable_maintenance.label: Switch to « test » mode and enable maintenance
+form.stripe_livemode.disable_and_enable_maintenance.alert: 'You are in « live » mode.<br>If you switch to « test » mode, maintenance will be enabled automatically.'
 form.settings.currency_code.label: Currency
 
 form.registration.username.help: |

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -364,10 +364,10 @@ form.settings.default_tax_category.label: VAT rate for deliveries
 form.settings.default_tax_category.help: Specify the VAT rate to use for deliveries
 form.settings.administrator_email.label: Administrator email
 form.settings.administrator_email.help: Notifications will be sent to this email
-form.maintenace.enable.label: Enable maintenance
-form.maintenace.disable.label: Disable maintenance
-form.maintenace.enable.alert: 'You are going to enable maintenance mode.<br>Only administrators will have access to the site.'
-form.maintenace.disable.alert: You are going to disable maintenance mode
+form.maintenance.enable.label: Enable maintenance
+form.maintenance.disable.label: Disable maintenance
+form.maintenance.enable.alert: 'You are going to enable maintenance mode.<br>Only administrators will have access to the site.'
+form.maintenance.disable.alert: You are going to disable maintenance mode
 form.settings.currency_code.label: Currency
 
 form.registration.username.help: |

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -392,6 +392,10 @@ form.settings.default_tax_category.help: Establezca la tasa de IVA para entregas
 form.settings.administrator_email.label: Correo del administrador
 form.settings.administrator_email.help: Las notificaciones se enviarán a éste correo
 form.settings.currency_code.label: Moneda
+form.maintenace.enable.label: Activar el mantenimiento
+form.maintenace.disable.label: Desactivar el mantenimiento
+form.maintenace.enable.alert: 'Estás a punto de activar el mantenimiento.<br>Solo los administradores tendrán acceso al sitio.'
+form.maintenace.disable.alert: Estás a punto de desactivar el mantenimiento
 form.registration.username.help: 'Su nombre de usuario no puede tener más de 15 caracteres.
 
   Un nombre de usuario solo puede contener caracteres alfanuméricos (letras A-Z, números
@@ -529,6 +533,7 @@ basics.add: Añadir
 basics.edit: Modificar
 basics.delete: Eliminar
 basics.powered_by: Impulsado por <a href="https://coopcycle.org">CoopCycle</a>
+basics.cancel: Cancelar
 
 authentication.forgot_password: ¿Contraseña olvidada?
 authentication.not_registered_yet: ¿Todavía no estas registrado?

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -392,10 +392,10 @@ form.settings.default_tax_category.help: Establezca la tasa de IVA para entregas
 form.settings.administrator_email.label: Correo del administrador
 form.settings.administrator_email.help: Las notificaciones se enviarán a éste correo
 form.settings.currency_code.label: Moneda
-form.maintenace.enable.label: Activar el mantenimiento
-form.maintenace.disable.label: Desactivar el mantenimiento
-form.maintenace.enable.alert: 'Estás a punto de activar el mantenimiento.<br>Solo los administradores tendrán acceso al sitio.'
-form.maintenace.disable.alert: Estás a punto de desactivar el mantenimiento
+form.maintenance.enable.label: Activar el mantenimiento
+form.maintenance.disable.label: Desactivar el mantenimiento
+form.maintenance.enable.alert: 'Estás a punto de activar el mantenimiento.<br>Solo los administradores tendrán acceso al sitio.'
+form.maintenance.disable.alert: Estás a punto de desactivar el mantenimiento
 form.registration.username.help: 'Su nombre de usuario no puede tener más de 15 caracteres.
 
   Un nombre de usuario solo puede contener caracteres alfanuméricos (letras A-Z, números

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -353,17 +353,17 @@ form.settings.stripe.help: '
   to configure this section, as well as Stripe Connect. Stripe takes a fee of 0.25cts + 1.4% per payment
   (up-to-date pricings <a href="https://stripe.com/fr/pricing">here</a>), to be paid by the shop owner.
 '
-form.settings.stripe.mode.help: '
-  If you pick ''No'' Stripe will be in test mode. You will have to use <a href="https://stripe.com/docs/testing">test credit cards</a> number to pay
-  on the platform (typically 4242 4242 4242 4242).
-  <strong>No money will be exchanged.</strong>
+form.settings.stripe_testmode.help: '
+  En modo « test », debe usar <a href="https://stripe.com/docs/testing">números de tarjetas de prueba</a> para pagar.
+  <strong>No se intercambiará dinero.</strong>
 '
-form.settings.stripe_publishable_key.label: Clave pública de stripe
+form.settings.stripe_enable_livemode.help: 'Para activar el modo « live », primero necesita configurar las credenciales « live ».'
+form.settings.stripe_publishable_key.label: Clave pública de Stripe
 form.settings.stripe_publishable_key.help: 'Crea una cuenta Stripe para obtener tu
   <a href="https://stripe.com/docs/dashboard#api-keys">clave pública</a>
 
   '
-form.settings.stripe_secret_key.label: Clave secreta de stripe
+form.settings.stripe_secret_key.label: Clave secreta de Stripe
 form.settings.stripe_secret_key.help: 'Crea una cuenta Stripe para obtener tu <a href="https://stripe.com/docs/dashboard#api-keys">clave
   secreta</a>
 
@@ -376,7 +376,6 @@ form.settings.stripe_connect_client_id.help: 'Puedes encontrar tu identificador 
 form.settings.stripe_secret_key.help: |
   Crea una cuenta Stripe para obtener tu <a href="https://stripe.com/docs/dashboard#api-keys">clave secreta</a>
 
-form.settings.stripe_livemode.label: Usar Stripe en modo « live »
 form.settings.google_api_key.label: Clave API de google
 form.settings.google_api_key.help: 'Crea una cuenta Google para obtener tu <a href="https://developers.google.com/maps/documentation/javascript/get-api-key?hl=Fr">clave
   API</a>
@@ -397,6 +396,12 @@ form.maintenance.enable.label: Activar el mantenimiento
 form.maintenance.disable.label: Desactivar el mantenimiento
 form.maintenance.enable.alert: 'Estás a punto de activar el mantenimiento.<br>Solo los administradores tendrán acceso al sitio.'
 form.maintenance.disable.alert: Estás a punto de desactivar el mantenimiento
+form.stripe_livemode.enable.label: Utilizar Stripe en modo « live »
+form.stripe_livemode.enable.alert: En modo « live », las tarjetas de crédito serán cargadas.
+form.stripe_livemode.disable.label: Utilizar Stripe en modo « test »
+form.stripe_livemode.disable.alert: En modo « test », las tarjetas de crédito no serán cargadas.
+form.stripe_livemode.disable_and_enable_maintenance.label: Utilizar el modo « test » y activar el mantenimiento
+form.stripe_livemode.disable_and_enable_maintenance.alert: 'Estás utilizando el modo « live ».<br>Si quiere pasar en modo « test », el mantenimiento se activará automáticamente.'
 form.registration.username.help: 'Su nombre de usuario no puede tener más de 15 caracteres.
 
   Un nombre de usuario solo puede contener caracteres alfanuméricos (letras A-Z, números

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -304,6 +304,7 @@ demo.disclaimer: <i class="fa fa-bullhorn"></i>  Bienvenido a a demo de la plata
   <a target="_blank" href="https://coopcycle.org">CoopCycle</a>.
 demo.disclaimer.subtitle: <a target="_blank" href="https://coopcycle.org/en/help/how-to-use-the-demo/"><i
   class="fa fa-info-circle"></i>  ¿Cómo usar la demo?</a>
+maintenance.disclaimer: El modo mantenimiento esta activado
 cart.title: Carrito
 cart.widget.title: Tus detalles de entrega
 cart.widget.button: Pedir

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -302,6 +302,7 @@ demo.disclaimer: <i class="fa fa-bullhorn"></i>  Bienvenue sur la démo de la pl
   <a target="_blank" href="https://coopcycle.org">CoopCycle</a>
 demo.disclaimer.subtitle: <a target="_blank" href="https://coopcycle.org/fr/aide/comment-utiliser-la-demo/"><i
   class="fa fa-info-circle"></i>  Comment utiliser cette démo ?</a>
+maintenance.disclaimer: Le mode maintenance est activé
 cart.title: Panier
 cart.widget.title: Vos détails de livraison
 cart.widget.button: Commander

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -366,10 +366,11 @@ form.settings.stripe.help: '
   Pour utiliser la partie e-commerce de la plateforme, il est nécessaire de configurer cette section, ainsi que Stripe Connect.
   Stripe prend une commission de 0.25cts + 1.4% par paiement (indicatif, tarifs actualisés <a href="https://stripe.com/fr/pricing">ici</a>) à la charge du commerçant.
 '
-form.settings.stripe.mode.help: '
-  Si vous cochez "non", Stripe sera en mode test. Il faudra utiliser des <a href="https://stripe.com/docs/testing">cartes tests</a>
-  pour faire des achats (typiquement 4242 4242 4242 4242). <strong>Personne ne sera débité, aucun argent échangé.</strong>
+form.settings.stripe_testmode.help: '
+  En mode « test », vous devez utiliser des <a href="https://stripe.com/docs/testing">cartes de test</a>
+  pour faire des achats. <strong>Personne n''est débité, aucun argent échangé.</strong>
 '
+form.settings.stripe_enable_livemode.help: 'Pour activer le mode « live », vous devez configurer les identifiants « live ».'
 form.settings.brand_name.label: Nom de la marque
 form.settings.stripe_publishable_key.label: Clé publique Stripe
 form.settings.stripe_publishable_key.help: 'Créez un compte Stripe pour récupérer
@@ -387,7 +388,6 @@ form.settings.stripe_connect_client_id.help: 'Récupérez l''identifiant Stripe 
   des paramètres</a>
 
   '
-form.settings.stripe_livemode.label: Utiliser Stripe en mode « live »
 form.settings.google_api_key.label: Clé d'API Google
 form.settings.google_api_key.help: 'Créez un compte Google pour récupérer votre <a
   href="https://developers.google.com/maps/documentation/javascript/get-api-key?hl=Fr">clé
@@ -408,6 +408,12 @@ form.maintenance.enable.label: Activer la maintenance
 form.maintenance.disable.label: Désactiver la maintenance
 form.maintenance.enable.alert: 'Vous allez activer le mode maintenance.<br>Seuls les administrateurs auront accès au site.'
 form.maintenance.disable.alert: Vous allez désactiver le mode maintenance
+form.stripe_livemode.enable.label: Utiliser Stripe en mode « live »
+form.stripe_livemode.enable.alert: En mode « live », les cartes seront débitées.
+form.stripe_livemode.disable.label: Utiliser Stripe en mode « test »
+form.stripe_livemode.disable.alert: En mode « test », les cartes ne seront pas débitées.
+form.stripe_livemode.disable_and_enable_maintenance.label: Passer en mode « test » et activer la maintenance
+form.stripe_livemode.disable_and_enable_maintenance.alert: 'Vous êtes actuellement en mode « live ».<br>Si vous souhaitez passer en « test », le mode maintenance sera activé automatiquement.'
 form.registration.username.help: 'Votre nom d''utilisateur ne peut pas dépasser 15
   caractères.
 

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -403,6 +403,10 @@ form.settings.default_tax_category.help: Définissez le taux de TVA à appliquer
   les livraisons
 form.settings.administrator_email.label: Email de l'administrateur
 form.settings.administrator_email.help: Les notifications seront envoyées à cet email
+form.maintenace.enable.label: Activer la maintenance
+form.maintenace.disable.label: Désactiver la maintenance
+form.maintenace.enable.alert: 'Vous allez activer le mode maintenance.<br>Seuls les administrateurs auront accès au site.'
+form.maintenace.disable.alert: Vous allez désactiver le mode maintenance
 form.registration.username.help: 'Votre nom d''utilisateur ne peut pas dépasser 15
   caractères.
 
@@ -545,6 +549,7 @@ basics.powered_by: Propulsé par <a href="https://coopcycle.org">CoopCycle</a>
 basics.edit: Modifier
 basics.add: Ajouter
 basics.delete: Supprimer
+basics.cancel: Annuler
 adminDashboard.embed.title: Intégration
 embed.delivery.title: Formulaire de création de livraison
 embed.delivery.configure_pricing_rule_set: Vous devez d'abord configurer un règle

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -403,10 +403,10 @@ form.settings.default_tax_category.help: Définissez le taux de TVA à appliquer
   les livraisons
 form.settings.administrator_email.label: Email de l'administrateur
 form.settings.administrator_email.help: Les notifications seront envoyées à cet email
-form.maintenace.enable.label: Activer la maintenance
-form.maintenace.disable.label: Désactiver la maintenance
-form.maintenace.enable.alert: 'Vous allez activer le mode maintenance.<br>Seuls les administrateurs auront accès au site.'
-form.maintenace.disable.alert: Vous allez désactiver le mode maintenance
+form.maintenance.enable.label: Activer la maintenance
+form.maintenance.disable.label: Désactiver la maintenance
+form.maintenance.enable.alert: 'Vous allez activer le mode maintenance.<br>Seuls les administrateurs auront accès au site.'
+form.maintenance.disable.alert: Vous allez désactiver le mode maintenance
 form.registration.username.help: 'Votre nom d''utilisateur ne peut pas dépasser 15
   caractères.
 

--- a/src/AppBundle/Resources/views/Admin/settings.html.twig
+++ b/src/AppBundle/Resources/views/Admin/settings.html.twig
@@ -1,6 +1,7 @@
 {% extends "AppBundle::admin.html.twig" %}
 
 {% form_theme form 'AppBundle:Form:settings.html.twig' %}
+{% form_theme maintenance_form 'bootstrap_3_layout.html.twig' %}
 
 {% block breadcrumb %}
 <li>{% trans %}adminDashboard.settings.title{% endtrans %}</li>
@@ -10,6 +11,13 @@
 {{ form_start(form) }}
   {{ form_row(form.brand_name) }}
   {{ form_row(form.administrator_email) }}
+
+  <div class="alert alert-danger">
+    <i class="fa fa-warning"></i> {{ 'form.maintenace.enable.label'|trans }}
+    <div class="pull-right">
+      <div id="maintenance"></div>
+    </div>
+  </div>
 
   <hr>
 
@@ -68,7 +76,67 @@
 
   <button type="submit" class="btn btn-block btn-primary">{{ 'basics.save'|trans }}</button>
 {{ form_end(form) }}
+
+<div id="modal-maintenance" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      {{ form_start(maintenance_form) }}
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title" data-enable>{{ 'form.maintenace.enable.label'|trans }}</h4>
+        <h4 class="modal-title" data-disable>{{ 'form.maintenace.disable.label'|trans }}</h4>
+      </div>
+      <div class="modal-body">
+        <div class="alert alert-danger" data-enable>
+          {% trans %}form.maintenace.enable.alert{% endtrans %}
+        </div>
+        <div class="alert alert-success" data-disable>
+          {% trans %}form.maintenace.disable.alert{% endtrans %}
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">{{ 'basics.cancel'|trans }}</button>
+        {{ form_widget(maintenance_form.enable, { attr: { class: 'btn-danger', 'data-enable': 'true' } }) }}
+        {{ form_widget(maintenance_form.disable, { attr: { class: 'btn-success', 'data-disable': 'true' } }) }}
+      </div>
+      {{ form_end(maintenance_form) }}
+    </div>
+  </div>
+</div>
+
 {% endblock %}
 
 {% block scripts %}
+  <script src="{{ asset('js/widgets.js') }}"></script>
+  <script>
+    var maintenanceSwitch;
+    var isMaintenanceEnabled = {{ maintenance is not empty ? 'true' : 'false' }};
+
+    $('#modal-maintenance').on('hidden.bs.modal', function(e) {
+      if (true === isMaintenanceEnabled) {
+        maintenanceSwitch.check();
+      } else {
+        maintenanceSwitch.uncheck();
+      }
+    });
+
+    var options = {
+      checked: isMaintenanceEnabled,
+      onChange: function(checked) {
+        if (checked !== isMaintenanceEnabled) {
+          if (checked) {
+            $('#modal-maintenance').find('[data-disable]').hide();
+          } else {
+            $('#modal-maintenance').find('[data-enable]').hide();
+          }
+          $('#modal-maintenance').modal('show');
+        }
+      }
+    };
+
+    maintenanceSwitch = new CoopCycle.Switch(document.querySelector('#maintenance'), options);
+
+  </script>
 {% endblock %}

--- a/src/AppBundle/Resources/views/Admin/settings.html.twig
+++ b/src/AppBundle/Resources/views/Admin/settings.html.twig
@@ -2,6 +2,7 @@
 
 {% form_theme form 'AppBundle:Form:settings.html.twig' %}
 {% form_theme maintenance_form 'bootstrap_3_layout.html.twig' %}
+{% form_theme stripe_livemode_form 'bootstrap_3_layout.html.twig' %}
 
 {% block breadcrumb %}
 <li>{% trans %}adminDashboard.settings.title{% endtrans %}</li>
@@ -66,11 +67,26 @@
     </div>
   </div>
 
-  <hr>
-
-  <div class="alert alert-info">
-    <i class="fa fa-info-circle"></i> {{ "form.settings.stripe.mode.help" | trans | raw }}
+  <div class="alert alert-danger">
+    <i class="fa fa-warning"></i> {{ 'form.stripe_livemode.enable.label'|trans }}
+    <div class="pull-right">
+      <div id="stripe_livemode_switch"></div>
+    </div>
   </div>
+
+  {% if not stripe_livemode %}
+  <p class="help-block">
+    <i class="fa fa-info-circle"></i> {{ 'form.settings.stripe_testmode.help'|trans|raw }}
+  </p>
+  {% endif %}
+
+  {% if not can_enable_stripe_livemode %}
+  <p class="help-block">
+    <i class="fa fa-info-circle"></i> {{ 'form.settings.stripe_enable_livemode.help'|trans|raw }}
+  </p>
+  {% endif %}
+
+  <hr>
 
   {{ form_rest(form) }}
 
@@ -106,13 +122,53 @@
   </div>
 </div>
 
+<div id="modal-stripe-livemode" class="modal fade" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      {{ form_start(stripe_livemode_form) }}
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+        <h4 class="modal-title" data-enable>{{ 'form.stripe_livemode.enable.label'|trans }}</h4>
+        <h4 class="modal-title" data-disable>{{ 'form.stripe_livemode.disable.label'|trans }}</h4>
+        <h4 class="modal-title" data-disable-and-enable-maintenance>{{ 'form.stripe_livemode.disable.label'|trans }}</h4>
+      </div>
+      <div class="modal-body">
+        <div class="alert alert-success" data-enable>
+          {% trans %}form.stripe_livemode.enable.alert{% endtrans %}
+        </div>
+        <div class="alert alert-danger" data-disable>
+          {% trans %}form.stripe_livemode.disable.alert{% endtrans %}
+        </div>
+        <div class="alert alert-danger" data-disable-and-enable-maintenance>
+          {% trans %}form.stripe_livemode.disable_and_enable_maintenance.alert{% endtrans %}
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">{{ 'basics.cancel'|trans }}</button>
+        {{ form_widget(stripe_livemode_form.enable, { attr: { class: 'btn-success', 'data-enable': 'true' } }) }}
+        {{ form_widget(stripe_livemode_form.disable, { attr: { class: 'btn-danger', 'data-disable': 'true' } }) }}
+        {{ form_widget(stripe_livemode_form.disable_and_enable_maintenance, { attr: { class: 'btn-danger', 'data-disable-and-enable-maintenance': 'true' } }) }}
+      </div>
+      {{ form_end(stripe_livemode_form) }}
+    </div>
+  </div>
+</div>
+
 {% endblock %}
 
 {% block scripts %}
   <script src="{{ asset('js/widgets.js') }}"></script>
   <script>
-    var maintenanceSwitch;
+
     var isMaintenanceEnabled = {{ maintenance is not empty ? 'true' : 'false' }};
+    var isStripeLivemode = {{ stripe_livemode ? 'true' : 'false' }};
+    var canEnableStripeLivemode = {{ can_enable_stripe_livemode ? 'true' : 'false' }};
+
+    var maintenanceSwitch, stripeLiveModeSwitch;
+
+    /* Maintenance */
 
     $('#modal-maintenance').on('hidden.bs.modal', function(e) {
       if (true === isMaintenanceEnabled) {
@@ -122,21 +178,62 @@
       }
     });
 
-    var options = {
+    var maintenanceSwitchOptions = {
       checked: isMaintenanceEnabled,
       onChange: function(checked) {
         if (checked !== isMaintenanceEnabled) {
           if (checked) {
             $('#modal-maintenance').find('[data-disable]').hide();
+            $('#modal-maintenance').find('[data-enable]').show();
           } else {
             $('#modal-maintenance').find('[data-enable]').hide();
+            $('#modal-maintenance').find('[data-disable]').show();
           }
           $('#modal-maintenance').modal('show');
         }
       }
     };
 
-    maintenanceSwitch = new CoopCycle.Switch(document.querySelector('#maintenance'), options);
+    maintenanceSwitch = new CoopCycle.Switch(document.querySelector('#maintenance'), maintenanceSwitchOptions);
+
+    /* Stripe Live Mode */
+
+    $('#modal-stripe-livemode').on('hidden.bs.modal', function(e) {
+      if (true === isStripeLivemode) {
+        stripeLiveModeSwitch.check();
+      } else {
+        stripeLiveModeSwitch.uncheck();
+      }
+    });
+
+    var stripeLiveModeSwitchOptions = {
+      checked: isStripeLivemode,
+      disabled: !canEnableStripeLivemode,
+      onChange: function(checked) {
+        if (checked !== isStripeLivemode) {
+          // Stripe was previously live, but the admin wants to disable it
+          if (isStripeLivemode && !checked) {
+            $('#modal-stripe-livemode').find('[data-enable]').hide();
+            if (!isMaintenanceEnabled) {
+              $('#modal-stripe-livemode').find('[data-disable]').hide();
+              $('#modal-stripe-livemode').find('[data-disable-and-enable-maintenance]').show();
+            } else {
+              $('#modal-stripe-livemode').find('[data-disable-and-enable-maintenance]').hide();
+              $('#modal-stripe-livemode').find('[data-disable]').show();
+            }
+            $('#modal-stripe-livemode').modal('show');
+          }
+          if (!isStripeLivemode && checked) {
+            $('#modal-stripe-livemode').find('[data-disable]').hide();
+            $('#modal-stripe-livemode').find('[data-disable-and-enable-maintenance]').hide();
+            $('#modal-stripe-livemode').find('[data-enable]').show();
+            $('#modal-stripe-livemode').modal('show');
+          }
+        }
+      }
+    };
+
+    stripeLiveModeSwitch = new CoopCycle.Switch(document.querySelector('#stripe_livemode_switch'), stripeLiveModeSwitchOptions);
 
   </script>
 {% endblock %}

--- a/src/AppBundle/Resources/views/Admin/settings.html.twig
+++ b/src/AppBundle/Resources/views/Admin/settings.html.twig
@@ -13,7 +13,7 @@
   {{ form_row(form.administrator_email) }}
 
   <div class="alert alert-danger">
-    <i class="fa fa-warning"></i> {{ 'form.maintenace.enable.label'|trans }}
+    <i class="fa fa-warning"></i> {{ 'form.maintenance.enable.label'|trans }}
     <div class="pull-right">
       <div id="maintenance"></div>
     </div>
@@ -85,15 +85,15 @@
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
-        <h4 class="modal-title" data-enable>{{ 'form.maintenace.enable.label'|trans }}</h4>
-        <h4 class="modal-title" data-disable>{{ 'form.maintenace.disable.label'|trans }}</h4>
+        <h4 class="modal-title" data-enable>{{ 'form.maintenance.enable.label'|trans }}</h4>
+        <h4 class="modal-title" data-disable>{{ 'form.maintenance.disable.label'|trans }}</h4>
       </div>
       <div class="modal-body">
         <div class="alert alert-danger" data-enable>
-          {% trans %}form.maintenace.enable.alert{% endtrans %}
+          {% trans %}form.maintenance.enable.alert{% endtrans %}
         </div>
         <div class="alert alert-success" data-disable>
-          {% trans %}form.maintenace.disable.alert{% endtrans %}
+          {% trans %}form.maintenance.disable.alert{% endtrans %}
         </div>
       </div>
       <div class="modal-footer">

--- a/src/AppBundle/Resources/views/_partials/maintenance.html.twig
+++ b/src/AppBundle/Resources/views/_partials/maintenance.html.twig
@@ -1,0 +1,11 @@
+{% if is_granted('ROLE_ADMIN') and coopcycle_maintenance() %}
+  <section id="banner">
+    <div class="container">
+      <div class="row">
+        <div class="col-md-8 col-md-offset-2 text-center">
+          {{ 'maintenance.disclaimer'|trans|raw }}
+        </div>
+      </div>
+    </div>
+  </section>
+{% endif %}

--- a/src/AppBundle/Resources/views/admin.html.twig
+++ b/src/AppBundle/Resources/views/admin.html.twig
@@ -1,6 +1,8 @@
 {% extends "AppBundle::base.html.twig" %}
 
-{% block banner %}{% endblock %}
+{% block banner %}
+  {% include '@App/_partials/maintenance.html.twig' %}
+{% endblock %}
 
 {% block body %}
 <div class="container container--full-height">

--- a/src/AppBundle/Resources/views/base.html.twig
+++ b/src/AppBundle/Resources/views/base.html.twig
@@ -27,6 +27,7 @@
           </div>
         </section>
       {% endif %}
+      {% include '@App/_partials/maintenance.html.twig' %}
     {% endblock %}
     <div class="content">
     {% block body %}{% endblock %}

--- a/src/AppBundle/Resources/views/maintenance.html.twig
+++ b/src/AppBundle/Resources/views/maintenance.html.twig
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="{{ app.request.locale }}">
+  <head>
+    {{ sonata_seo_title() }}
+    {{ sonata_seo_link_canonical() }}
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    {{ sonata_seo_metadatas() }}
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Open+Sans:400,700">
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Raleway:400,700">
+    <link rel="stylesheet" href="{{ asset('css/styles.css') }}">
+  </head>
+  <body>
+    <div class="container container--full-height container--center  ">
+      <div class="maintenance">
+        <i class="fa fa-warning"></i>
+        <br />
+        Site en maintenance.
+        <br />
+        Nous revenons dans quelques instants.
+      </div>
+    </div>
+    {% if app.environment == "prod" %}
+      <script src="https://cdn.ravenjs.com/3.23.1/raven.min.js" crossorigin="anonymous"></script>
+      <script>
+        Raven.config("{{ sentry_public_dsn }}").install();
+      </script>
+    {% endif %}
+    <script src="{{ asset('manifest.js') }}"></script>
+    <script src="{{ asset('js/vendor.js') }}"></script>
+    <script src="{{ asset('js/common.js') }}"></script>
+    {% if app.environment == "dev" %}
+      <script src="{{ asset('webpack-dev-server.js') }}"></script>
+    {% endif %}
+    {% include "@App/_partials/piwik.html.twig" %}
+  </body>
+</html>

--- a/src/AppBundle/Service/SettingsManager.php
+++ b/src/AppBundle/Service/SettingsManager.php
@@ -77,7 +77,7 @@ class SettingsManager
         } catch (\RuntimeException $e) {}
     }
 
-    private function isStripeLivemode()
+    public function isStripeLivemode()
     {
         $livemode = $this->get('stripe_livemode');
 
@@ -86,6 +86,20 @@ class SettingsManager
         }
 
         return filter_var($livemode, FILTER_VALIDATE_BOOLEAN);
+    }
+
+    public function canEnableStripeLivemode()
+    {
+        try {
+            $stripeLivePublishableKey = $this->craueConfig->get('stripe_live_publishable_key');
+            $stripeLiveSecretKey = $this->craueConfig->get('stripe_live_secret_key');
+            $stripeLiveConnectClientId = $this->craueConfig->get('stripe_live_connect_client_id');
+
+            return !empty($stripeLivePublishableKey) && !empty($stripeLiveSecretKey) && !empty($stripeLiveConnectClientId);
+
+        } catch (\RuntimeException $e) {
+            return false;
+        }
     }
 
     public function set($name, $value)

--- a/src/AppBundle/Twig/CoopCycleExtension.php
+++ b/src/AppBundle/Twig/CoopCycleExtension.php
@@ -22,6 +22,7 @@ class CoopCycleExtension extends \Twig_Extension
     {
         return array(
             new \Twig_SimpleFunction('coopcycle_setting', array(SettingResolver::class, 'resolveSetting')),
+            new \Twig_SimpleFunction('coopcycle_maintenance', array(MaintenanceResolver::class, 'isEnabled')),
         );
     }
 

--- a/src/AppBundle/Twig/MaintenanceResolver.php
+++ b/src/AppBundle/Twig/MaintenanceResolver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AppBundle\Twig;
+
+use Predis\Client as Redis;
+
+class MaintenanceResolver
+{
+    private $redis;
+
+    public function __construct(Redis $redis)
+    {
+        $this->redis = $redis;
+    }
+
+    public function isEnabled()
+    {
+        return !empty($this->redis->get('maintenance'));
+    }
+}


### PR DESCRIPTION
In maintenance mode, all requests return a 503, except for administrators, who can continue to browse the site. This will allow, for example, to disable Stripe live mode, to make some tests with fake credit cards. 

![maintenance_mode](https://user-images.githubusercontent.com/1162230/45154671-a55a2200-b1d8-11e8-8a41-fe7c27ab353d.gif)

---

This is also linked with Stripe live mode. If the platform is in live mode, switching to test mode automatically switches to maintenance. 

![disable_live_mode](https://user-images.githubusercontent.com/1162230/45173248-e584c900-b207-11e8-859c-c0d06cf29008.gif)

--- 

Finally, it is now impossible to switch to live mode without the keys configured.

<img width="969" alt="capture d ecran 2018-09-06 a 19 27 30" src="https://user-images.githubusercontent.com/1162230/45174385-069ae900-b20b-11e8-8768-bbfe17f57364.png">
