### PR TITLE
Decouple deliveries from orders

### DIFF
--- a/app/DoctrineMigrations/Version20181115101859.php
+++ b/app/DoctrineMigrations/Version20181115101859.php
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20181115101859 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE delivery ADD store_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE delivery ADD CONSTRAINT FK_3781EC10B092A811 FOREIGN KEY (store_id) REFERENCES store (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_3781EC10B092A811 ON delivery (store_id)');
+
+        $stmt = $this->connection->prepare('SELECT * FROM store_delivery');
+
+        $stmt->execute();
+        while ($storeDelivery = $stmt->fetch()) {
+            $this->addSql('UPDATE delivery SET store_id = :store_id WHERE id = :delivery_id', [
+                'store_id' => $storeDelivery['store_id'],
+                'delivery_id' => $storeDelivery['delivery_id'],
+            ]);
+        }
+
+        $this->addSql('DROP TABLE store_delivery');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE TABLE store_delivery (store_id INT NOT NULL, delivery_id INT NOT NULL, PRIMARY KEY(store_id, delivery_id))');
+        $this->addSql('CREATE UNIQUE INDEX uniq_9f693ea12136921 ON store_delivery (delivery_id)');
+        $this->addSql('CREATE INDEX idx_9f693eab092a811 ON store_delivery (store_id)');
+        $this->addSql('ALTER TABLE store_delivery ADD CONSTRAINT fk_9f693ea12136921 FOREIGN KEY (delivery_id) REFERENCES delivery (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE store_delivery ADD CONSTRAINT fk_9f693eab092a811 FOREIGN KEY (store_id) REFERENCES store (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        $stmt = $this->connection->prepare('SELECT * FROM delivery WHERE store_id IS NOT NULL');
+
+        $stmt->execute();
+        while ($delivery = $stmt->fetch()) {
+            $this->addSql('INSERT INTO store_delivery (store_id, delivery_id) VALUES (:store_id, :delivery_id)', [
+                'store_id' => $delivery['store_id'],
+                'delivery_id' => $delivery['id'],
+            ]);
+        }
+
+        $this->addSql('ALTER TABLE delivery DROP CONSTRAINT FK_3781EC10B092A811');
+        $this->addSql('DROP INDEX IDX_3781EC10B092A811');
+        $this->addSql('ALTER TABLE delivery DROP store_id');
+    }
+}

--- a/app/config/message_bus/task.yml
+++ b/app/config/message_bus/task.yml
@@ -59,3 +59,14 @@ services:
           subscribes_to: task:failed
         - name: event_subscriber
           subscribes_to: task:cancelled
+
+  coopcycle.domain.task.reactor.send_email:
+    class: AppBundle\Domain\Task\Reactor\SendEmail
+    arguments:
+      - '@coopcycle.email_manager'
+      - '@coopcycle.settings_manager'
+    tags:
+        - name: event_subscriber
+          subscribes_to: task:done
+        - name: event_subscriber
+          subscribes_to: task:failed

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -336,12 +336,12 @@ services:
       - { name: form.type }
 
   'AppBundle\Form\DeliveryType':
-    arguments: [ '@doctrine', '@routing_service', '@translator' ]
+    arguments: [ '@routing_service', '@translator' ]
     tags:
       - { name: form.type }
 
   'AppBundle\Form\DeliveryEmbedType':
-    arguments: [ '@doctrine', '@routing_service', '@translator', '%country_iso%' ]
+    arguments: [ '@routing_service', '@translator', '%country_iso%' ]
     tags: [ form.type ]
 
   'AppBundle\Form\OrderType':

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -1094,6 +1094,13 @@ table.task-table {
   }
 }
 
+.panel--delivery {
+  .panel-heading > a {
+    display: block;
+    text-decoration: none;
+  }
+}
+
 #help {
   img {
     display: block;

--- a/js/app/delivery/form.jsx
+++ b/js/app/delivery/form.jsx
@@ -21,33 +21,6 @@ function enableForm() {
   $('#loader').addClass('hidden')
 }
 
-function calculatePrice(distance, pickup, dropoff) {
-
-  const deliveryParams = {
-    distance,
-    pickup_address: [ pickup.getLatLng().lat, pickup.getLatLng().lng ].join(','),
-    dropoff_address: [ dropoff.getLatLng().lat, dropoff.getLatLng().lng ].join(','),
-    pricing_rule_set: $('#delivery_pricingRuleSet').val(),
-    vehicle: $('#delivery_vehicle').val(),
-    weight: $('#delivery_weight').val()
-  }
-
-  $('#no-price-warning').hide()
-  disableForm()
-
-  $.getJSON(window.AppData.DeliveryForm.calculatePriceURL, deliveryParams)
-    .then(price => {
-      if (isNaN(price)) {
-        $('#no-price-warning').show()
-        $('#delivery_price').text('')
-      } else {
-        $('#delivery_price').text((price / 100).formatMoney(2, window.AppData.currencySymbol))
-      }
-      enableForm()
-    })
-    .catch(e => enableForm())
-}
-
 function refreshRouting() {
 
   // We need to have 2 markers
@@ -72,7 +45,7 @@ function refreshRouting() {
     $('#delivery_distance').text(kms + ' Km');
     $('#delivery_duration').text(minutes + ' min');
 
-    calculatePrice(distance, pickup, dropoff)
+    enableForm()
 
     // return decodePolyline(data.routes[0].geometry);
   })
@@ -188,9 +161,3 @@ window.initMap = function() {
 }
 
 map = MapHelper.init('map');
-
-// Update price when parameters have changed
-if ($('#delivery_pricingRuleSet').is('select')) {
-  $('#delivery_pricingRuleSet').on('change', e => refreshRouting())
-}
-$('#delivery_vehicle').on('change', e => refreshRouting())

--- a/src/AppBundle/Controller/Utils/StoreTrait.php
+++ b/src/AppBundle/Controller/Utils/StoreTrait.php
@@ -211,6 +211,7 @@ trait StoreTrait
             'stores_route' => $routes['stores'],
             'store_route' => $routes['store'],
             'store_delivery_new_route' => $routes['store_delivery_new'],
+            'delivery_route' => $routes['delivery'],
         ]);
     }
 }

