### PR TITLE
Add submit button in mobile cart header

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -236,6 +236,27 @@ $cart-heading-line-height: ($navbar-height - ($panel-heading-padding-vertical * 
       }
     }
   }
+
+  &--success {
+    @media screen and (max-width: $screen-md-min) {
+      background-color: $state-success-bg !important;
+      color: $state-success-text !important;
+
+      .cart-heading__left,
+      .cart-heading__right {
+        background-color: $state-success-text;
+        color: $state-success-bg;
+      }
+
+      .cart-heading__right {
+        display: none;
+      }
+
+      .cart-heading__button {
+        display: block;
+      }
+    }
+  }
 }
 
 .cart-heading__right {
@@ -255,6 +276,21 @@ $cart-heading-line-height: ($navbar-height - ($panel-heading-padding-vertical * 
   }
   &--ripple:after {
     animation: ripple-effect-radomir 0.5s ease-out forwards;
+  }
+}
+
+.cart-heading__button {
+  display: none;
+
+  @media screen and (max-width: $screen-md-min) {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: $navbar-height;
+    height: $navbar-height;
+    background-color: $state-success-text;
+    color: $state-success-bg;
+    border: none;
   }
 }
 

--- a/js/app/cart/Cart.jsx
+++ b/js/app/cart/Cart.jsx
@@ -28,7 +28,8 @@ class Cart extends React.Component
       address: streetAddress,
       geohash: geohash,
       errors: {},
-      loading: false
+      loading: false,
+      initialized: false,
     }
 
     this.onAddressChange = this.onAddressChange.bind(this)
@@ -92,6 +93,13 @@ class Cart extends React.Component
   }
 
   setCart(cart) {
+
+    const { initialized } = this.state
+
+    if (!initialized) {
+      cart = { ...cart, initialized: true }
+    }
+
     this.setState(cart)
   }
 
@@ -169,11 +177,21 @@ class Cart extends React.Component
 
   renderHeading(warningAlerts, dangerAlerts) {
 
-    const { toggled } = this.state
+    const { toggled, initialized } = this.state
+    const { validateCartURL } = this.props
 
     const headingClasses = ['panel-heading', 'cart-heading']
     if (warningAlerts.length > 0 || dangerAlerts.length > 0) {
       headingClasses.push('cart-heading--warning')
+    }
+
+    if (initialized && warningAlerts.length === 0 && dangerAlerts.length === 0) {
+      headingClasses.push('cart-heading--success')
+    }
+
+    const onButtonClick = e => {
+      window.location.href = validateCartURL
+      e.stopPropagation()
     }
 
     return (
@@ -188,6 +206,9 @@ class Cart extends React.Component
         <span className="cart-heading__right" ref="headingRight">
           <i className={ toggled ? "fa fa-chevron-up" : "fa fa-chevron-down" }></i>
         </span>
+        <button onClick={ onButtonClick } className="cart-heading__button">
+          <i className="fa fa-arrow-right "></i>
+        </button>
       </div>
     )
   }
@@ -213,6 +234,8 @@ class Cart extends React.Component
   }
 
   headingTitle(warnings, errors) {
+    const { initialized } = this.state
+
     if (errors.length > 0) {
       return _.first(errors)
     }
@@ -220,7 +243,7 @@ class Cart extends React.Component
       return _.first(warnings)
     }
 
-    return i18n.t('CART_TITLE')
+    return initialized ? i18n.t('CART_WIDGET_BUTTON') : i18n.t('CART_TITLE')
   }
 
   render() {
@@ -250,10 +273,6 @@ class Cart extends React.Component
     } else {
       cartContent = ( <div className="alert alert-warning">{i18n.t("CART_EMPTY")}</div> )
     }
-
-    const itemCount = _.reduce(items, function(memo, item) {
-      return memo + (item.quantity);
-    }, 0)
 
     const warningAlerts = []
     const dangerAlerts = []


### PR DESCRIPTION
When the cart has no errors, it turns to "success" state, and a button on the right allows to go to next step in one click. 

<img width="323" alt="capture d ecran 2018-09-23 a 20 21 47" src="https://user-images.githubusercontent.com/1162230/45931434-6e249880-bf6e-11e8-969e-7c56936a64ff.png">

--- 

![cart-button-continue](https://user-images.githubusercontent.com/1162230/45931407-2c93ed80-bf6e-11e8-9910-98739b285889.gif)
