### PR TITLE
Reintroduce "preferred addresses" 

### DIFF
--- a/app/DoctrineMigrations/Version20190216143748.php
+++ b/app/DoctrineMigrations/Version20190216143748.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20190216143748 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        $stmt = [];
+
+        $stmt['multi_address'] = $this->connection->prepare('SELECT api_user_id, address.geo, COUNT(address.id), ARRAY_TO_STRING(ARRAY_AGG(address.id), \',\') AS address_ids FROM api_user_address JOIN address ON api_user_address.address_id = address.id GROUP BY api_user_id, address.geo HAVING COUNT(address.id) > 1');
+
+        $stmt['multi_address']->execute();
+        while ($row = $stmt['multi_address']->fetch()) {
+
+            $addressIds = array_map('intval', explode(',', $row['address_ids']));
+
+            // We keep the address with the smallest id
+            sort($addressIds);
+            $addressIdToKeep = current($addressIds);
+
+            $addressIdsToRemove = array_diff($addressIds, [ $addressIdToKeep ]);
+
+            $stmt['orders'] = $this->connection->executeQuery(
+                'SELECT * FROM sylius_order WHERE shipping_address_id IN (:address_ids)',
+                [ 'address_ids' => $addressIds ],
+                [ 'address_ids' => Connection::PARAM_INT_ARRAY ]
+            );
+
+            while ($order = $stmt['orders']->fetch()) {
+                $this->addSql('UPDATE sylius_order SET shipping_address_id = :address_id WHERE id = :id', [
+                    'address_id' => $addressIdToKeep,
+                    'id' => $order['id'],
+                ]);
+            }
+
+            foreach ($addressIdsToRemove as $addressId) {
+                $this->addSql('DELETE FROM api_user_address WHERE address_id = :address_id', [
+                    'address_id' => $addressId,
+                ]);
+                $this->addSql('DELETE FROM address WHERE id = :address_id', [
+                    'address_id' => $addressId,
+                ]);
+            }
+        }
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+
+    }
+}

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -329,6 +329,7 @@ fos_js_routing:
         - ^restaurant$
         - restaurant_remove_from_cart
         - restaurant_cart_reset
+        - restaurant_cart_address
         - admin_foodtech_dashboard
         - admin_foodtech_settings
         - admin_order_accept

--- a/features/checkout.feature
+++ b/features/checkout.feature
@@ -40,12 +40,60 @@ Feature: Checkout
     Then the url should match "/profile/orders/\d+"
 
   @javascript
+  Scenario: Login and order something at restaurant with saved address
+    Given the fixtures files are loaded:
+      | sylius_channels.yml        |
+      | restaurants_standalone.yml |
+    And the user is loaded:
+      | email    | bob@demo.coopcycle.org |
+      | username | bob                    |
+      | password | 123456                 |
+    And the user "bob" has delivery address:
+      | streetAddress | 1, Rue de Rivoli, Paris, France |
+      | postalCode    | 75004                           |
+      | geo           | 48.855799, 2.359207             |
+    And the setting "default_tax_category" has value "tva_livraison"
+    And the setting "administrator_email" has value "admin@demo.coopcycle.org"
+    Given I am on "/login"
+    And I fill in "Nom d'utilisateur" with "bob"
+    And I fill in "Mot de passe" with "123456"
+    And I press "Connexion"
+    Then I should be on "/fr/"
+    Given I enter address "1, Rue de Rivoli" in the homepage search
+    Then I should see address suggestions in the homepage search
+    And I should see section "Adresses sauvegardées" in the homepage search suggestions
+    And I should see address "1, Rue de Rivoli, Paris, France" in section "Adresses sauvegardées" in the homepage search suggestions
+    Given I select address "1, Rue de Rivoli, Paris, France" in section "Adresses sauvegardées" in the homepage search suggestions
+    Then I should be on "/fr/restaurants"
+    # TODO Assert query string contains "geohash" & "address"
+    And I click on restaurant "Crazy Hamburger"
+    Then the url should match "/fr/restaurant/[0-9]+-crazy-hamburger"
+    Given I wait for cart to be ready
+    Then the cart address picker should contain "1, Rue de Rivoli, Paris, France"
+    Given I click on menu item "Cheeseburger"
+    Then the product options modal should appear
+    Given I check all the mandatory product options
+    Then the product options modal submit button should not be disabled
+    And I submit the product options modal
+    Then the product "Cheeseburger" should be added to the cart
+    Given I click on menu item "Cheese Cake"
+    Then the product "Cheese Cake" should be added to the cart
+    And the cart submit button should not be disabled
+    Given I submit the cart
+    Then I should be on "/order/"
+    Given I press "Commander"
+    Then I should be on "/order/payment"
+    Given I enter test credit card details
+    Then the url should match "/profile/orders/\d+"
+
+  @javascript
   Scenario: Use search address as default
     Given the fixtures files are loaded:
       | sylius_channels.yml        |
       | restaurants_standalone.yml |
     And the setting "default_tax_category" has value "tva_livraison"
     And the setting "administrator_email" has value "admin@demo.coopcycle.org"