--- a/src/AppBundle/Controller/Utils/StoreTrait.php
+++ b/src/AppBundle/Controller/Utils/StoreTrait.php
@@ -101,7 +101,6 @@ trait StoreTrait
 
     public function newStoreDeliveryAction($id, Request $request)
     {
-        $deliveryManager = $this->get('coopcycle.delivery.manager');
         $routes = $request->attributes->get('routes');
 
         $store = $this->getDoctrine()
@@ -111,7 +110,6 @@ trait StoreTrait
         $this->accessControl($store);
 
         $delivery = Delivery::createWithDefaults();
-        $delivery->getPickup()->setAddress($store->getAddress());
 
         $form = $this->createDeliveryForm($delivery, [
             'pricing_rule_set' => $store->getPricingRuleSet(),

--- a/src/AppBundle/Controller/Utils/StoreTrait.php
+++ b/src/AppBundle/Controller/Utils/StoreTrait.php
@@ -110,18 +110,21 @@ trait StoreTrait
         $this->accessControl($store);
 
         $delivery = Delivery::createWithDefaults();
+        $delivery->setStore($store);
 
-        $form = $this->createDeliveryForm($delivery);
+        $form = $this->createDeliveryForm($delivery, ['with_store' => false]);
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
 
             $delivery = $form->getData();
 
-            $store->addDelivery($delivery);
+            $this->getDoctrine()
+                ->getManagerForClass(Delivery::class)
+                ->persist($delivery);
 
             $this->getDoctrine()
-                ->getManagerForClass(Store::class)
+                ->getManagerForClass(Delivery::class)
                 ->flush();
 
             // TODO Add flash message

--- a/src/AppBundle/Controller/Utils/StoreTrait.php
+++ b/src/AppBundle/Controller/Utils/StoreTrait.php
@@ -27,7 +27,7 @@ trait StoreTrait
             'pages' => $pages,
             'page' => $page,
             'store_route' => $routes['store'],
-            'store_delivery_route' => $routes['store_delivery'],
+            'store_delivery_new_route' => $routes['store_delivery_new'],
             'store_deliveries_route' => $routes['store_deliveries'],
         ]);
     }
@@ -93,7 +93,7 @@ trait StoreTrait
             'store' => $store,
             'form' => $form->createView(),
             'stores_route' => $routes['stores'],
-            'store_delivery_route' => $routes['store_delivery'],
+            'store_delivery_new_route' => $routes['store_delivery_new'],
             'store_deliveries_route' => $routes['store_deliveries'],
             'store_api_keys_route' => $routes['store_api_keys'],
         ]);
@@ -210,7 +210,7 @@ trait StoreTrait
             'deliveries' => $deliveries,
             'stores_route' => $routes['stores'],
             'store_route' => $routes['store'],
-            'store_delivery_route' => $routes['store_delivery'],
+            'store_delivery_new_route' => $routes['store_delivery_new'],
         ]);
     }
 }

--- a/src/AppBundle/Domain/Task/Reactor/SendEmail.php
+++ b/src/AppBundle/Domain/Task/Reactor/SendEmail.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace AppBundle\Domain\Task\Reactor;
+
+use AppBundle\Domain\Task\Event;
+use AppBundle\Service\EmailManager;
+use AppBundle\Service\SettingsManager;
+
+class SendEmail
+{
+    private $emailManager;
+    private $settingsManager;
+
+    public function __construct(
+        EmailManager $emailManager,
+        SettingsManager $settingsManager)
+    {
+        $this->emailManager = $emailManager;
+        $this->settingsManager = $settingsManager;
+    }
+
+    public function __invoke(Event $event)
+    {
+        $task = $event->getTask();
+
+        $delivery = $task->getDelivery();
+
+        if (null === $delivery) {
+            return;
+        }
+
+        $order = $delivery->getOrder();
+
+        // Skip if this is related to foodtech
+        if (null !== $order && $order->isFoodtech()) {
+            return;
+        }
+
+        $store = $delivery->getStore();
+
+        if (null === $store) {
+            return;
+        }
+
+        if ($event instanceof Event\TaskDone || $event instanceof Event\TaskFailed) {
+
+            // Send email to store owners
+            $owners = $store->getOwners()->toArray();
+            if (count($owners) > 0) {
+
+                $ownerMails = [];
+                foreach ($owners as $owner) {
+                    $ownerMails[$owner->getEmail()] = $owner->getFullName();
+                }
+
+                $this->emailManager->sendTo(
+                    $this->emailManager->createTaskCompletedMessage($task),
+                    $ownerMails
+                );
+            }
+        }
+    }
+}

--- a/src/AppBundle/Entity/Delivery.php
+++ b/src/AppBundle/Entity/Delivery.php
@@ -54,6 +54,8 @@ class Delivery extends TaskCollection implements TaskCollectionInterface
 
     private $vehicle = self::VEHICLE_BIKE;
 
+    private $store;
+
     public function __construct()
     {
         parent::__construct();
@@ -172,5 +174,15 @@ class Delivery extends TaskCollection implements TaskCollectionInterface
             return $this::COLORS_LIST[$this->getId() % count($this::COLORS_LIST)];
         }
 
+    }
+
+    public function setStore(Store $store)
+    {
+        $this->store = $store;
+    }
+
+    public function getStore()
+    {
+        return $this->store;
     }
 }

--- a/src/AppBundle/Entity/DeliveryRepository.php
+++ b/src/AppBundle/Entity/DeliveryRepository.php
@@ -93,4 +93,25 @@ class DeliveryRepository extends EntityRepository
 
         return '0min';
     }
+
+    public function createFindByStoreQuery(Store $store)
+    {
+        // @see https://stackoverflow.com/questions/5432404/doctrine-2-dql-how-to-select-inverse-side-of-unidirectional-many-to-many-query
+        // @see https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/dql-doctrine-query-language.html
+        $query = $this->_em->createQuery(
+            'SELECT d FROM AppBundle\Entity\Delivery d ' .
+            'JOIN AppBundle\Entity\Store s WITH 1 = 1 ' .
+            'JOIN s.deliveries sd ' .
+            'WHERE d.id = sd.id AND s.id = :store ' .
+            'ORDER BY d.createdAt DESC'
+        );
+        $query->setParameter('store', $store);
+
+        return $query;
+    }
+
+    public function findByStore(Store $store)
+    {
+        return $this->createFindByStoreQuery($store)->getResult();
+    }
 }

