### PR TITLE
Introduce coupon-based promotions

### DIFF
--- a/app/config/message_bus/order.yml
+++ b/app/config/message_bus/order.yml
@@ -232,3 +232,13 @@ services:
           subscribes_to: order:dropped
         - name: event_subscriber
           subscribes_to: order:fulfilled
+
+  coopcycle.domain.order.reactor.modify_promotions_usage:
+    class: AppBundle\Domain\Order\Reactor\ModifyPromotionsUsage
+    arguments:
+      - '@coopcycle.socket_io_manager'
+    tags:
+        - name: event_subscriber
+          subscribes_to: order:created
+        - name: event_subscriber
+          subscribes_to: order:cancelled

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -96,6 +96,8 @@ services:
       $channelFactory: '@sylius.factory.channel'
       $currencyRepository: '@sylius.repository.currency'
       $currencyFactory: '@sylius.factory.currency'
+      $promotionFactory: '@sylius.factory.promotion'
+      $locale: '%kernel.default_locale%'
 
   AppBundle\Command\InitDemoCommand:
     arguments:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -213,6 +213,13 @@ services:
       - "@sylius.factory.adjustment"
       - "@translator"
 
+  sylius.order_processing.order_promotion_processor:
+    class: AppBundle\Sylius\OrderProcessing\OrderPromotionProcessor
+    arguments:
+      - "@sylius.promotion_processor"
+    tags:
+      - { name: sylius.order_processor, priority: 64 }
+
   sylius.order_processing.order_options_fee_processor:
     class: AppBundle\Sylius\OrderProcessing\OrderOptionsFeeProcessor
     arguments:

--- a/app/config/services/forms.yml
+++ b/app/config/services/forms.yml
@@ -128,3 +128,8 @@ services:
     arguments:
       - '@Trikoder\Bundle\OAuth2Bundle\Manager\ClientManagerInterface'
     tags: [ form.type ]
+
+  sylius.form.extension.type.promotion_coupon:
+    class: AppBundle\Form\Extension\PromotionCouponTypeExtension
+    tags:
+      - { name: form.type_extension, extended_type: Sylius\Bundle\PromotionBundle\Form\Type\PromotionCouponType }