+    # TODO Make sure localStorage is empty
     Given I am on "/fr"
     Given I enter address "91 rue de rivoli" in the homepage search
     Then I should see address suggestions in the homepage search

--- a/features/login.feature
+++ b/features/login.feature
@@ -9,7 +9,7 @@ Feature: Login Test
 
   @javascript
   Scenario: login failed
-    When  I fill in "Nom d'utilisateur" with "bob"
+    When I fill in "Nom d'utilisateur" with "bob"
     And I fill in "Mot de passe" with "123"
     And I press "Connexion"
     Then I should see "Identifiants invalides."
@@ -20,7 +20,7 @@ Feature: Login Test
       | email    | bob@coopcycle.org |
       | username | bob               |
       | password | 123456            |
-    When  I fill in "Nom d'utilisateur" with "bob"
+    When I fill in "Nom d'utilisateur" with "bob"
     And I fill in "Mot de passe" with "123456"
     And I press "Connexion"
     Then I should not see "Identifiants invalides."

--- a/js/app/cart/components/AddressModal.js
+++ b/js/app/cart/components/AddressModal.js
@@ -30,10 +30,11 @@ class AddressModal extends Component {
         className="ReactModal__Content--enter-address">
         <h4 className="text-center">{ this.props.titleText }</h4>
         <AddressAutosuggest
+          addresses={ this.props.addresses }
           autofocus
           address={ '' }
           geohash={ '' }
-          onAddressSelected={ (value, address) => this.props.changeAddress(address) } />
+          onAddressSelected={ (value, address, type) => this.props.changeAddress(address) } />
       </Modal>
     )
   }
@@ -45,7 +46,8 @@ function mapStateToProps(state) {
 
   return {
     isOpen: hasError,
-    titleText: hasError ? _.first(state.errors.shippingAddress) : ''
+    titleText: hasError ? _.first(state.errors.shippingAddress) : '',
+    addresses: state.addresses,
   }
 }
 

--- a/js/app/cart/components/Cart.js
+++ b/js/app/cart/components/Cart.js
@@ -58,10 +58,11 @@ class Cart extends Component {
             <CartErrors />
             <div className="cart">
               <AddressAutosuggest
+                addresses={ this.props.addresses }
                 address={ this.props.streetAddress }
                 geohash={ '' }
                 key={ this.props.streetAddress }
-                onAddressSelected={ (value, address) => this.props.changeAddress(address) } />
+                onAddressSelected={ (value, address, type) => this.props.changeAddress(address) } />
               <hr />
               <DatePicker
                 dateInputName={ this.props.datePickerDateInputName }
@@ -98,6 +99,7 @@ function mapStateToProps(state) {
     shippingAddress: state.cart.shippingAddress,
     streetAddress: state.cart.shippingAddress ? state.cart.shippingAddress.streetAddress : '',
     isMobileCartVisible: state.isMobileCartVisible,
+    addresses: state.addresses,
   }
 }
 