--- a/src/AppBundle/Entity/DeliveryRepository.php
+++ b/src/AppBundle/Entity/DeliveryRepository.php
@@ -96,18 +96,11 @@ class DeliveryRepository extends EntityRepository
 
     public function createFindByStoreQuery(Store $store)
     {
-        // @see https://stackoverflow.com/questions/5432404/doctrine-2-dql-how-to-select-inverse-side-of-unidirectional-many-to-many-query
-        // @see https://www.doctrine-project.org/projects/doctrine-orm/en/2.6/reference/dql-doctrine-query-language.html
-        $query = $this->_em->createQuery(
-            'SELECT d FROM AppBundle\Entity\Delivery d ' .
-            'JOIN AppBundle\Entity\Store s WITH 1 = 1 ' .
-            'JOIN s.deliveries sd ' .
-            'WHERE d.id = sd.id AND s.id = :store ' .
-            'ORDER BY d.createdAt DESC'
-        );
-        $query->setParameter('store', $store);
+        $qb = $this->createQueryBuilder('d');
+        $qb->where('d.store = :store');
+        $qb->setParameter('store', $store);
 
-        return $query;
+        return $qb->getQuery();
     }
 
     public function findByStore(Store $store)

--- a/src/AppBundle/Form/DeliveryEmbedType.php
+++ b/src/AppBundle/Form/DeliveryEmbedType.php
@@ -29,6 +29,8 @@ class DeliveryEmbedType extends DeliveryType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $options = array_merge($options, ['with_store' => false]);
+
         parent::buildForm($builder, $options);
 
         $builder

--- a/src/AppBundle/Form/DeliveryEmbedType.php
+++ b/src/AppBundle/Form/DeliveryEmbedType.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Form;
 
 use AppBundle\Service\RoutingInterface;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use libphonenumber\PhoneNumberFormat;
 use Misd\PhoneNumberBundle\Form\Type\PhoneNumberType;
 use Symfony\Component\Form\AbstractType;
@@ -19,11 +18,11 @@ use Symfony\Component\Translation\TranslatorInterface;
 class DeliveryEmbedType extends DeliveryType
 {
     public function __construct(
-        ManagerRegistry $doctrine,
         RoutingInterface $routing,
-        TranslatorInterface $translator, $countryCode)
+        TranslatorInterface $translator,
+        $countryCode)
     {
-        parent::__construct($doctrine, $routing, $translator);
+        parent::__construct($routing, $translator);
 
         $this->countryCode = $countryCode;
     }

--- a/src/AppBundle/Form/DeliveryType.php
+++ b/src/AppBundle/Form/DeliveryType.php
@@ -3,15 +3,11 @@
 namespace AppBundle\Form;
 
 use AppBundle\Entity\Delivery;
-use AppBundle\Entity\Delivery\PricingRuleSet;
 use AppBundle\Entity\Task;
 use AppBundle\Service\RoutingInterface;
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Bridge\Doctrine\Form\Type\EntityType;
-use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -25,16 +21,13 @@ use Symfony\Component\Validator\Constraints as Assert;
 
 class DeliveryType extends AbstractType
 {
-    private $doctrine;
     private $routing;
     private $translator;
 
     public function __construct(
-        ManagerRegistry $doctrine,
         RoutingInterface $routing,
         TranslatorInterface $translator)
     {
-        $this->doctrine = $doctrine;
         $this->routing = $routing;
         $this->translator = $translator;
     }
@@ -79,45 +72,6 @@ class DeliveryType extends AbstractType
             ]);
         }
 
-        if ($options['pricing_rule_set']) {
-
-            $transformer = new CallbackTransformer(
-                function ($entity) {
-                    if ($entity instanceof PricingRuleSet) {
-                        return $entity->getId();
-                    }
-                    return '';
-                },
-                function ($id) {
-                    if (!$id) {
-                        return null;
-                    }
-                    return $this->doctrine->getRepository(PricingRuleSet::class)->find($id);
-                }
-            );
-
-            $builder
-                ->add('pricingRuleSet', HiddenType::class, array(
-                    'mapped' => false,
-                ));
-            $builder->get('pricingRuleSet')
-                ->addViewTransformer($transformer);
-
-        } else {
-            $builder
-                ->add('pricingRuleSet', EntityType::class, array(
-                    'mapped' => false,
-                    'required' => true,
-                    'placeholder' => 'form.store_type.pricing_rule_set.placeholder',
-                    'label' => 'form.store_type.pricing_rule_set.label',
-                    'class' => PricingRuleSet::class,
-                    'choice_label' => 'name',
-                    'query_builder' => function (EntityRepository $er) {
-                        return $er->createQueryBuilder('prs')->orderBy('prs.name', 'ASC');
-                    }
-                ));
-        }
-
         $builder->get('pickup')->addEventListener(
             FormEvents::PRE_SET_DATA,
             function (FormEvent $event) use ($options) {
@@ -138,23 +92,6 @@ class DeliveryType extends AbstractType
                     if ($task->getType() === Task::TYPE_DROPOFF) {
                         $event->setData($task);
                     }
-                }
-            }
-        );
-
-        $builder->addEventListener(
-            FormEvents::POST_SET_DATA,
-            function (FormEvent $event) use ($options) {
-
-                $form = $event->getForm();
-                $delivery = $form->getData();
-
-                if (null !== $delivery->getId()) {
-                    $form->remove('pricingRuleSet');
-                } else if ($options['pricing_rule_set']) {
-                    $form
-                        ->get('pricingRuleSet')
-                        ->setData($options['pricing_rule_set']);
                 }
             }
         );
