### PR TITLE
Improve registration.

### DIFF
--- a/app/Resources/FOSUserBundle/views/Registration/check_email.html.twig
+++ b/app/Resources/FOSUserBundle/views/Registration/check_email.html.twig
@@ -1,0 +1,25 @@
+{% extends "@App/base.html.twig" %}
+
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% block body %}
+  <div class="container container--full-height container--center">
+    <div class="row">
+      <div class="col-xs-12">
+      {% block fos_user_content %}
+        <p class="text-center">
+          {% trans with { '%email%': user.email } %}registration.check_email{% endtrans %}
+          {% set cart = cart_provider.getCart() %}
+          {% if cart is not empty and cart.state == 'cart' %}
+          <br>
+          {% trans %}registration.before_confirmation_continue_order{% endtrans %}
+          {% endif %}
+        </p>
+        <p class="text-center">
+          <i class="fa fa-cog fa-spin fa-3x fa-fw"></i>
+        </p>
+      {% endblock fos_user_content %}
+      </div>
+    </div>
+  </div>
+{% endblock body %}

--- a/app/Resources/FOSUserBundle/views/Registration/confirmed.html.twig
+++ b/app/Resources/FOSUserBundle/views/Registration/confirmed.html.twig
@@ -1,0 +1,35 @@
+{% extends "@App/base.html.twig" %}
+
+{% trans_default_domain 'FOSUserBundle' %}
+
+{% block body %}
+  <div class="container container--full-height container--center">
+    <div class="row">
+      <div class="col-xs-12">
+      {% block fos_user_content %}
+        <p class="text-center">
+          <span class="text-success">
+            <i class="fa fa-check-circle fa-3x" aria-hidden="true"></i>
+          </span>
+          <br>
+          {% trans with { '%username%': user.username } %}registration.confirmed{% endtrans %}
+        </p>
+        {% set cart = cart_provider.getCart() %}
+        {% if cart is not empty and cart.state == 'cart' %}
+          <div class="text-center">
+            <a href="{{ path('order') }}" class="btn btn-success">
+              {{ 'registration.after_confirmation_continue_order'|trans }} <i class="fa fa-arrow-right" aria-hidden="true"></i>
+            </a>
+          </div>
+        {% elseif targetUrl %}
+          <p class="text-center">
+            <a href="{{ targetUrl }}">
+              {{ 'registration.back'|trans }}
+            </a>
+          </p>
+        {% endif %}
+      {% endblock fos_user_content %}
+      </div>
+    </div>
+  </div>
+{% endblock body %}

--- a/src/AppBundle/Resources/translations/FOSUserBundle.en.yml
+++ b/src/AppBundle/Resources/translations/FOSUserBundle.en.yml
@@ -1,0 +1,10 @@
+registration:
+    check_email: |
+      An email has been sent to %email%.
+      <br>
+      It contains an activation link you must click to activate your account.
+    confirmed: |
+      Congrats <strong>%username%</strong>, your account is now activated.
+    before_confirmation_continue_order: |
+      Once you have activated your account, you can complete your order.
+    after_confirmation_continue_order: Complete your order

--- a/src/AppBundle/Resources/translations/FOSUserBundle.es.yml
+++ b/src/AppBundle/Resources/translations/FOSUserBundle.es.yml
@@ -1,0 +1,10 @@
+registration:
+    check_email: |
+      Se ha enviado un correo electrónico a %email%.
+      <br>
+      Contiene un enlace de activación al que debes acceder para activar tu cuenta.
+    confirmed: |
+      Felicidades <strong>%username%</strong>, tu cuenta está ahora confirmada.$
+    before_confirmation_continue_order: |
+      Una vez que haya activado su cuenta, puede completar su pedido.
+    after_confirmation_continue_order: Completa tu pedido

--- a/src/AppBundle/Resources/translations/FOSUserBundle.fr.yml
+++ b/src/AppBundle/Resources/translations/FOSUserBundle.fr.yml
@@ -1,0 +1,10 @@
+registration:
+    check_email: |
+      Un e-mail a été envoyé à l'adresse %email%.
+      <br>
+      Il contient un lien d'activation sur lequel il vous faudra cliquer afin d'activer votre compte.
+    confirmed: |
+      Félicitations <strong>%username%</strong>, votre compte est maintenant activé.
+    before_confirmation_continue_order: |
+      Une fois que vous avez activé votre compte, vous pouvez terminer votre commande.
+    after_confirmation_continue_order: Terminez votre commande


### PR DESCRIPTION
Basically this is just template customization. 

The templates where not customized at all, and were using the `profile.html.twig` layout, which could lead to confusion for the user. 

### Check email

<img width="1307" alt="capture d ecran 2018-10-05 a 22 54 46" src="https://user-images.githubusercontent.com/1162230/46560932-cb690400-c8f5-11e8-9fdd-2ae5e405cbe7.png">

### Confirmed

<img width="1306" alt="capture d ecran 2018-10-05 a 23 14 41" src="https://user-images.githubusercontent.com/1162230/46561004-0d924580-c8f6-11e8-8234-0de6de2d3463.png">

