### PR TITLE
More instructions for newcomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ How to run a local instance
 
     - On Linux : follow [the instructions for your distribution](https://docs.docker.com/engine/installation/). `docker-compose` binary is to be installed independently. You can use Coopcycle without root privileges, to do so run `sudo usermod -aG docker your-user` (will add you to the `docker` group).
 
+* Setup Google Maps API
+
+Coopcycle uses Google Maps API for Geocoding. You will need to create a project
+in the Google Cloud Platform Console, and enable the Google Maps API. GCP will
+give you an API token that you will need later.  By default, the Geocoding API
+will not be enabled, so you need to enable it as well (Maps API dashboard >
+APIs > Geocoding > Enable).
+
+* (Linux) Setup permissions
+
+If you are using Linux, you will need to allow the user `www-data` used by the
+php docker container to write files to your local disk. You can do this by running
+the following commands in the directory containing your local clone of the
+repository:
+
+```
+sudo chown -R $(id -u):82 .
+sudo chmod -R g+w .
+```
+
 * Run the install scripts.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ the following commands in the directory containing your local clone of the
 repository:
 
 ```
-sudo chown -R $(id -u):82 .
-sudo chmod -R g+w .
+sudo chown -R $(id -u):82 coopcycle-web
+sudo chmod -R g+w coopcycle-web
 ```
 
 * Run the install scripts.

--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ How to run a local instance
 
     - On Windows : use [Docker for Windows](https://www.docker.com/docker-windows) which will provide you both `docker` and `docker-compose`. It doesn't rely on Virtualbox as Docker used to.
 
-    - On Linux : follow [the instructions for your distribution](https://docs.docker.com/engine/installation/). `docker-compose` binary is to be installed independently. You can use Coopcycle without root privileges, to do so run `sudo usermod -aG docker your-user` (will add you to the `docker` group).
+    - On Linux : follow [the instructions for your distribution](https://docs.docker.com/engine/installation/). `docker-compose` binary is to be installed independently. You can use CoopCycle without root privileges, to do so run `sudo usermod -aG docker your-user` (will add you to the `docker` group).
 
 * Setup Google Maps API
 
-Coopcycle uses Google Maps API for Geocoding. You will need to create a project
-in the Google Cloud Platform Console, and enable the Google Maps API. GCP will
-give you an API token that you will need later.  By default, the Geocoding API
-will not be enabled, so you need to enable it as well (Maps API dashboard >
-APIs > Geocoding > Enable).
+CoopCycle uses the Google Maps API for Geocoding, as well as the Places API.
+You will need to create a project in the Google Cloud Platform Console, and
+enable the Google Maps API. GCP will give you an API token that you will need
+later.  By default, the Geocoding and Places API will not be enabled, so you
+need to enable them as well (`Maps API dashboard > APIs > Geocoding API >
+Enable`, and `Maps API dashboard > APIs > Places API for Web > Enable`).
 
 * (Linux) Setup permissions
 


### PR DESCRIPTION
Setup might not be as straightforward as running `make install` for newcomers. Adding more instructions regarding the Google Maps API and file permissions on Linux can help them set up a test environment more easily the first time.

Issue #436 