@@ -193,7 +130,6 @@ class DeliveryType extends AbstractType
     {
         $resolver->setDefaults(array(
             'data_class' => Delivery::class,
-            'pricing_rule_set' => null,
             'with_vehicle' => false,
         ));
     }

--- a/src/AppBundle/Form/DeliveryType.php
+++ b/src/AppBundle/Form/DeliveryType.php
@@ -3,9 +3,11 @@
 namespace AppBundle\Form;
 
 use AppBundle\Entity\Delivery;
+use AppBundle\Entity\Store;
 use AppBundle\Entity\Task;
 use AppBundle\Service\RoutingInterface;
 use Doctrine\ORM\EntityRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -96,6 +98,25 @@ class DeliveryType extends AbstractType
             }
         );
 
+        if ($options['with_store']) {
+            $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
+
+                $form = $event->getForm();
+                $delivery = $event->getData();
+
+                $form->add('store', EntityType::class, [
+                    'class' => Store::class,
+                    'query_builder' => function (EntityRepository $repository) {
+                        return $repository->createQueryBuilder('s')
+                            ->orderBy('s.name', 'ASC');
+                    },
+                    'label' => 'form.delivery.store.label',
+                    'choice_label' => 'name',
+                    'required' => false,
+                ]);
+            });
+        }
+
         $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
 
             $form = $event->getForm();
@@ -131,6 +152,7 @@ class DeliveryType extends AbstractType
         $resolver->setDefaults(array(
             'data_class' => Delivery::class,
             'with_vehicle' => false,
+            'with_store' => true,
         ));
     }
 }

--- a/src/AppBundle/Resources/config/doctrine/Delivery.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Delivery.orm.yml
@@ -16,3 +16,11 @@ AppBundle\Entity\Delivery:
             joinColumns:
                 order_id:
                     referencedColumnName: id
+    manyToOne:
+        store:
+            targetEntity: AppBundle\Entity\Store
+            inversedBy: deliveries
+            joinColumn:
+                store_id:
+                    referencedColumnName: id
+                    nullable: true

--- a/src/AppBundle/Resources/config/doctrine/Store.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Store.orm.yml
@@ -88,6 +88,8 @@ AppBundle\Entity\Store:
             mappedBy: stores
         deliveries:
             targetEntity: AppBundle\Entity\Delivery
+            cascade:
+                - persist
             joinTable:
                 name: store_delivery
                 joinColumns:

--- a/src/AppBundle/Resources/config/doctrine/Store.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Store.orm.yml
@@ -86,16 +86,9 @@ AppBundle\Entity\Store:
         owners:
             targetEntity: AppBundle\Entity\ApiUser
             mappedBy: stores
+    oneToMany:
         deliveries:
             targetEntity: AppBundle\Entity\Delivery
+            mappedBy: store
             cascade:
                 - persist
-            joinTable:
-                name: store_delivery
-                joinColumns:
-                    store_id:
-                        referencedColumnName: id
-                inverseJoinColumns:
-                    delivery_id:
-                        referencedColumnName: id
-                        unique: true

--- a/src/AppBundle/Resources/config/routing/admin.yml
+++ b/src/AppBundle/Resources/config/routing/admin.yml
@@ -364,7 +364,7 @@ admin_stores:
         template: '@App/admin/stores.html.twig'
         routes:
             store: admin_store
-            store_delivery: admin_store_delivery
+            store_delivery_new: admin_store_delivery_new
             store_deliveries: admin_store_deliveries
     methods:  [ GET ]
 
@@ -375,7 +375,7 @@ admin_store_new:
         layout: '@App/admin.html.twig'
         routes:
             stores: admin_stores
-            store_delivery: admin_store_delivery
+            store_delivery_new: admin_store_delivery_new
             store_deliveries: admin_store_deliveries
             store_api_keys: admin_store_api_keys
     methods:  [ GET, POST ]
@@ -387,7 +387,7 @@ admin_store:
         layout: '@App/admin.html.twig'
         routes:
             stores: admin_stores
-            store_delivery: admin_store_delivery
+            store_delivery_new: admin_store_delivery_new
             store_deliveries: admin_store_deliveries
             store_api_keys: admin_store_api_keys
     methods:  [ GET, POST ]
@@ -400,10 +400,10 @@ admin_store_deliveries:
         routes:
             stores: admin_stores
             store: admin_store
-            store_delivery: admin_store_delivery
+            store_delivery_new: admin_store_delivery_new
     methods:  [ GET ]
 
-admin_store_delivery:
+admin_store_delivery_new:
     path: /admin/stores/{id}/deliveries/new
     defaults:
         _controller: AppBundle:Admin:newStoreDelivery

--- a/src/AppBundle/Resources/config/routing/admin.yml
+++ b/src/AppBundle/Resources/config/routing/admin.yml
@@ -411,7 +411,7 @@ admin_store_delivery:
         routes:
             stores: admin_stores
             store: admin_store
-            success: admin_orders
+            success: admin_store_deliveries
             calculate_price: admin_deliveries_calculate_price
     methods:  [ GET, POST ]
 

--- a/src/AppBundle/Resources/config/routing/admin.yml
+++ b/src/AppBundle/Resources/config/routing/admin.yml
@@ -401,6 +401,7 @@ admin_store_deliveries:
             stores: admin_stores
             store: admin_store
             store_delivery_new: admin_store_delivery_new
+            delivery: admin_delivery
     methods:  [ GET ]
 
 admin_store_delivery_new:

--- a/src/AppBundle/Resources/config/routing/profile.yml
+++ b/src/AppBundle/Resources/config/routing/profile.yml
@@ -287,7 +287,7 @@ profile_stores:
         template: '@App/profile/stores.html.twig'
         routes:
             store: profile_store
-            store_delivery: profile_store_delivery
+            store_delivery_new: profile_store_delivery_new
             store_deliveries: profile_store_deliveries
     methods:  [ GET ]
 
@@ -298,7 +298,7 @@ profile_store:
         layout: '@App/profile.html.twig'
         routes:
             stores: profile_stores
-            store_delivery: profile_store_delivery
+            store_delivery_new: profile_store_delivery_new
             store_deliveries: profile_store_deliveries
             store_api_keys: profile_store_api_keys
     methods:  [ GET, POST ]
