### PR TITLE
Improve mobile cart.

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -13,4 +13,5 @@
 @import "utils.scss";
 @import "dragula.scss";
 @import "stripe.scss";
+@import "ripple.scss";
 @import "styles.scss";

--- a/assets/css/ripple.scss
+++ b/assets/css/ripple.scss
@@ -1,0 +1,24 @@
+// https://tympanus.net/codrops/2015/02/11/subtle-click-feedback-effects/
+// https://tympanus.net/Development/ClickEffects/
+// https://github.com/codrops/ClickEffects
+
+@keyframes ripple-effect-radomir {
+  0% {
+    opacity: 1;
+    -webkit-transform: scale3d(0.4, 0.4, 1);
+    transform: scale3d(0.4, 0.4, 1);
+  }
+  80% {
+    box-shadow: inset 0 0 0 2px rgba(111,148,182,0.8);
+    opacity: 0.1;
+  }
+  100% {
+    box-shadow: inset 0 0 0 2px rgba(111,148,182,0.8);
+    opacity: 0;
+    -webkit-transform: scale3d(1.2, 1.2, 1);
+    transform: scale3d(1.2, 1.2, 1);
+  }
+}
+
+
+

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -222,10 +222,43 @@ $cart-heading-line-height: ($navbar-height - ($panel-heading-padding-vertical * 
     background-color: $main-blue-light !important;
     line-height: $cart-heading-line-height;
   }
+
+  &--warning {
+    @media screen and (max-width: $screen-md-min) {
+      background-color: $state-warning-bg !important;
+      color: $state-warning-text !important;
+
+      .cart-heading__left,
+      .cart-heading__right {
+        background-color: $state-warning-text;
+        color: $state-warning-bg;
+      }
+    }
+  }
 }
 
-.cart-heading--items,
-.cart-heading--total {
+.cart-heading__right {
+  position: relative;
+  &:after {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin: -35px 0 0 -35px;
+    width: 70px;
+    height: 70px;
+    border-radius: 50%;
+    content: '';
+    opacity: 0;
+    pointer-events: none;
+    box-shadow: inset 0 0 0 35px rgba(111, 148, 182, 0);
+  }
+  &--ripple:after {
+    animation: ripple-effect-radomir 0.5s ease-out forwards;
+  }
+}
+
+.cart-heading__left,
+.cart-heading__right {
   display: none;
 
   @media screen and (max-width: $screen-md-min) {
@@ -239,15 +272,28 @@ $cart-heading-line-height: ($navbar-height - ($panel-heading-padding-vertical * 
   }
 }
 
-.cart-heading--items {
+.cart-heading__left {
   @media screen and (max-width: $screen-md-min) {
     left: $panel-heading-padding-horizontal;
   }
 }
 
-.cart-heading--total {
+.cart-heading__right {
   @media screen and (max-width: $screen-md-min) {
     right: $panel-heading-padding-horizontal;
+  }
+}
+
+.cart-heading--title {
+  @media screen and (max-width: $screen-md-min) {
+    display: none;
+  }
+}
+
+.cart-heading--title-or-errors {
+  display: none;
+  @media screen and (max-width: $screen-md-min) {
+    display: inline;
   }
 }
 
@@ -266,10 +312,10 @@ $cart-heading-line-height: ($navbar-height - ($panel-heading-padding-vertical * 
     right: 0;
     transform: translateY(calc(100% - #{$navbar-height}));
     transition: transform 0.4s;
-  }
 
-  .fa-spinner {
-    margin-right: 4px;
+    &__messages {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
- Show "status" icon on the left.
- Display error text on the heading.
- Add "ripple effect" when there is an error.

![cart_mobile](https://user-images.githubusercontent.com/1162230/45257061-dd5f9180-b39f-11e8-8a95-ac48b95d8b5d.gif)
