### PR TITLE
Handle order cancellation properly

### DIFF
--- a/app/config/message_bus/order.yml
+++ b/app/config/message_bus/order.yml
@@ -107,6 +107,14 @@ services:
           subscribes_to: order:accepted
           priority: 255
 
+  coopcycle.domain.order.reactor.cancel_tasks:
+    class: AppBundle\Domain\Order\Reactor\CancelTasks
+    arguments:
+      - '@coopcycle.task_manager'
+    tags:
+        - name: event_subscriber
+          subscribes_to: order:cancelled
+
   coopcycle.domain.order.reactor.send_email:
     class: AppBundle\Domain\Order\Reactor\SendEmail
     arguments:

--- a/app/config/state_machine.yml
+++ b/app/config/state_machine.yml
@@ -63,7 +63,7 @@ winzou_state_machine:
                 from: [cart, new, authorized]
                 to: failed
             cancel:
-                from: [new]
+                from: [cart, new, authorized]
                 to: cancelled
             refund:
                 from: [completed]

--- a/features/tasks.feature
+++ b/features/tasks.feature
@@ -259,3 +259,39 @@ Feature: Tasks
       """
     Then the response status code should be 403
     And the response should be in JSON
+
+  Scenario: Cancelled task can't be marked as done
+    Given the database is empty
+    And the fixtures file "tasks.yml" is loaded
+    And the courier "bob" is loaded:
+      | email     | bob@coopcycle.org |
+      | password  | 123456            |
+      | telephone | 0033612345678     |
+    And the user "bob" is authenticated
+    And the tasks with comments matching "#bob" are assigned to "bob"
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "PUT" request to "/api/tasks/6/done" with body:
+      """
+      {}
+      """
+    Then the response status code should be 400
+    And the response should be in JSON
+
+  Scenario: Cancelled task can't be marked as failed
+    Given the database is empty
+    And the fixtures file "tasks.yml" is loaded
+    And the courier "bob" is loaded:
+      | email     | bob@coopcycle.org |
+      | password  | 123456            |
+      | telephone | 0033612345678     |
+    And the user "bob" is authenticated
+    And the tasks with comments matching "#bob" are assigned to "bob"
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "PUT" request to "/api/tasks/6/failed" with body:
+      """
+      {}
+      """
+    Then the response status code should be 400
+    And the response should be in JSON

--- a/js/api/tracking/index.js
+++ b/js/api/tracking/index.js
@@ -83,6 +83,10 @@ const channels = {
     toJSON: true,
     psubscribe: false
   },
+  'task:cancelled': {
+    toJSON: true,
+    psubscribe: false
+  },
   'restaurant:*:orders': {
     toJSON: true,
     psubscribe: true

--- a/js/app/dashboard/store/reducers.js
+++ b/js/app/dashboard/store/reducers.js
@@ -191,13 +191,12 @@ const unassignedTasks = (state = unassignedTasksInitial, action) => {
 
     case 'ADD_CREATED_TASK':
       if (!moment(action.task.doneBefore).isSame(window.AppData.Dashboard.date, 'day')) {
-        return state.slice(0)
+        return state
       }
-
       if (!_.find(unassignedTasksInitial, (task) => { task['id'] === action.task.id })) {
-        return Array.prototype.concat(state, [action.task])
+        newState = state.slice(0)
+        return addLinkProperty(Array.prototype.concat(newState, [ action.task ]))
       }
-      break;
     case 'ASSIGN_TASKS':
       newState = state.slice(0)
       newState = _.differenceWith(
@@ -244,6 +243,22 @@ const unassignedTasks = (state = unassignedTasksInitial, action) => {
 }
 
 const allTasks = (state = tasksInitial, action) => {
+  let newState
+
+  switch (action.type) {
+
+    case 'ADD_CREATED_TASK':
+      if (!moment(action.task.doneBefore).isSame(window.AppData.Dashboard.date, 'day')) {
+        return state
+      }
+
+      newState = state.slice(0)
+      return addLinkProperty(Array.prototype.concat(newState, [ action.task ]))
+
+    // case 'UPDATE_TASK':
+    //   break;
+  }
+
   return state
 }
 

--- a/src/AppBundle/Action/Task/Base.php
+++ b/src/AppBundle/Action/Task/Base.php
@@ -40,11 +40,4 @@ abstract class Base
             return $data['reason'];
         }
     }
-
-    protected function accessControl(Task $task)
-    {
-        if (!$task->isAssignedTo($this->getUser())) {
-            throw new AccessDeniedHttpException(sprintf('User %s cannot update task', $this->getUser()->getUsername()));
-        }
-    }
 }

--- a/src/AppBundle/Action/Task/Done.php
+++ b/src/AppBundle/Action/Task/Done.php
@@ -4,6 +4,7 @@ namespace AppBundle\Action\Task;
 
 use AppBundle\Entity\Task;
 use AppBundle\Exception\PreviousTaskNotCompletedException;
+use AppBundle\Exception\TaskCancelledException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -18,6 +19,8 @@ class Done extends Base
         try {
             $this->taskManager->markAsDone($task, $this->getNotes($request));
         } catch (PreviousTaskNotCompletedException $e) {
+            throw new BadRequestHttpException($e->getMessage());
+        } catch (TaskCancelledException $e) {
             throw new BadRequestHttpException($e->getMessage());
         }
 

--- a/src/AppBundle/Action/Task/Done.php
+++ b/src/AppBundle/Action/Task/Done.php
@@ -11,22 +11,10 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class Done extends Base
 {
-    /**
-     * @Route(
-     *   name="api_task_done",
-     *   path="/tasks/{id}/done",
-     *   defaults={
-     *     "_api_resource_class"=Task::class,
-     *     "_api_item_operation_name"="task_done"
-     *   }
-     * )
-     * @Method("PUT")
-     */
     public function __invoke(Task $data, Request $request)
     {
         $task = $data;
 
-        $this->accessControl($task);
         try {
             $this->taskManager->markAsDone($task, $this->getNotes($request));
         } catch (PreviousTaskNotCompletedException $e) {

--- a/src/AppBundle/Action/Task/Failed.php
+++ b/src/AppBundle/Action/Task/Failed.php
@@ -11,22 +11,10 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class Failed extends Base
 {
-    /**
-     * @Route(
-     *   name="api_task_failed",
-     *   path="/tasks/{id}/failed",
-     *   defaults={
-     *     "_api_resource_class"=Task::class,
-     *     "_api_item_operation_name"="task_failed"
-     *   }
-     * )
-     * @Method("PUT")
-     */
     public function __invoke(Task $data, Request $request)
     {
         $task = $data;
 
-        $this->accessControl($task);
         try {
             $this->taskManager->markAsFailed($task, $this->getNotes($request));
         } catch (PreviousTaskNotCompletedException $e) {

--- a/src/AppBundle/Action/Task/Failed.php
+++ b/src/AppBundle/Action/Task/Failed.php
@@ -4,6 +4,7 @@ namespace AppBundle\Action\Task;
 
 use AppBundle\Entity\Task;
 use AppBundle\Exception\PreviousTaskNotCompletedException;
+use AppBundle\Exception\TaskCancelledException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -18,6 +19,8 @@ class Failed extends Base
         try {
             $this->taskManager->markAsFailed($task, $this->getNotes($request));
         } catch (PreviousTaskNotCompletedException $e) {
+            throw new BadRequestHttpException($e->getMessage());
+        } catch (TaskCancelledException $e) {
             throw new BadRequestHttpException($e->getMessage());
         }
 

--- a/src/AppBundle/Domain/Order/Reactor/CancelTasks.php
+++ b/src/AppBundle/Domain/Order/Reactor/CancelTasks.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AppBundle\Domain\Order\Reactor;
+
+use AppBundle\Domain\Order\Event\OrderCancelled;
+use AppBundle\Service\TaskManager;
+
+class CancelTasks
+{
+    private $taskManager;
+
+    public function __construct(TaskManager $taskManager)
+    {
+        $this->taskManager = $taskManager;
+    }
+
+    public function __invoke(OrderCancelled $event)
+    {
+        $order = $event->getOrder();
+
+        if (null === $order->getDelivery()) {
+            return;
+        }
+
+        $this->taskManager->cancel($order->getDelivery()->getPickup());
+        $this->taskManager->cancel($order->getDelivery()->getDropoff());
+    }
+}

--- a/src/AppBundle/Domain/Task/Handler/MarkAsDoneHandler.php
+++ b/src/AppBundle/Domain/Task/Handler/MarkAsDoneHandler.php
@@ -6,6 +6,7 @@ use AppBundle\Domain\Task\Command\MarkAsDone;
 use AppBundle\Domain\Task\Event;
 use AppBundle\Entity\Task;
 use AppBundle\Exception\PreviousTaskNotCompletedException;
+use AppBundle\Exception\TaskCancelledException;
 use SimpleBus\Message\Recorder\RecordsMessages;
 
 class MarkAsDoneHandler
@@ -20,6 +21,11 @@ class MarkAsDoneHandler
     public function __invoke(MarkAsDone $command)
     {
         $task = $command->getTask();
+
+        // TODO Use StateMachine?
+        if ($task->isCancelled()) {
+            throw new TaskCancelledException(sprintf('Task #%d is cancelled', $task->getId()));
+        }
 
         if ($task->hasPrevious() && !$task->getPrevious()->isDone()) {
             throw new PreviousTaskNotCompletedException('Previous task must be completed first');

--- a/src/AppBundle/Domain/Task/Handler/MarkAsFailedHandler.php
+++ b/src/AppBundle/Domain/Task/Handler/MarkAsFailedHandler.php
@@ -6,6 +6,7 @@ use AppBundle\Domain\Task\Command\MarkAsFailed;
 use AppBundle\Domain\Task\Event;
 use AppBundle\Entity\Task;
 use AppBundle\Exception\PreviousTaskNotCompletedException;
+use AppBundle\Exception\TaskCancelledException;
 use SimpleBus\Message\Recorder\RecordsMessages;
 
 class MarkAsFailedHandler
@@ -20,6 +21,11 @@ class MarkAsFailedHandler
     public function __invoke(MarkAsFailed $command)
     {
         $task = $command->getTask();
+
+        // TODO Use StateMachine?
+        if ($task->isCancelled()) {
+            throw new TaskCancelledException(sprintf('Task #%d is cancelled', $task->getId()));
+        }
 
         if ($task->hasPrevious() && !$task->getPrevious()->isDone()) {
             throw new PreviousTaskNotCompletedException('Previous task must be completed first');

--- a/src/AppBundle/Entity/Task.php
+++ b/src/AppBundle/Entity/Task.php
@@ -2,6 +2,8 @@
 
 namespace AppBundle\Entity;
 
+use AppBundle\Action\Task\Done as TaskDone;
+use AppBundle\Action\Task\Failed as TaskFailed;
 use AppBundle\Entity\Task\Group as TaskGroup;
 use AppBundle\Entity\Model\TaggableInterface;
 use AppBundle\Entity\Model\TaggableTrait;
@@ -33,8 +35,18 @@ use Symfony\Component\Validator\Constraints as Assert;
  *   },
  *   itemOperations={
  *     "get"={"method"="GET"},
- *     "task_done"={"route_name"="api_task_done"},
- *     "task_failed"={"route_name"="api_task_failed"}
+ *     "task_done"={
+ *       "method"="PUT",
+ *       "path"="/tasks/{id}/done",
+ *       "controller"=TaskDone::class,
+ *       "access_control"="is_granted('ROLE_COURIER') and object.isAssignedTo(user)"
+ *     },
+ *     "task_failed"={
+ *       "method"="PUT",
+ *       "path"="/tasks/{id}/failed",
+ *       "controller"=TaskFailed::class,
+ *       "access_control"="is_granted('ROLE_COURIER') and object.isAssignedTo(user)"
+ *     }
  *   }
  * )
  */

--- a/src/AppBundle/Exception/TaskCancelledException.php
+++ b/src/AppBundle/Exception/TaskCancelledException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace AppBundle\Exception;
+
+class TaskCancelledException extends \Exception
+{
+}


### PR DESCRIPTION
**Cancel tasks when an order is cancelled**

Previously, the tasks were left untouched. Now, they are cancelled properly. 

**Make sure a cancelled task cannot be marked as done/failed**

As tasks were still there even if the order was cancelled, a courier may complete the dropoff task anyway, triggering the capture of the payment. Now, cancelled task can't be completed. 

**Fix dashboard**

Also, I noticed newly created tasks were causing an error when dragged. This is fixed. 