@@ -311,10 +311,10 @@ profile_store_deliveries:
         routes:
             stores: profile_stores
             store: profile_store
-            store_delivery: profile_store_delivery
+            store_delivery_new: profile_store_delivery_new
     methods:  [ GET ]
 
-profile_store_delivery:
+profile_store_delivery_new:
     path: /profile/stores/{id}/deliveries/new
     defaults:
         _controller: AppBundle:Profile:newStoreDelivery

--- a/src/AppBundle/Resources/config/routing/profile.yml
+++ b/src/AppBundle/Resources/config/routing/profile.yml
@@ -275,6 +275,16 @@ profile_restaurant_stripe_oauth_redirect:
         redirect_after: profile_restaurant
     methods: [ GET ]
 
+profile_delivery:
+  path: /profile/deliveries/{id}
+  defaults:
+      _controller: AppBundle:Profile:delivery
+      layout: '@App/profile.html.twig'
+      routes:
+          success: profile_deliveries
+          calculate_price: profile_deliveries_calculate_price
+  methods:  [ GET, POST ]
+
 profile_deliveries_calculate_price:
     path: /profile/deliveries/calculate-price
     defaults: { _controller: AppBundle:Profile:calculateDeliveryPrice }
@@ -312,6 +322,7 @@ profile_store_deliveries:
             stores: profile_stores
             store: profile_store
             store_delivery_new: profile_store_delivery_new
+            delivery: profile_delivery
     methods:  [ GET ]
 
 profile_store_delivery_new:

--- a/src/AppBundle/Resources/config/routing/profile.yml
+++ b/src/AppBundle/Resources/config/routing/profile.yml
@@ -322,7 +322,7 @@ profile_store_delivery:
         routes:
             stores: profile_stores
             store: profile_store
-            success: profile_orders
+            success: profile_store_deliveries
             calculate_price: profile_deliveries_calculate_price
     methods:  [ GET, POST ]
 

--- a/src/AppBundle/Resources/translations/emails.en.yml
+++ b/src/AppBundle/Resources/translations/emails.en.yml
@@ -70,3 +70,17 @@ order.cancelled.body.intro: |
   <br>
   <br>
   We are sorry, but your order has been cancelled.
+
+task.done.subject: "Task #%task.id% completed"
+task.done.body: |
+  Hello,
+  <br>
+  <br>
+  Task #%task.id% has been completed.
+
+task.failed.subject: "Task #%task.id% could not be completed"
+task.failed.body: |
+  Hello,
+  <br>
+  <br>
+  Task #%task.id% could not be completed.

--- a/src/AppBundle/Resources/translations/emails.es.yml
+++ b/src/AppBundle/Resources/translations/emails.es.yml
@@ -70,3 +70,17 @@ order.cancelled.body.intro: |
   <br>
   <br>
   Lo sentimos, pero tu pedido ha sido cancelado.
+
+task.done.subject: "La tarea #%task.id% ha sido completada"
+task.done.body: |
+  Buenos dias,
+  <br>
+  <br>
+  La tarea #%task.id% ha sido completada.
+
+task.failed.subject: "La tarea #%task.id% no se pudo completar"
+task.failed.body: |
+  Buenos dias,
+  <br>
+  <br>
+  La tarea #%task.id% no se pudo completar.

--- a/src/AppBundle/Resources/translations/emails.fr.yml
+++ b/src/AppBundle/Resources/translations/emails.fr.yml
@@ -70,3 +70,17 @@ order.cancelled.body.intro: |
   <br>
   <br>
   Nous sommes désolé, mais votre commande a été annulée.
+
+task.done.subject: "La tâche #%task.id% a été terminée"
+task.done.body: |
+  Bonjour,
+  <br>
+  <br>
+  La tâche #%task.id% a été terminée avec succès.
+
+task.failed.subject: "La tâche #%task.id% n'a pas pu être réalisée"
+task.failed.body: |
+  Bonjour,
+  <br>
+  <br>
+  La tâche #%task.id% n'a pas pu être réalisée.

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -318,8 +318,7 @@ checkout.breadcrumb.payment: Payment
 
 form.geojson_upload.file: File
 form.store_type.pricing_rule_set.label: Pricing
-form.delivery.pricing_rule_set.about: |
-  The following pricing will be applied: <a href="%link%" target="_blank">%name%</a>
+
 form.delivery.vehicle.VEHICLE_BIKE: Bike
 form.delivery.vehicle.VEHICLE_CARGO_BIKE: Cargo bike
 form.store_type.pricing_rule_set.placeholder: Choose a pricing
@@ -525,6 +524,7 @@ stores.pricing_rule_set: Pricing
 stores.api_keys: API keys
 stores.deliveries: Deliveries
 stores.deliveries.heading: 'Delivery #%delivery_id% - %delivery_distance%'
+stores.deliveries.task_unassigned: Unassigned
 
 meta.title: Delivery platform for worker-owned business
 

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -328,10 +328,7 @@ checkout.breadcrumb.payment: Pago
 
 form.geojson_upload.file: Archivo
 form.store_type.pricing_rule_set.label: Tarifa
-form.delivery.pricing_rule_set.about: 'Se aplicará la siguiente tarifa: <a href="%link%"
-  target="_blank">%name%</a>
 
-  '
 form.delivery.vehicle.VEHICLE_BIKE: Bicicleta
 form.delivery.vehicle.VEHICLE_CARGO_BIKE: Bicicleta de carga
 form.store_type.pricing_rule_set.placeholder: Escoge una tarifa
@@ -565,6 +562,7 @@ stores.pricing_rule_set: Tarificación
 stores.deliveries: Entregas
 stores.deliveries.heading: 'Entrega #%delivery_id% - %delivery_distance%'
 stores.api_keys: Llaves API
+stores.deliveries.task_unassigned: No asignada
 
 meta.title: Plataforma de logística para cooperativas
 admin.settings.missing_mandatory_settings: 'Algunos ajustes obligatorios no han sido

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -321,10 +321,7 @@ checkout.breadcrumb.payment: Paiement
 
 form.geojson_upload.file: Fichier
 form.store_type.pricing_rule_set.label: Tarification