--- a/js/app/cart/components/CartTotal.js
+++ b/js/app/cart/components/CartTotal.js
@@ -8,12 +8,19 @@ class CartTotal extends React.Component {
 
   renderAdjustments() {
 
-    const { adjustments } = this.props
+    let adjustments = []
+    if (this.props.adjustments.hasOwnProperty('delivery')) {
+      adjustments = adjustments.concat(this.props.adjustments.delivery)
+    }
 
-    if (adjustments.hasOwnProperty('delivery')) {
+    if (this.props.adjustments.hasOwnProperty('delivery_promotion')) {
+      adjustments = adjustments.concat(this.props.adjustments.delivery_promotion)
+    }
+
+    if (adjustments.length > 0) {
       return (
         <div>
-          { adjustments.delivery.map(adjustment =>
+          { adjustments.map(adjustment =>
             <div key={ adjustment.id }>
               <span>{ adjustment.label }</span>
               <strong className="pull-right">{ (adjustment.amount / 100).formatMoney(2, window.AppData.currencySymbol) }</strong>

--- a/src/AppBundle/Domain/Order/Reactor/ModifyPromotionsUsage.php
+++ b/src/AppBundle/Domain/Order/Reactor/ModifyPromotionsUsage.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AppBundle\Domain\Order\Reactor;
+
+use AppBundle\Domain\Order\Event;
+use AppBundle\Sylius\Promotion\Modifier\OrderPromotionsUsageModifier;
+use SimpleBus\Message\Bus\MessageBus;
+
+/**
+ * @see https://github.com/Sylius/Sylius/blob/60134b783c51c4b9da0b58c5a54482824a8baf8a/src/Sylius/Bundle/CoreBundle/Resources/config/app/state_machine/sylius_order.yml
+ */
+class ModifyPromotionsUsage
+{
+    private $usageModifier;
+
+    public function __construct()
+    {
+        $this->usageModifier = new OrderPromotionsUsageModifier();
+    }
+
+    public function __invoke(Event $event)
+    {
+        $order = $event->getOrder();
+
+        if ($event instanceof Event\OrderCreated) {
+            $this->usageModifier->increment($order);
+        }
+
+        if ($event instanceof Event\OrderCancelled) {
+            $this->usageModifier->decrement($order);
+        }
+    }
+}

--- a/src/AppBundle/Form/Checkout/CheckoutAddressType.php
+++ b/src/AppBundle/Form/Checkout/CheckoutAddressType.php
@@ -5,6 +5,7 @@ namespace AppBundle\Form\Checkout;
 use AppBundle\Form\AddressType;
 use AppBundle\Utils\ShippingDateFilter;
 use Sylius\Bundle\PromotionBundle\Form\Type\PromotionCouponToCodeType;
+use Sylius\Bundle\PromotionBundle\Validator\Constraints\PromotionSubjectCoupon;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -14,6 +15,7 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 class CheckoutAddressType extends AbstractType
@@ -112,5 +114,14 @@ class CheckoutAddressType extends AbstractType
         $options['disabled'] = true;
 
         $form->add($name, get_class($config->getType()->getInnerType()), $options);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefault('constraints', [
+            new PromotionSubjectCoupon()
+        ]);
     }
 }

--- a/src/AppBundle/Form/Checkout/CheckoutAddressType.php
+++ b/src/AppBundle/Form/Checkout/CheckoutAddressType.php
@@ -4,8 +4,10 @@ namespace AppBundle\Form\Checkout;
 
 use AppBundle\Form\AddressType;
 use AppBundle\Utils\ShippingDateFilter;
+use Sylius\Bundle\PromotionBundle\Form\Type\PromotionCouponToCodeType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormError;
@@ -37,6 +39,10 @@ class CheckoutAddressType extends AbstractType
                 'required' => false,
                 'label' => 'form.checkout_address.notes.label',
                 'attr' => ['placeholder' => 'form.checkout_address.notes.placeholder']
+            ])
+            ->add('promotionCoupon', PromotionCouponToCodeType::class, [
+                'label' => 'form.checkout_address.promotion_coupon.label',
+                'required' => false,
             ]);
 
         $builder->get('shippingAddress')->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {

--- a/src/AppBundle/Form/Extension/PromotionCouponTypeExtension.php
+++ b/src/AppBundle/Form/Extension/PromotionCouponTypeExtension.php
@@ -1,0 +1,33 @@
+<?php
+
+
+namespace AppBundle\Form\Extension;
+
+use Sylius\Bundle\PromotionBundle\Form\Type\PromotionCouponType;
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class PromotionCouponTypeExtension extends AbstractTypeExtension
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('perCustomerUsageLimit', IntegerType::class, [
+                'label' => 'sylius.form.promotion_coupon.per_customer_usage_limit',
+                'required' => false,
+            ])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExtendedType(): string
+    {
+        return PromotionCouponType::class;
+    }
+}

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -101,6 +101,7 @@ adminDashboard.zones.uploadGeoJSON: Upload a GeoJSON file
 adminDashboard.zones.send: Send
 
 adminDashboard.back.title: Back to website
+adminDashboard.promotions.title: Promotions
 
 deliveryForm.noPriceWarning: No price could be calculated. Please enter it.
 deliveryForm.noPriceFromPricingWarning: No price could be calculated from the pricing. Please enter it manually or edit the pricing.
@@ -517,6 +518,8 @@ form.api_app.store.label: Store
 form.api_app.client_id.label: Identifier
 form.api_app.client_secret.label: Secret key
 
+promotion_coupon.used.label: Number of uses
+
 product_option.strategy.free: Free
 product_option.strategy.option: Fixed price whatever the choice
 product_option.strategy.option_value: Price according to the choice
@@ -625,6 +628,8 @@ maintenance.text: Sitio web bajo mantenimiento<br>Volvemos pronto
 api_apps.breadcrumb: API clients
 api_apps.created.message: The client has been added. Use the credentials below to authenticate.
 
+promotions.breadcrumb: Promotions
+
 allergens.CEREALS_CONTAINING_GLUTEN: Cereals containing gluten
 allergens.CRUSTACEANS: Crustaceans
 allergens.EGGS: Eggs
@@ -651,3 +656,6 @@ restricted_diets.LOW_LACTOSE_DIET: Low lactose
 restricted_diets.LOW_SALT_DIET: Low salt
 restricted_diets.VEGAN_DIET: Vegan
 restricted_diets.VEGETARIAN_DIET: Vegetarian
+
+sylius.ui.code: Code
+sylius.form.promotion_coupon.per_customer_usage_limit: Per customer usage limit

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -232,6 +232,7 @@ order.cart.title: Cart
 order.items.products_with_count: Products (%count%)
 order.summary.heading: Order %number% (#%id%)
 order.total_including_tax: Total (tax incl.)
+order.items_total: Total products
 order.total_tax: Taxes
 order.total_tax_by_rate: Total %name%
 order.shipping_date.title: Your shipping date
@@ -509,6 +510,7 @@ form.checkout_address.notes.label: An observation?
 form.checkout_address.notes.placeholder: |
   Example: without sauce, without tomatoes…
 form.checkout_address.notes.help: Your observation will be forwarded to the restaurant
+form.checkout_address.promotion_coupon.label: Coupon code
 
 form.orders_export.start.label: Start
 form.orders_export.end.label: End
@@ -629,6 +631,7 @@ api_apps.breadcrumb: API clients
 api_apps.created.message: The client has been added. Use the credentials below to authenticate.
 
 promotions.breadcrumb: Promotions
+promotions.promotion_coupon.success: Your coupon code %code% has been taken into account
 
 allergens.CEREALS_CONTAINING_GLUTEN: Cereals containing gluten
 allergens.CRUSTACEANS: Crustaceans

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -246,6 +246,7 @@ order.cart.title: Cesta
 order.items.products_with_count: Productos (%count%)
 order.summary.heading: Pedido %number% (#%id%)
 order.total_including_tax: Total (IVA incl.)
+order.items_total: Total productos
 order.total_tax: IVA
 order.total_tax_by_rate: Total %name%
 order.shipping_date.title: Tu horario de entrega
@@ -545,6 +546,7 @@ form.checkout_address.notes.label: ¿Un comentario?
 form.checkout_address.notes.placeholder: |
   Ejemplo: sin salsa, sin tomates…
 form.checkout_address.notes.help: Tu comentario será enviado al restaurante.
+form.checkout_address.promotion_coupon.label: Código promocional
 
 form.orders_export.start.label: Inicio
 form.orders_export.end.label: Final
@@ -672,6 +674,7 @@ api_apps.breadcrumb: Clientes API
 api_apps.created.message: El cliente ha sido añadido. Utilice las credenciales a continuación para autenticar.
 
 promotions.breadcrumb: Promociones
+promotions.promotion_coupon.success: Tu código promocional %code% ha sido tomado en cuenta
 
 allergens.CEREALS_CONTAINING_GLUTEN: Cereales que contienen gluten
 allergens.CRUSTACEANS: Crustáceos

--- a/src/AppBundle/Resources/translations/messages.es.yml
+++ b/src/AppBundle/Resources/translations/messages.es.yml
@@ -95,6 +95,8 @@ adminDashboard.zones.send: Enviar
 
 adminDashboard.back.title: Volver al sitio
 
+adminDashboard.promotions.title: Promociones
+
 deliveryForm.noPriceWarning: No se ha podido calcular un precio. Por favor introduzca
   un precio.
 deliveryForm.noPriceFromPricingWarning: No se ha podido calcular un precio a partir
@@ -552,6 +554,8 @@ form.api_app.store.label: Tienda
 form.api_app.client_id.label: Login
 form.api_app.client_secret.label: Clave secreta
 
+promotion_coupon.used.label: Número de usos
+
 product_option.strategy.free: Gratis
 product_option.strategy.option: Precio fijo sea cual sea la elección
 product_option.strategy.option_value: Precio según la elección
@@ -667,6 +671,8 @@ maintenance.text: Site under maintenance<br>We will be back soon
 api_apps.breadcrumb: Clientes API
 api_apps.created.message: El cliente ha sido añadido. Utilice las credenciales a continuación para autenticar.
 
+promotions.breadcrumb: Promociones
+
 allergens.CEREALS_CONTAINING_GLUTEN: Cereales que contienen gluten
 allergens.CRUSTACEANS: Crustáceos
 allergens.EGGS: Huevos
@@ -693,3 +699,6 @@ restricted_diets.LOW_LACTOSE_DIET: Baja lactosa
 restricted_diets.LOW_SALT_DIET: Bajo en sal
 restricted_diets.VEGAN_DIET: Vegano
 restricted_diets.VEGETARIAN_DIET: Vegetariano
+
+sylius.ui.code: Codigo
+sylius.form.promotion_coupon.per_customer_usage_limit: Límite de uso por cliente

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -233,6 +233,7 @@ order.cart.title: Panier
 order.items.products_with_count: Produits (%count%)
 order.summary.heading: Commande %number% (#%id%)
 order.total_including_tax: Total TTC
+order.items_total: Total produits
 order.total_tax: TVA
 order.total_tax_by_rate: Total %name%
 order.shipping_date.title: Votre horaire de livraison
@@ -545,6 +546,7 @@ form.checkout_address.notes.label: Une remarque ?
 form.checkout_address.notes.placeholder: |
   Exemple : sans sauce, sans tomates…
 form.checkout_address.notes.help: Votre remarque sera transmise au restaurant
+form.checkout_address.promotion_coupon.label: Code promotionnel
 
 form.orders_export.start.label: Début
 form.orders_export.end.label: Fin
@@ -712,6 +714,7 @@ api_apps.breadcrumb: Clients d'API
 api_apps.created.message: Le client a bien été ajouté. Utilisez les identifiants ci-dessous pour vous authentifier.
 
 promotions.breadcrumb: Promotions
+promotions.promotion_coupon.success: Votre code promotionnel %code% a été pris en compte
 
 allergens.CEREALS_CONTAINING_GLUTEN: Céréales contenant du gluten
 allergens.CRUSTACEANS: Crustacés

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -88,6 +88,8 @@ adminDashboard.zones.delete: Supprimer
 adminDashboard.zones.uploadGeoJSON: Uploadez un fichier GeoJSON
 adminDashboard.zones.send: Envoyer
 adminDashboard.back.title: Revenir au site
+adminDashboard.promotions.title: Promotions
+
 delivery.createNew: Créer une livraison
 help.title: Aide
 help.home: Accueil
@@ -552,6 +554,8 @@ form.api_app.store.label: Magasin
 form.api_app.client_id.label: Identifiant
 form.api_app.client_secret.label: Clé secrète
 
+promotion_coupon.used.label: Nombre d'utilisations
+
 product_option.strategy.free: Gratuit
 product_option.strategy.option: Prix fixe quelque soit le choix
 product_option.strategy.option_value: Prix en fonction du choix
@@ -707,6 +711,8 @@ maintenance.text: Site en maintenance<br>Nous revenons dans quelques instants
 api_apps.breadcrumb: Clients d'API
 api_apps.created.message: Le client a bien été ajouté. Utilisez les identifiants ci-dessous pour vous authentifier.
 
+promotions.breadcrumb: Promotions
+
 allergens.CEREALS_CONTAINING_GLUTEN: Céréales contenant du gluten
 allergens.CRUSTACEANS: Crustacés
 allergens.EGGS: Oeufs
@@ -733,3 +739,6 @@ restricted_diets.LOW_LACTOSE_DIET: Sans lactose
 restricted_diets.LOW_SALT_DIET: Sans sel
 restricted_diets.VEGAN_DIET: Vegan
 restricted_diets.VEGETARIAN_DIET: Végétarien
+
+sylius.ui.code: Code
+sylius.form.promotion_coupon.per_customer_usage_limit: Limite d'utilisation par client

--- a/src/AppBundle/Resources/views/_partials/order/items.html.twig
+++ b/src/AppBundle/Resources/views/_partials/order/items.html.twig
@@ -32,6 +32,13 @@
     </tr>
   {% endfor %}
   <tbody>
+  {% set delivery_adjustment = order.getAdjustments('delivery')|first %}
+  {% set promotion_adjustments = [] %}
+  {% for adjusment in order.adjustments %}
+    {% if adjusment.type == 'delivery_promotion' %}
+      {% set promotion_adjustments = [ adjusment ]|merge(promotion_adjustments) %}
+    {% endif %}
+  {% endfor %}
   <tfoot>
     {% if with_taxes is not defined or (with_taxes is defined and with_taxes == true) %}
       {% for tax_rate in order|split_tax_rates %}
@@ -39,6 +46,28 @@
         <th>{% trans with { '%name%': tax_rate.name } %}order.total_tax_by_rate{% endtrans %}</th>
         <td class="text-right">
           {{ tax_rate.amount|price_format }}
+        </td>
+      </tr>
+      {% endfor %}
+    {% endif %}
+    <tr>
+      <th>{% trans %}order.items_total{% endtrans %}</th>
+      <td class="text-right">
+        {{ order.itemsTotal|price_format }}
+      </td>
+    </tr>
+    <tr>
+      <th>{{ delivery_adjustment.label }}</th>
+      <td class="text-right">
+        {{ delivery_adjustment.amount|price_format }}
+      </td>
+    </tr>
+    {% if promotion_adjustments|length > 0 %}
+      {% for adjustment in promotion_adjustments %}
+      <tr>
+        <th>{{ adjustment.label }}</th>
+        <td class="text-right">
+          {{ adjustment.amount|price_format }}
         </td>
       </tr>
       {% endfor %}

--- a/src/AppBundle/Resources/views/admin/nav.html.twig
+++ b/src/AppBundle/Resources/views/admin/nav.html.twig
@@ -72,6 +72,7 @@
             <li><a href="{{ path('admin_taxation_settings') }}">{% trans %}adminDashboard.taxation.title{% endtrans %}</a></li>
             <li><a href="{{ path('admin_zones') }}">{% trans %}adminDashboard.zones.title{% endtrans %}</a></li>
             <li><a href="{{ path('admin_embed') }}">{% trans %}adminDashboard.embed.title{% endtrans %}</a></li>
+            <li><a href="{{ path('admin_promotions') }}">{% trans %}adminDashboard.promotions.title{% endtrans %}</a></li>
             <li><a href="{{ path('admin_api_apps') }}">API</a></li>
           </ul>
         </li>

--- a/src/AppBundle/Resources/views/admin/promotion.html.twig
+++ b/src/AppBundle/Resources/views/admin/promotion.html.twig
@@ -1,0 +1,48 @@
+{% extends "@App/admin.html.twig" %}
+
+{% block breadcrumb %}
+<li><a href="{{ path('admin_promotions') }}">{{ 'promotions.breadcrumb'|trans }}</a></li>
+<li><a href="{{ path('admin_promotion', { id: promotion.id }) }}">{{ promotion.name }}</a></li>
+
+{% endblock %}
+
+{% block content %}
+<p class="text-right">
+  <a href="{{ path('admin_new_promotion_coupon', { id: promotion.id }) }}" class="btn btn-success">
+    <i class="fa fa-plus"></i> {% trans %}basics.add{% endtrans %}
+  </a>
+</p>
+
+<table class="table task-table">
+  <thead>
+    <th>{% trans %}sylius.ui.code{% endtrans %}</th>
+    <th>{% trans %}sylius.form.promotion_coupon.usage_limit{% endtrans %}</th>
+    <th>{% trans %}sylius.form.promotion_coupon.per_customer_usage_limit{% endtrans %}</th>
+    <th>{% trans %}sylius.form.promotion_coupon.expires_at{% endtrans %}</th>
+    <th class="text-right">{% trans %}promotion_coupon.used.label{% endtrans %}</th>
+  </thead>
+  <tbody>
+  {% for coupon in promotion.coupons %}
+      <td width="5%">
+        <a href="{{ path('admin_promotion_coupon', { id: promotion.id, code: coupon.code }) }}">
+          {{ coupon.code }}
+        </a>
+      </td>
+      <td>
+        {{ coupon.usageLimit }}
+      </td>
+      <td>
+        {{ coupon.perCustomerUsageLimit }}
+      </td>
+      <td>
+        {{ coupon.expiresAt }}
+      </td>
+      <td class="text-right">
+        {{ coupon.used }}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+
+{% endblock %}

--- a/src/AppBundle/Resources/views/admin/promotion_coupon.html.twig
+++ b/src/AppBundle/Resources/views/admin/promotion_coupon.html.twig
@@ -1,0 +1,24 @@
+{% extends "@App/admin.html.twig" %}
+
+{% form_theme form 'bootstrap_3_layout.html.twig' %}
+
+{% block breadcrumb %}
+{% set promotion_coupon = form.vars.data %}
+{% set is_new = (promotion_coupon.id is null) %}
+<li><a href="{{ path('admin_promotions') }}">{{ 'promotions.breadcrumb'|trans }}</a></li>
+<li><a href="{{ path('admin_promotion', { id: promotion_coupon.promotion.id }) }}">{{ promotion_coupon.promotion.name }}</a></li>
+{% if is_new %}
+<li>{{ 'basics.add'|trans }}</li>
+{% else %}
+<li>{{ promotion_coupon.code }}</li>
+{% endif %}
+{% endblock %}
+
+{% block content %}
+{{ form_start(form) }}
+  {{ form_widget(form) }}
+  <button type="submit" class="btn btn-block btn-primary">
+    {{ 'basics.save'|trans }}
+  </button>
+{{ form_end(form) }}
+{% endblock %}

--- a/src/AppBundle/Resources/views/admin/promotions.html.twig
+++ b/src/AppBundle/Resources/views/admin/promotions.html.twig
@@ -1,0 +1,27 @@
+{% extends "@App/admin.html.twig" %}
+
+{% block breadcrumb %}
+<li><a href="{{ path('admin_promotions') }}">{{ 'promotions.breadcrumb'|trans }}</a></li>
+{% endblock %}
+
+{% block content %}
+<table class="table task-table">
+  <thead>
+    <th>#</th>
+    <th>{% trans %}basics.name{% endtrans %}</th>
+  </thead>
+  <tbody>
+  {% for promotion in promotions %}
+      <td width="5%">
+        <a href="{{ path('admin_promotion', { id: promotion.id }) }}">
+          #{{ promotion.id }}
+        </a>
+      </td>
+      <td>
+        {{ promotion.name }}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/src/AppBundle/Resources/views/order/index.html.twig
+++ b/src/AppBundle/Resources/views/order/index.html.twig
@@ -10,25 +10,29 @@
     {% include '@App/order/breadcrumb.html.twig' %}
 
     <div class="order-map__wrapper">
+      {{ form_start(form) }}
       <div class="row">
-        <div class="col-xs-12 col-md-6 col-md-offset-6">
+        <div class="col-xs-12 col-md-6">
           <div class="order-map__column">
 
-            {{ form_start(form) }}
-
-            <a class="order-map__column-heading" role="button" data-toggle="collapse" href="#restaurant" aria-expanded="false" aria-controls="restaurant">
-              <h4>{{ order.restaurant.name }} <span class="pull-right"><i class="fa fa-chevron-down"></i></span></h4>
-            </a>
-            <div class="collapse order-map__column-block" id="restaurant">
+            <h4>{{ order.restaurant.name }}</h4>
+            <div class="order-map__column-block">
               {% include "@App/_partials/order/restaurant_details.html.twig" %}
             </div>
 
-            <a class="order-map__column-heading" role="button" data-toggle="collapse" href="#items" aria-expanded="false" aria-controls="items">
-              <h4>{{ 'order.cart.title'|trans }}<span class="pull-right"><i class="fa fa-chevron-down"></i></span></h4>
-            </a>
-            <div class="collapse order-map__column-block" id="items">
+            <h4>{{ 'order.cart.title'|trans }}</h4>
+            <div class="order-map__column-block" id="items">
               {% include '@App/_partials/order/items.html.twig' with { with_taxes: false } %}
             </div>
+
+            <div class="order-map__column-block">
+              {{ form_row(form.promotionCoupon) }}
+            </div>
+
+          </div>
+        </div>
+        <div class="col-xs-12 col-md-6">
+          <div class="order-map__column">
 
             {% if form.shippedAt is defined %}
             <h4>{% trans %}order.shipping_date.title{% endtrans %}</h4>
@@ -51,9 +55,7 @@
                 </div>
               </div>
               {{ form_row(form.shippingAddress.description) }}
-
               <hr>
-
               {{ form_row(form.notes) }}
 
               <div class="text-center">
@@ -61,10 +63,11 @@
               </div>
             </div>
 
-            {{ form_end(form) }}
           </div>
         </div>
       </div>
+      {{ form_end(form) }}
+
       <div id="map" class="order-map hidden-xs hidden-sm"></div>
     </div>
 

--- a/src/AppBundle/Serializer/CartNormalizer.php
+++ b/src/AppBundle/Serializer/CartNormalizer.php
@@ -64,8 +64,17 @@ class CartNormalizer implements NormalizerInterface, DenormalizerInterface
             ];
         }, $object->getAdjustments(AdjustmentInterface::DELIVERY_ADJUSTMENT)->toArray());
 
+        $deliveryPromotionAdjustments = array_map(function (BaseAdjustmentInterface $adjustment) {
+            return [
+                'id' => $adjustment->getId(),
+                'label' => $adjustment->getLabel(),
+                'amount' => $adjustment->getAmount(),
+            ];
+        }, $object->getAdjustments(AdjustmentInterface::DELIVERY_PROMOTION_ADJUSTMENT)->toArray());
+
         $data['adjustments'] = [
-            AdjustmentInterface::DELIVERY_ADJUSTMENT => array_values($deliveryAdjustments)
+            AdjustmentInterface::DELIVERY_ADJUSTMENT => array_values($deliveryAdjustments),
+            AdjustmentInterface::DELIVERY_PROMOTION_ADJUSTMENT => array_values($deliveryPromotionAdjustments)
         ];
 
         $shippedAt = $object->getShippedAt();

--- a/src/AppBundle/Sylius/OrderProcessing/OrderFeeProcessor.php
+++ b/src/AppBundle/Sylius/OrderProcessing/OrderFeeProcessor.php
@@ -43,6 +43,11 @@ final class OrderFeeProcessor implements OrderProcessorInterface
         $customerAmount = $restaurant->getContract()->getCustomerAmount();
         $businessAmount = $restaurant->getContract()->getFlatDeliveryPrice();
 
+        $deliveryPromotionAdjustments = $order->getAdjustments(AdjustmentInterface::DELIVERY_PROMOTION_ADJUSTMENT);
+        foreach ($deliveryPromotionAdjustments as $deliveryPromotionAdjustment) {
+            $businessAmount += $deliveryPromotionAdjustment->getAmount();
+        }
+
         $feeAdjustment = $this->adjustmentFactory->createWithData(
             AdjustmentInterface::FEE_ADJUSTMENT,
             $this->translator->trans('order.adjustment_type.platform_fees'),

--- a/src/AppBundle/Sylius/OrderProcessing/OrderPromotionProcessor.php
+++ b/src/AppBundle/Sylius/OrderProcessing/OrderPromotionProcessor.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AppBundle\Sylius\OrderProcessing;
+
+use AppBundle\Sylius\Order\OrderInterface;
+use Sylius\Component\Order\Model\OrderInterface as BaseOrderInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\Component\Promotion\Processor\PromotionProcessorInterface;
+use Webmozart\Assert\Assert;
+
+/**
+ * @see https://github.com/Sylius/Sylius/blob/500f0a9870667c5751d59ff0d9bf4e4227548aed/src/Sylius/Component/Core/OrderProcessing/OrderPromotionProcessor.php
+ */
+final class OrderPromotionProcessor implements OrderProcessorInterface
+{
+    private $promotionProcessor;
+
+    public function __construct(
+        PromotionProcessorInterface $promotionProcessor)
+    {
+        $this->promotionProcessor = $promotionProcessor;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function process(BaseOrderInterface $order): void
+    {
+        Assert::isInstanceOf($order, OrderInterface::class);
+
+        $this->promotionProcessor->process($order);
+    }
+}

--- a/src/AppBundle/Sylius/Promotion/Modifier/OrderPromotionsUsageModifier.php
+++ b/src/AppBundle/Sylius/Promotion/Modifier/OrderPromotionsUsageModifier.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace AppBundle\Sylius\Promotion\Modifier;
+
+use Sylius\Component\Order\Model\OrderInterface;
+
+/**
+ * @see https://github.com/Sylius/Sylius/blob/60134b783c51c4b9da0b58c5a54482824a8baf8a/src/Sylius/Component/Core/Promotion/Modifier/OrderPromotionsUsageModifier.php
+ */
+final class OrderPromotionsUsageModifier
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function increment(OrderInterface $order): void
+    {
+        foreach ($order->getPromotions() as $promotion) {
+            $promotion->incrementUsed();
+        }
+
+        $promotionCoupon = $order->getPromotionCoupon();
+        if (null !== $promotionCoupon) {
+            $promotionCoupon->incrementUsed();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function decrement(OrderInterface $order): void
+    {
+        foreach ($order->getPromotions() as $promotion) {
+            $promotion->decrementUsed();
+        }
+
+        $promotionCoupon = $order->getPromotionCoupon();
+        if (null !== $promotionCoupon) {
+            $promotionCoupon->decrementUsed();
+        }
+    }
+}


### PR DESCRIPTION
For now, we only support coupon-based promotions. 
A unique promotion `FREE_DELIVERY` is created by default. 
The admin interface is simplified and only allows to add coupons to the `FREE_DELIVERY` promotion. 

**TODO**

- [x] Add per-customer usage limit (see [PromotionCouponPerCustomerUsageLimitEligibilityChecker](https://github.com/Sylius/Sylius/blob/master/src/Sylius/Component/Core/Promotion/Checker/Eligibility/PromotionCouponPerCustomerUsageLimitEligibilityChecker.php))
- [x] Increment usage of promotion
- [x] Confirmation flash message appears even when coupon is not eligible 25ba673910cff73c63a36ab7a9b97a629625c26a

<img width="1152" alt="Capture d’écran 2019-04-11 à 14 40 39" src="https://user-images.githubusercontent.com/1162230/55957932-cfd8f580-5c67-11e9-9aa6-c4f300a59ef3.png">