--- a/js/app/cart/redux/actions.js
+++ b/js/app/cart/redux/actions.js
@@ -172,24 +172,45 @@ export function changeAddress(address) {
 
     window._paq.push(['trackEvent', 'Checkout', 'changeAddress', address.streetAddress])
 
+    const {
+      addressFormElements,
+      isNewAddressFormElement,
+      restaurant
+    } = getState()
+
     if (address.isPrecise) {
 
       // Change field value immediately
       dispatch(setStreetAddress(address.streetAddress))
 
-      const addressFormElements = getState().addressFormElements
-
-      _.forEach(addressFormElements, (el, key) => {
-        if (address.hasOwnProperty(key)) {
-          el.value = address[key]
-        }
-      })
-
       dispatch(fetchRequest())
 
-      postForm()
-        .then(res => handleAjaxResponse(res, dispatch, true))
-        .fail(e => handleAjaxResponse(e.responseJSON, dispatch, false))
+      if (address.hasOwnProperty('id')) {
+
+        isNewAddressFormElement.value = '0'
+
+        const url =
+          window.Routing.generate('restaurant_cart_address', { id: restaurant.id })
+
+        $.post(url, { address: address.id })
+          .then(res => handleAjaxResponse(res, dispatch, true))
+          .fail(e => handleAjaxResponse(e.responseJSON, dispatch, false))
+
+      } else {
+
+        isNewAddressFormElement.value = '1'
+
+        _.forEach(addressFormElements, (el, key) => {
+          if (address.hasOwnProperty(key)) {
+            el.value = address[key]
+          }
+        })
+
+        postForm()
+          .then(res => handleAjaxResponse(res, dispatch, true))
+          .fail(e => handleAjaxResponse(e.responseJSON, dispatch, false))
+      }
+
     } else {
       dispatch(addError('shippingAddress', [
         i18n.t('CART_ADDRESS_NOT_ENOUGH_PRECISION')

--- a/js/app/cart/redux/reducers.js
+++ b/js/app/cart/redux/reducers.js
@@ -23,9 +23,11 @@ const initialState = {
   errors: [],
   availabilities: [],
   addressFormElements: {},
+  isNewAddressFormElement: null,
   datePickerDateInputName: 'date',
   datePickerTimeInputName: 'time',
   isMobileCartVisible: false,
+  addresses: [],
 }
 
 const isFetching = (state = initialState.isFetching, action = {}) => {
@@ -100,9 +102,13 @@ const restaurant = (state = initialState.restaurant, action = {}) => state
 
 const addressFormElements = (state = initialState.addressFormElements, action = {}) => state
 
+const isNewAddressFormElement = (state = initialState.isNewAddressFormElement, action = {}) => state
+
 const datePickerDateInputName = (state = initialState.datePickerDateInputName, action = {}) => state
 
 const datePickerTimeInputName = (state = initialState.datePickerTimeInputName, action = {}) => state
+
+const addresses = (state = initialState.addresses, action = {}) => state
 
 const isMobileCartVisible = (state = initialState.isMobileCartVisible, action = {}) => {
   switch (action.type) {
@@ -121,7 +127,9 @@ export default combineReducers({
   errors,
   availabilities,
   addressFormElements,
+  isNewAddressFormElement,
   datePickerDateInputName,
   datePickerTimeInputName,
   isMobileCartVisible,
+  addresses,
 })

--- a/js/app/restaurant/index.js
+++ b/js/app/restaurant/index.js
@@ -76,9 +76,14 @@ window.initMap = function() {
   })
 
   const restaurantDataElement = document.querySelector('#js-restaurant-data')
+  const addressesDataElement = document.querySelector('#js-addresses-data')
 
   const restaurant = JSON.parse(restaurantDataElement.dataset.restaurant)
   let cart = JSON.parse(restaurantDataElement.dataset.cart)
+
+  const addresses = JSON.parse(addressesDataElement.dataset.addresses)
+
+  // FIXME Check parse errors
 
   new OpeningHoursParser(document.querySelector('#opening-hours'), {
     openingHours: restaurant.openingHours,
@@ -109,7 +114,9 @@ window.initMap = function() {
       addressLocality: document.querySelector('#cart_shippingAddress_addressLocality'),
       latitude: document.querySelector('#cart_shippingAddress_latitude'),
       longitude: document.querySelector('#cart_shippingAddress_longitude')
-    }
+    },
+    isNewAddressFormElement: document.querySelector('#cart_isNewAddress'),
+    addresses
   }
 
   store = createStoreFromPreloadedState(state)

--- a/js/app/utils/GoogleMaps.js
+++ b/js/app/utils/GoogleMaps.js
@@ -16,6 +16,7 @@ export const placeToAddress = (place, value = '') => {
   }
 
   return {
+    // FIXME Wrap in "geo" key
     latitude: place.geometry.location.lat(),
     longitude: place.geometry.location.lng(),
     addressCountry: addressDict.country || '',

--- a/src/AppBundle/Controller/IndexController.php
+++ b/src/AppBundle/Controller/IndexController.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller;
 
+use AppBundle\Controller\Utils\UserTrait;
 use AppBundle\Entity\Restaurant;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
@@ -13,6 +14,8 @@ use Symfony\Component\Routing\Annotation\Route;
  */
 class IndexController extends AbstractController
 {
+    use UserTrait;
+
     const MAX_RESULTS = 3;
 
     /**
@@ -32,6 +35,7 @@ class IndexController extends AbstractController
             'restaurants' => $restaurants,
             'max_results' => self::MAX_RESULTS,
             'show_more' => $showMore,
+            'addresses_normalized' => $this->getUserAddresses(),
         );
     }
 }

--- a/src/AppBundle/Controller/RestaurantController.php
+++ b/src/AppBundle/Controller/RestaurantController.php
@@ -3,9 +3,11 @@
 namespace AppBundle\Controller;
 
 use AppBundle\Annotation\HideSoftDeleted;
+use AppBundle\Controller\Utils\UserTrait;
 use AppBundle\Sylius\Order\AdjustmentInterface;
 use AppBundle\Sylius\Order\OrderInterface;
 use AppBundle\Sylius\Order\OrderItemInterface;
+use AppBundle\Entity\Address;
 use AppBundle\Entity\Restaurant;
 use AppBundle\Entity\RestaurantRepository;
 use AppBundle\Form\Order\CartType;
@@ -38,6 +40,8 @@ use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
  */
 class RestaurantController extends AbstractController
 {
+    use UserTrait;
+
     const ITEMS_PER_PAGE = 15;
 
     private $orderManager;
@@ -219,6 +223,8 @@ class RestaurantController extends AbstractController
             'pages' => $pages,
             'geohash' => $request->query->get('geohash'),
             'images' => $images,
+            'addresses_normalized' => $this->getUserAddresses(),
+            'address' => $request->query->has('address') ? $request->query->get('address') : null,
         );
     }
 
@@ -249,6 +255,23 @@ class RestaurantController extends AbstractController
         $request->getSession()->set('restaurantId', $id);
 
         $cart = $cartContext->getCart();
+
+        $user = $this->getUser();
+        if ($request->query->has('address') && $user && count($user->getAddresses()) > 0) {
+
+            $addressId = intval(base_convert($request->query->get('address'), 36, 10));
+
+            $shippingAddress = $this->getDoctrine()
+                ->getRepository(Address::class)
+                ->find($addressId);
+
+            if ($user->getAddresses()->contains($shippingAddress)) {
+                $cart->setShippingAddress($shippingAddress);
+
+                $this->orderManager->persist($cart);
+                $this->orderManager->flush();
+            }
+        }
 
         $cartForm = $this->createForm(CartType::class, $cart);
 
@@ -339,6 +362,7 @@ class RestaurantController extends AbstractController
             'availabilities' => $this->getAvailabilities($cart),
             'delay' => $delay,
             'cart_form' => $cartForm->createView(),
+            'addresses_normalized' => $this->getUserAddresses(),
         );
     }
 

--- a/src/AppBundle/Controller/Utils/UserTrait.php
+++ b/src/AppBundle/Controller/Utils/UserTrait.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Controller\Utils;
 
+use AppBundle\Entity\Address;
 use AppBundle\Entity\TrackingPosition;
 use FOS\UserBundle\Model\UserInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,5 +28,25 @@ trait UserTrait
             'date' => $date,
             'positions' => $positions,
         ];
+    }
+
+    protected function getUserAddresses()
+    {
+        $addresses = [];
+
+        $user = $this->getUser();
+        if ($user) {
+            $addresses = $user->getAddresses()->toArray();
+        }
+
+        return array_map(function ($address) {
+
+            return $this->get('serializer')->normalize($address, 'jsonld', [
+                'resource_class' => Address::class,
+                'operation_type' => 'item',
+                'item_operation_name' => 'get',
+                'groups' => ['address', 'place']
+            ]);
+        }, $addresses);
     }
 }

--- a/src/AppBundle/Resources/views/_partials/restaurant/list_thumbnail.html.twig
+++ b/src/AppBundle/Resources/views/_partials/restaurant/list_thumbnail.html.twig
@@ -25,10 +25,19 @@
 
 {% endif %}
 
+{% set restaurant_path_params = {
+  id: restaurant.id,
+  slug: restaurant.name|slugify
+} %}
+
+{% if address is defined and address is not empty %}
+  {% set restaurant_path_params = restaurant_path_params|merge({ address: address }) %}
+{% endif %}
+
 {% set isOpen = restaurant.isOpen %}
 
 <a class="thumbnail restaurant-item {% if not restaurant.enabled %}restaurant-item--disabled{% endif %}"
-  href="{{ path('restaurant', {'id': restaurant.id, 'slug': restaurant.name|slugify}) }}">
+  href="{{ path('restaurant', restaurant_path_params) }}">
   <img class="restaurant-image" src="{{ restaurant_image }}" alt="{{ restaurant.name }}">
   <div class="caption">
     <h4>{{ restaurant.name|truncate(24, false, '…') }}</h4>

--- a/src/AppBundle/Resources/views/index/index.html.twig
+++ b/src/AppBundle/Resources/views/index/index.html.twig
@@ -87,15 +87,39 @@
 {% block scripts %}
   <script>
   function initMap() {
+    var $searchForm = $('#address-search-form');
     new CoopCycle.AddressAutosuggest(document.querySelector('#address-search'), {
       address: sessionStorage.getItem('search_address') || '',
+      addresses: {{ addresses_normalized|json_encode()|raw }},
       geohash: sessionStorage.getItem('search_geohash') || '',
-      onAddressSelected: function(value, address) {
+      onAddressSelected: function(value, address, type) {
+
+        var $addressInput = $searchForm.find('input[name="address"]');
+        var $geohashInput = $searchForm.find('input[name="geohash"]');
+
+        if (type === 'address') {
+          if ($addressInput.length === 0) {
+            var $newAddressInput = $('<input>');
+            $newAddressInput.attr('type', 'hidden');
+            $newAddressInput.attr('name', 'address');
+            $newAddressInput.val(address.id.toString(36));
+            $searchForm.append($newAddressInput);
+          }
+        }
+
+        if (type === 'prediction') {
+          if ($addressInput.length > 0) {
+            $addressInput.remove();
+          }
+        }
+
         sessionStorage.setItem('search_geohash', address.geohash);
         sessionStorage.setItem('search_address', value);
+
         _paq.push(['trackEvent', 'Homepage', 'searchAddress', value]);
-        $('#address-search-form').find('input[name="geohash"]').val(address.geohash);
-        $('#address-search-form').submit();
+
+        $geohashInput.val(address.geohash);
+        $searchForm.submit();
       }
     });
   }

--- a/src/AppBundle/Resources/views/restaurant/index.html.twig
+++ b/src/AppBundle/Resources/views/restaurant/index.html.twig
@@ -227,6 +227,9 @@
   data-restaurant="{{ restaurant_json|json_encode|e('html_attr') }}"
   data-cart="{{ cart_json|json_encode|e('html_attr') }}"></div>
 
+<div id="js-addresses-data"
+  data-addresses="{{ addresses_normalized|json_encode|e('html_attr') }}"></div>
+
 {% endblock %}
 
 {% block scripts %}

--- a/src/AppBundle/Resources/views/restaurant/list.html.twig
+++ b/src/AppBundle/Resources/views/restaurant/list.html.twig
@@ -46,16 +46,41 @@
   <script>
   var initialGeohash = "{{ geohash }}";
   function initMap() {
+    var $searchForm = $('#restaurant-search-form');
     new CoopCycle.AddressAutosuggest(document.querySelector('#address-search'), {
       address: sessionStorage.getItem('search_address') || '',
+      addresses: {{ addresses_normalized|json_encode()|raw }},
       geohash: initialGeohash,
-      onAddressSelected: function(value, address) {
+      onAddressSelected: function(value, address, type) {
+
+        var $addressInput = $searchForm.find('input[name="address"]');
+        var $geohashInput = $searchForm.find('input[name="geohash"]');
+
         if (address.geohash !== initialGeohash) {
+
+          if (type === 'address') {
+            if ($addressInput.length === 0) {
+              var $newAddressInput = $('<input>');
+              $newAddressInput.attr('type', 'hidden');
+              $newAddressInput.attr('name', 'address');
+              $newAddressInput.val(address.id.toString(36));
+              $searchForm.append($newAddressInput);
+            }
+          }
+
+          if (type === 'prediction') {
+            if ($addressInput.length > 0) {
+              $addressInput.remove();
+            }
+          }
+
           sessionStorage.setItem('search_geohash', address.geohash);
           sessionStorage.setItem('search_address', value);
+
           _paq.push(['trackEvent', 'RestaurantList', 'searchAddress', value]);
-          $('#restaurant-search-form').find('input[name="geohash"]').val(address.geohash);
-          $('#restaurant-search-form').submit();
+
+          $geohashInput.val(address.geohash);
+          $searchForm.submit();
         }
       }
     });


### PR DESCRIPTION
When a customer is logged in & has saved addresses, they are displayed in the autosuggest. 
When selected, the address won't be re-created. 

Also, the migration will deduplicate customer addresses that have the same geo coordinates.

<img width="382" alt="capture d ecran 2019-02-21 a 20 00 55" src="https://user-images.githubusercontent.com/1162230/53194350-73683b00-3613-11e9-99bb-44d886afbe7d.png">