-form.delivery.pricing_rule_set.about: 'La tarification suivante sera appliquée : <a
-  href="%link%" target="_blank">%name%</a>
 
-  '
 form.delivery.vehicle.VEHICLE_BIKE: Vélo
 form.delivery.vehicle.VEHICLE_CARGO_BIKE: Vélo cargo
 form.store_type.pricing_rule_set.placeholder: Choisissez une tarification
@@ -571,6 +568,7 @@ stores.pricing_rule_set: Tarification
 stores.deliveries: Livraisons
 stores.deliveries.heading: 'Livraison #%delivery_id% - %delivery_distance%'
 stores.api_keys: Clés d'API
+stores.deliveries.task_unassigned: Non assignée
 
 meta.title: Plateforme de livraison pour les sociétés coopératives
 admin.settings.missing_mandatory_settings: 'Des paramètres obligatoires sont manquants.

--- a/src/AppBundle/Resources/views/delivery/form.html.twig
+++ b/src/AppBundle/Resources/views/delivery/form.html.twig
@@ -63,16 +63,7 @@
       <hr>
       <div class="form-horizontal">
 
-        {% block disclaimer %}{% endblock %}
-
         {{ form_errors(form) }}
-        <div id="no-price-warning" class="alert alert-warning" style="display:none;">
-          {% trans from 'validators' %}delivery.price.error.priceCalculation{% endtrans %}
-        </div>
-
-        {% if form.pricingRuleSet is defined %}
-          {{ form_row(form.pricingRuleSet) }}
-        {% endif %}
 
         <div class="form-group">
           <label class="col-sm-2 control-label" for="delivery_distance">
@@ -104,19 +95,6 @@
           </div>
         </div>
 
-        {% if delivery.id is null %}
-        <div class="form-group">
-          <label class="col-sm-2 control-label" for="delivery_price">
-            {% trans %}form.delivery.price.label{% endtrans %}
-          </label>
-          <div class="col-sm-10">
-            <p class="form-control-static">
-              <span id="delivery_price"></span>
-            </p>
-          </div>
-        </div>
-        {% endif %}
-
       </div>
       <hr>
       <button id="delivery-submit" type="submit" class="btn btn-block btn-lg btn-primary">
@@ -131,12 +109,6 @@
 {% endblock %}
 
 {% block scripts %}
-<script>
-  window.AppData = window.AppData || {};
-  window.AppData.DeliveryForm = {
-    calculatePriceURL: "{{ path(calculate_price_route) }}"
-  };
-</script>
 <script src="{{ asset('js/delivery-form.js') }}"></script>
 <script src="https://maps.googleapis.com/maps/api/js?key={{ coopcycle_setting('google_api_key') }}&libraries=places&callback=initMap"
   async defer></script>

--- a/src/AppBundle/Resources/views/delivery/form.html.twig
+++ b/src/AppBundle/Resources/views/delivery/form.html.twig
@@ -49,6 +49,9 @@
 
   <div class="row">
     <div class="col-sm-6">
+      {% if form.store is defined %}
+        {{ form_row(form.store) }}
+      {% endif %}
       {% if form.vehicle is defined %}
         {{ form_row(form.vehicle) }}
       {% endif %}

--- a/src/AppBundle/Resources/views/emails/task/completed.html.twig
+++ b/src/AppBundle/Resources/views/emails/task/completed.html.twig
@@ -1,0 +1,17 @@
+{% extends '@App/emails/layout.html.twig' %}
+
+{% block content %}
+
+  {% if task.done %}
+    {{ 'task.done.body' | trans({
+      '%task.id%': task.id,
+    }, 'emails') | raw }}
+  {% endif %}
+
+  {% if task.failed %}
+    {{ 'task.failed.body' | trans({
+      '%task.id%': task.id,
+    }, 'emails') | raw }}
+  {% endif %}
+
+{% endblock %}

--- a/src/AppBundle/Resources/views/form/delivery.html.twig
+++ b/src/AppBundle/Resources/views/form/delivery.html.twig
@@ -1,5 +1,13 @@
 {% extends 'bootstrap_3_horizontal_layout.html.twig' %}
 
+{% block form_label_class -%}
+col-sm-3
+{%- endblock form_label_class %}
+
+{% block form_group_class -%}
+col-sm-9
+{%- endblock form_group_class %}
+
 {% block task_row %}
 <div class="panel panel-default">
   <div class="panel-heading" role="tab">
@@ -45,7 +53,7 @@
 
 {% block task_address_streetAddress_row %}
 <div class="form-group {% if not form.vars.valid %}has-error{% endif %}">
-  <div class="col-sm-10 col-md-offset-2">
+  <div class="col-sm-9 col-md-offset-3">
     <div class="input-group">
       <div class="input-group-addon"><i class="fa fa-{{ icon }}"></i></div>
       {{ form_widget(form) }}

--- a/src/AppBundle/Resources/views/order/service.html.twig
+++ b/src/AppBundle/Resources/views/order/service.html.twig
@@ -45,6 +45,21 @@
   <div class="col-md-5">
 
     {% if is_granted('ROLE_ADMIN') %}
+
+    {% if not order.foodtech %}
+    <div class="form-group">
+      <label class="control-label">Lien public</label>
+      <div class="input-group">
+        <input id="order-public-url" type="text" class="form-control" value="{{ url('public_order', { number: order.number }) }}">
+        <span class="input-group-btn">
+          <button class="btn btn-default" type="button" data-clipboard-target="#order-public-url" id="copy">
+            <i class="fa fa-copy"></i>
+          </button>
+        </span>
+      </div>
+    </div>
+    {% endif %}
+
     <div class="panel panel-default">
       <div class="panel-heading">
         <h4 class="panel-title">Client</h4>
@@ -244,12 +259,13 @@
 {% endblock %}
 
 {% block scripts %}
-{% if pickup_address is not empty and dropoff_address is not empty %}
 <script>
+new ClipboardJS('#copy');
+{% if pickup_address is not empty and dropoff_address is not empty %}
 new CoopCycle.DeliveryMap('map', {
   pickup: [ {{ pickup_address.geo.latitude }}, {{ pickup_address.geo.longitude }} ],
   dropoff: [ {{ dropoff_address.geo.latitude }}, {{ dropoff_address.geo.longitude }} ]
 });
-</script>
 {% endif %}
+</script>
 {% endblock %}

--- a/src/AppBundle/Resources/views/store/_partials/task_row.html.twig
+++ b/src/AppBundle/Resources/views/store/_partials/task_row.html.twig
@@ -1,0 +1,26 @@
+<tr>
+  <td width="2%">
+    {% include "@App/_partials/task/status_icon.html.twig" %}
+  </td>
+  <td width="5%">
+    #{{ task.id }}
+  </td>
+  <td width="5%">
+    {% include "@App/_partials/task/type_label.html.twig" %}
+  </td>
+  <td width="30%">
+    {{ task.address.streetAddress }}
+  </td>
+  <td>
+  {% if task.assigned %}
+    <span title="{{ task.assignedCourier.username }}">
+      <i class="fa fa-user"></i> {{ task.assignedCourier.username }}
+    </span>
+  {% else %}
+    <i class="fa fa-question-circle"></i> {{ 'stores.deliveries.task_unassigned'|trans }}
+  {% endif %}
+  </td>
+  <td class="text-right" width="20%">
+    <i class="fa fa-clock-o"></i>  {{ task.doneBefore|localizeddate('medium', 'short') }}
+  </td>
+</tr>

--- a/src/AppBundle/Resources/views/store/deliveries.html.twig
+++ b/src/AppBundle/Resources/views/store/deliveries.html.twig
@@ -18,16 +18,25 @@
 
 {% if deliveries|length > 0 %}
   {% for delivery in deliveries %}
-    <div class="panel panel-default">
+    <div class="panel panel-default panel--delivery">
       <div class="panel-heading">
-        <h5 class="nomargin">
+        {% if is_granted('ROLE_ADMIN') %}
+        <a href="{{ path(delivery_route, { id: delivery.id }) }}">
+        {% endif %}
           <i class="fa fa-bicycle"></i>  
           <span>{{ 'stores.deliveries.heading'|trans({
             '%delivery_id%': delivery.id,
             '%delivery_distance%': delivery.distance|meters_to_kilometers
           }) }}
           </span>
-        </h5>
+          {% if is_granted('ROLE_ADMIN') %}
+          <span class="pull-right">
+            <i class="fa fa-arrow-right"></i>  
+          </span>
+          {% endif %}
+        {% if is_granted('ROLE_ADMIN') %}
+        </a>
+        {% endif %}
       </div>
       <table class="table">
         <tbody>

--- a/src/AppBundle/Resources/views/store/deliveries.html.twig
+++ b/src/AppBundle/Resources/views/store/deliveries.html.twig
@@ -10,7 +10,7 @@
 
 <p>
   <span class="pull-right">
-    <a href="{{ path(store_delivery_route, { id: store.id }) }}" class="btn btn-success">
+    <a href="{{ path(store_delivery_new_route, { id: store.id }) }}" class="btn btn-success">
       <i class="fa fa-plus"></i>  {{ 'basics.add'|trans }}
     </a>
   </span>

--- a/src/AppBundle/Resources/views/store/deliveries.html.twig
+++ b/src/AppBundle/Resources/views/store/deliveries.html.twig
@@ -31,32 +31,15 @@
       </div>
       <table class="table">
         <tbody>
-          <tr>
-            <td width="1%">
-              {% include "@App/_partials/task/type_label.html.twig" with { task: delivery.pickup } %}
-            </td>
-            <td width="35%">
-              {{ delivery.pickup.address.streetAddress }}
-            </td>
-            <td class="text-right">
-              {{ delivery.pickup.doneBefore|localizeddate('medium', 'short') }}
-            </td>
-          </tr>
-          <tr>
-            <td width="1%">
-              {% include "@App/_partials/task/type_label.html.twig" with { task: delivery.dropoff } %}
-            </td>
-            <td width="35%">
-              {{ delivery.dropoff.address.streetAddress }}
-            </td>
-            <td class="text-right">
-              {{ delivery.dropoff.doneBefore|localizeddate('medium', 'short') }}
-            </td>
-          </tr>
+          {% include "@App/store/_partials/task_row.html.twig" with { task: delivery.pickup } %}
+          {% include "@App/store/_partials/task_row.html.twig" with { task: delivery.dropoff } %}
         </tbody>
       </table>
     </div>
   {% endfor %}
+  <nav class="text-center">
+    {{ knp_pagination_render(deliveries) }}
+  </nav>
 {% else %}
   <div class="alert alert-info">
   {% trans %}stores.list.noUsers{% endtrans %}

--- a/src/AppBundle/Resources/views/store/delivery_form.html.twig
+++ b/src/AppBundle/Resources/views/store/delivery_form.html.twig
@@ -13,18 +13,5 @@
   <li>{% trans %}adminDashboard.deliveries.createNew{% endtrans %}</li>
   {% endif %}
 
-  {% endblock %}
-
-{% block disclaimer %}
-
-  {% if is_granted('ROLE_ADMIN') %}
-    <div class="alert alert-info">
-      {% set trans_params = {
-        '%name%': store.pricingRuleSet.name,
-        '%link%': path('admin_deliveries_pricing_ruleset', { id: store.pricingRuleSet.id })
-      } %}
-      {% trans with trans_params %}form.delivery.pricing_rule_set.about{% endtrans %}
-    </div>
-  {% endif %}
-
 {% endblock %}
+

--- a/src/AppBundle/Resources/views/store/form.html.twig
+++ b/src/AppBundle/Resources/views/store/form.html.twig
@@ -33,7 +33,7 @@
           <i class="fa fa-key"></i>  {% trans %}stores.api_keys{% endtrans %}
         </a>
         {% endif %}
-        <a href="{{ path(store_delivery_route, { id: store.id }) }}" class="btn btn-success navbar-btn">
+        <a href="{{ path(store_delivery_new_route, { id: store.id }) }}" class="btn btn-success navbar-btn">
           <i class="fa fa-plus"></i>  {% trans %}delivery.createNew{% endtrans %}
         </a>
       </div>

--- a/src/AppBundle/Resources/views/store/list.html.twig
+++ b/src/AppBundle/Resources/views/store/list.html.twig
@@ -29,7 +29,7 @@
                 </a>
               </li>
               <li>
-                <a href="{{ path(store_delivery_route, { id: store.id }) }}">
+                <a href="{{ path(store_delivery_new_route, { id: store.id }) }}">
                   {% trans %}stores.createNewDelivery{% endtrans %}
                 </a>
               </li>

--- a/src/AppBundle/Service/EmailManager.php
+++ b/src/AppBundle/Service/EmailManager.php
@@ -5,6 +5,7 @@ namespace AppBundle\Service;
 use AppBundle\Entity\ApiUser;
 use AppBundle\Entity\Delivery;
 use AppBundle\Entity\StripePayment;
+use AppBundle\Entity\Task;
 use Symfony\Bridge\Twig\TwigEngine;
 use Sylius\Component\Order\Model\OrderInterface;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -71,6 +72,7 @@ class EmailManager
 
     public function send(\Swift_Message $message)
     {
+        // FIXME Filter array instead
         foreach ($message->getTo() as $address => $name) {
             if (preg_match('/@demo.coopcycle.org$/', $address)) {
                 return;
@@ -140,5 +142,17 @@ class EmailManager
         ]);
 
         return $this->createHtmlMessageWithReplyTo($subject, $body);
+    }
+
+    public function createTaskCompletedMessage(Task $task)
+    {
+        $key = $task->isDone() ? 'task.done.subject' : 'task.failed.subject';
+
+        $subject = $this->translator->trans($key, ['%task.id%' => $task->getId()], 'emails');
+        $body = $this->templating->render('@App/emails/task/completed.html.twig', [
+            'task' => $task,
+        ]);
+
+        return $this->createHtmlMessage($subject, $body);
     }
 }

--- a/tests/AppBundle/Domain/Task/Reactor/SendEmailTest.php
+++ b/tests/AppBundle/Domain/Task/Reactor/SendEmailTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\AppBundle\Domain\Task\Reactor;
+
+use AppBundle\Domain\Task\Event\TaskDone;
+use AppBundle\Domain\Task\Event\TaskFailed;
+use AppBundle\Domain\Task\Reactor\SendEmail;
+use AppBundle\Entity\ApiUser;
+use AppBundle\Entity\Delivery;
+use AppBundle\Entity\Store;
+use AppBundle\Entity\Task;
+use AppBundle\Service\EmailManager;
+use AppBundle\Service\SettingsManager;
+use AppBundle\Sylius\Order\OrderInterface;
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+
+class SendEmailTest extends TestCase
+{
+    private $sendEmail;
+
+    public function setUp()
+    {
+        $this->emailManager = $this->prophesize(EmailManager::class);
+        $this->settingsManager = $this->prophesize(SettingsManager::class);
+
+        $this->sendEmail = new SendEmail(
+            $this->emailManager->reveal(),
+            $this->settingsManager->reveal()
+        );
+    }
+
+    public function testDoesNothingWithStandaloneTask()
+    {
+        $task = new Task();
+
+        $this->emailManager
+            ->sendTo(Argument::type('string'), Argument::type('string'))
+            ->shouldNotBeCalled();
+
+        call_user_func_array($this->sendEmail, [ new TaskDone($task, 'Lorem ipsum') ]);
+    }
+
+    public function testDoesNothingWithFoodtechOrder()
+    {
+        $task = new Task();
+
+        $delivery = new Delivery();
+
+        $order = $this->prophesize(OrderInterface::class);
+        $order
+            ->isFoodtech()
+            ->willReturn(true);
+
+        $delivery->setOrder($order->reveal());
+
+        $task->setDelivery($delivery);
+
+        $this->emailManager
+            ->sendTo(Argument::type('string'), Argument::type('string'))
+            ->shouldNotBeCalled();
+
+        call_user_func_array($this->sendEmail, [ new TaskDone($task, 'Lorem ipsum') ]);
+    }
+
+    public function testDoesNothingWithDeliveryNotBelongingToStore()
+    {
+        $task = new Task();
+
+        $delivery = new Delivery();
+
+        $task->setDelivery($delivery);
+
+        $this->emailManager
+            ->sendTo(Argument::type('string'), Argument::type('string'))
+            ->shouldNotBeCalled();
+
+        call_user_func_array($this->sendEmail, [ new TaskDone($task, 'Lorem ipsum') ]);
+    }
+
+    public function testSendsEmailToStoreOwners()
+    {
+        $store = new Store();
+
+        $bob = $this->prophesize(ApiUser::class);
+        $bob->getFullName()->willReturn('Bob');
+        $bob->getEmail()->willReturn('bob@acme.com');
+
+        $sarah = $this->prophesize(ApiUser::class);
+        $sarah->getFullName()->willReturn('Sarah');
+        $sarah->getEmail()->willReturn('sarah@acme.com');
+
+        $store->getOwners()->add($bob->reveal());
+        $store->getOwners()->add($sarah->reveal());
+
+        $delivery = new Delivery();
+        $delivery->setStore($store);
+
+        $task = new Task();
+        $task->setDelivery($delivery);
+
+        $message = \Swift_Message::newInstance();
+
+        $this->emailManager
+            ->createTaskCompletedMessage($task)
+            ->willReturn($message);
+
+        $this->emailManager
+            ->sendTo($message, Argument::that(function ($to) {
+                return array_key_exists('bob@acme.com', $to) && array_key_exists('sarah@acme.com', $to);
+            }))
+            ->shouldBeCalled();
+
+        call_user_func_array($this->sendEmail, [ new TaskDone($task, 'Lorem ipsum') ]);
+    }
+}


### PR DESCRIPTION
This Pull Request rolls back the coupling between orders & deliveries. 
It is now possible to create a "standalone" delivery, without an associated order, and without applying a pricing. 

**TODO**

- [x] Allow associating a delivery with a store
- [x] Send emails on pickup/dropoff