### PR TITLE
Introduce configurable Time Slots

### DIFF
--- a/app/DoctrineMigrations/Version20190711184422.php
+++ b/app/DoctrineMigrations/Version20190711184422.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190711184422 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE TABLE time_slot (id SERIAL NOT NULL, name VARCHAR(255) NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE TABLE time_slot_choice (id SERIAL NOT NULL, time_slot_id INT DEFAULT NULL, start_time VARCHAR(255) NOT NULL, end_time VARCHAR(255) NOT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_179BD679D62B0FA ON time_slot_choice (time_slot_id)');
+        $this->addSql('ALTER TABLE time_slot_choice ADD CONSTRAINT FK_179BD679D62B0FA FOREIGN KEY (time_slot_id) REFERENCES time_slot (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE time_slot_choice DROP CONSTRAINT FK_179BD679D62B0FA');
+        $this->addSql('DROP TABLE time_slot');
+        $this->addSql('DROP TABLE time_slot_choice');
+    }
+}

--- a/app/DoctrineMigrations/Version20190711205815.php
+++ b/app/DoctrineMigrations/Version20190711205815.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20190711205815 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE store ADD time_slot_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE store ADD CONSTRAINT FK_FF575877D62B0FA FOREIGN KEY (time_slot_id) REFERENCES time_slot (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_FF575877D62B0FA ON store (time_slot_id)');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('ALTER TABLE store DROP CONSTRAINT FK_FF575877D62B0FA');
+        $this->addSql('DROP INDEX IDX_FF575877D62B0FA');
+        $this->addSql('ALTER TABLE store DROP time_slot_id');
+    }
+}

--- a/app/config/services/forms.yml
+++ b/app/config/services/forms.yml
@@ -39,12 +39,20 @@ services:
       - { name: form.type }
 
   AppBundle\Form\DeliveryType:
-    arguments: [ '@routing_service', '@translator' ]
+    arguments:
+      $routing: '@routing_service'
+      $translator: '@translator'
+      $country: '%country_iso%'
+      $locale: '%kernel.default_locale%'
     tags:
       - { name: form.type }
 
   AppBundle\Form\DeliveryEmbedType:
-    arguments: [ '@routing_service', '@coopcycle.settings_manager', '@translator', '%country_iso%' ]
+    parent: AppBundle\Form\DeliveryType
+    autowire: false
+    autoconfigure: false
+    arguments:
+      $settingsManager: '@coopcycle.settings_manager'
     tags: [ form.type ]
 
   AppBundle\Form\OrderType:

--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,8 @@
         "nyholm/psr7": "^1.1",
         "hwi/oauth-bundle": "dev-master",
         "php-http/httplug-bundle": "^1.16",
-        "m6web/daemon-bundle": "^4.1"
+        "m6web/daemon-bundle": "^4.1",
+        "azuyalabs/yasumi": "^2.1"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^4.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd51684ff270704e9da7a7a1b8b46b4d",
+    "content-hash": "07561bf53670ab4a68765b7cc94cd0bf",
     "packages": [
         {
             "name": "api-platform/core",
@@ -149,6 +149,59 @@
                 "swagger"
             ],
             "time": "2019-06-22T10:48:51+00:00"
+        },
+        {
+            "name": "azuyalabs/yasumi",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/azuyalabs/yasumi.git",
+                "reference": "5a086db23204e8ec45d874839ad9b1bb783dcbb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/azuyalabs/yasumi/zipball/5a086db23204e8ec45d874839ad9b1bb783dcbb8",
+                "reference": "5a086db23204e8ec45d874839ad9b1bb783dcbb8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.14",
+                "fzaninotto/faker": "~1.8",
+                "mikey179/vfsstream": "~1.6",
+                "phpunit/phpunit": "~7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Yasumi\\": "src/Yasumi/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sacha Telgenhof",
+                    "email": "me@sachatelgenhof.com"
+                }
+            ],
+            "description": "Yasumi is an easy PHP Library for calculating national holidays.",
+            "keywords": [
+                "Bank",
+                "calculation",
+                "calendar",
+                "celebration",
+                "date",
+                "holiday",
+                "holidays",
+                "national",
+                "time"
+            ],
+            "time": "2019-03-29T03:04:45+00:00"
         },
         {
             "name": "beberlei/assert",

--- a/js/app/forms/delivery.js
+++ b/js/app/forms/delivery.js
@@ -59,13 +59,18 @@ function createAddressWidget(name, type, cb) {
 }
 
 function createDatePickerWidget(name, type, cb) {
-  new DateTimePicker(document.querySelector(`#${name}_${type}_doneBefore_widget`), {
-    defaultValue: document.querySelector(`#${name}_${type}_doneBefore`).value,
-    onChange: function(date) {
-      document.querySelector(`#${name}_${type}_doneBefore`).value = date.format('YYYY-MM-DD HH:mm:ss')
-      cb(type, date)
-    }
-  })
+
+  const el = document.querySelector(`#${name}_${type}_doneBefore`)
+
+  if (el) {
+    new DateTimePicker(document.querySelector(`#${name}_${type}_doneBefore_widget`), {
+      defaultValue: el.value,
+      onChange: function(date) {
+        el.value = date.format('YYYY-MM-DD HH:mm:ss')
+        cb(type, date)
+      }
+    })
+  }
 }
 
 function createTagsWidget(name, type, tags) {

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -20,6 +20,7 @@ use AppBundle\Entity\Restaurant\Pledge;
 use AppBundle\Entity\Delivery\PricingRuleSet;
 use AppBundle\Entity\Restaurant;
 use AppBundle\Entity\Store;
+use AppBundle\Entity\TimeSlot;
 use AppBundle\Entity\Tag;
 use AppBundle\Entity\Task;
 use AppBundle\Entity\Zone;
@@ -36,6 +37,7 @@ use AppBundle\Form\MaintenanceType;
 use AppBundle\Form\SettingsType;
 use AppBundle\Form\StripeLivemodeType;
 use AppBundle\Form\Sylius\Promotion\CreditNoteType;
+use AppBundle\Form\TimeSlotType;
 use AppBundle\Form\TaxationType;
 use AppBundle\Form\ZoneCollectionType;
 use AppBundle\Service\ActivityManager;
@@ -1352,7 +1354,7 @@ class AdminController extends Controller
         ]);
     }
 
-     /**
+    /**
      * @Route("/admin/restaurants/pledges/{id}/emails", name="admin_pledge_email_preview")
      */
     public function pledgeEmailPreviewAction($id, Request $request, EmailManager $emailManager)
@@ -1373,5 +1375,40 @@ class AdminController extends Controller
         $response->setContent($message->getBody());
 
         return $response;
+    }
+
+    /**
+     * @Route("/admin/settings/time-slots", name="admin_time_slots")
+     */
+    public function timeSlotsAction(Request $request)
+    {
+        $timeSlots = $this->getDoctrine()->getRepository(TimeSlot::class)->findAll();
+
+        return $this->render('@App/admin/time_slots.html.twig', [
+            'time_slots' => $timeSlots,
+        ]);
+    }
+
+    /**
+     * @Route("/admin/settings/time-slots/new", name="admin_new_time_slot")
+     */
+    public function newTimeSlotAction(Request $request, ObjectManager $objectManager)
+    {
+        $timeSlot = new TimeSlot();
+
+        $form = $this->createForm(TimeSlotType::class, $timeSlot);
+
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+
+            $objectManager->persist($timeSlot);
+            $objectManager->flush();
+
+            return $this->redirectToRoute('admin_time_slots');
+        }
+
+        return $this->render('@App/admin/time_slot.html.twig', [
+            'form' => $form->createView(),
+        ]);
     }
 }

--- a/src/AppBundle/Entity/Store.php
+++ b/src/AppBundle/Entity/Store.php
@@ -100,6 +100,8 @@ class Store extends LocalBusiness
 
     private $addresses;
 
+    private $timeSlot;
+
     public function __construct() {
         $this->deliveries = new ArrayCollection();
         $this->owners = new ArrayCollection();
@@ -308,5 +310,17 @@ class Store extends LocalBusiness
         $this->getAddresses()->add($address);
 
         return $this;
+    }
+
+    public function setTimeSlot($timeSlot)
+    {
+        $this->timeSlot = $timeSlot;
+
+        return $this;
+    }
+
+    public function getTimeSlot()
+    {
+        return $this->timeSlot;
     }
 }

--- a/src/AppBundle/Entity/TimeSlot.php
+++ b/src/AppBundle/Entity/TimeSlot.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace AppBundle\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Gedmo\Timestampable\Traits\Timestampable;
+
+class TimeSlot
+{
+    use Timestampable;
+
+    private $id;
+    private $name;
+    private $choices;
+
+    public function __construct()
+    {
+    	$this->choices = new ArrayCollection();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param mixed $name
+     *
+     * @return self
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getChoices()
+    {
+        $iterator = $this->choices->getIterator();
+        $iterator->uasort(function ($a, $b) {
+
+            $date = new \DateTime();
+
+            [ $startA ] = $a->toDateTime($date);
+            [ $startB ] = $b->toDateTime($date);
+
+            return ($startA < $startB) ? -1 : 1;
+        });
+
+        return new ArrayCollection(iterator_to_array($iterator));
+    }
+
+    /**
+     * @param mixed $choices
+     *
+     * @return self
+     */
+    public function setChoices($choices)
+    {
+        $this->choices = $choices;
+
+        return $this;
+    }
+
+    public function addChoice($choice)
+    {
+        $choice->setTimeSlot($this);
+
+        $this->choices->add($choice);
+    }
+
+    public function removeChoice($choice)
+    {
+        $this->choices->removeElement($choice);
+    }
+}

--- a/src/AppBundle/Entity/TimeSlot/Choice.php
+++ b/src/AppBundle/Entity/TimeSlot/Choice.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace AppBundle\Entity\TimeSlot;
+
+use AppBundle\Entity\Task;
+use Carbon\Carbon;
+use Gedmo\Timestampable\Traits\Timestampable;
+
+class Choice
+{
+    use Timestampable;
+
+    private $id;
+    private $timeSlot;
+    private $startTime;
+    private $endTime;
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTimeSlot()
+    {
+        return $this->timeSlot;
+    }
+
+    /**
+     * @param mixed $timeSlot
+     *
+     * @return self
+     */
+    public function setTimeSlot($timeSlot)
+    {
+        $this->timeSlot = $timeSlot;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getStartTime()
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * @param mixed $startTime
+     *
+     * @return self
+     */
+    public function setStartTime($startTime)
+    {
+        $this->startTime = $startTime;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getEndTime()
+    {
+        return $this->endTime;
+    }
+
+    /**
+     * @param mixed $endTime
+     *
+     * @return self
+     */
+    public function setEndTime($endTime)
+    {
+        $this->endTime = $endTime;
+
+        return $this;
+    }
+
+    public function apply(Task $task, \DateTime $date = null)
+    {
+        [ $start, $end ] = $this->toDateTime($date);
+
+        $task->setDoneAfter($start);
+        $task->setDoneBefore($end);
+    }
+
+    public function toDateTime(\DateTime $date = null)
+    {
+        if (null === $date) {
+            $date = Carbon::now();
+        }
+
+        [ $startHour, $startMinute ] = explode(':', $this->getStartTime());
+        [ $endHour, $endMinute ] = explode(':', $this->getEndTime());
+
+        $after = clone $date;
+        $before = clone $date;
+
+        $after->setTime($startHour, $startMinute);
+        $before->setTime($endHour, $endMinute);
+
+        return [ $after, $before ];
+    }
+}

--- a/src/AppBundle/Form/DeliveryEmbedType.php
+++ b/src/AppBundle/Form/DeliveryEmbedType.php
@@ -19,18 +19,17 @@ use Symfony\Component\Translation\TranslatorInterface;
 class DeliveryEmbedType extends DeliveryType
 {
     private $settingsManager;
-    private $countryCode;
 
     public function __construct(
         RoutingInterface $routing,
-        SettingsManager $settingsManager,
         TranslatorInterface $translator,
-        $countryCode)
+        string $country,
+        string $locale,
+        SettingsManager $settingsManager)
     {
-        parent::__construct($routing, $translator);
+        parent::__construct($routing, $translator, $country, $locale);
 
         $this->settingsManager = $settingsManager;
-        $this->countryCode = $countryCode;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -56,7 +55,7 @@ class DeliveryEmbedType extends DeliveryType
             ->add('telephone', PhoneNumberType::class, [
                 'mapped' => false,
                 'format' => PhoneNumberFormat::NATIONAL,
-                'default_region' => strtoupper($this->countryCode),
+                'default_region' => strtoupper($this->country),
                 'label' => 'form.delivery_embed.telephone.label',
             ])
             ->add('billingAddress', AddressType::class, [

--- a/src/AppBundle/Form/StoreType.php
+++ b/src/AppBundle/Form/StoreType.php
@@ -2,8 +2,9 @@
 
 namespace AppBundle\Form;
 
-use AppBundle\Entity\Store;
 use AppBundle\Entity\Delivery\PricingRuleSet;
+use AppBundle\Entity\Store;
+use AppBundle\Entity\TimeSlot;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
@@ -43,6 +44,12 @@ class StoreType extends LocalBusinessType
                 ])
                 ->add('createOrders', CheckboxType::class, [
                     'label' => 'form.store_type.create_orders.label',
+                    'required' => false,
+                ])
+                ->add('timeSlot', EntityType::class, [
+                    'label' => 'form.store_type.time_slot.label',
+                    'class' => TimeSlot::class,
+                    'choice_label' => 'name',
                     'required' => false,
                 ]);
 

--- a/src/AppBundle/Form/TimeSlotChoiceType.php
+++ b/src/AppBundle/Form/TimeSlotChoiceType.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Entity\TimeSlot\Choice as TimeSlotChoice;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TimeType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TimeSlotChoiceType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('startTime', TimeType::class, [
+            	'label' => 'form.time_slot_choice.start_time.label',
+                'input' => 'string'
+            ])
+            ->add('endTime', TimeType::class, [
+            	'label' => 'form.time_slot_choice.end_time.label',
+                'input' => 'string'
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => TimeSlotChoice::class,
+        ));
+    }
+}

--- a/src/AppBundle/Form/TimeSlotType.php
+++ b/src/AppBundle/Form/TimeSlotType.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Entity\TimeSlot;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class TimeSlotType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('name', TextType::class, [
+            	'label' => 'form.time_slot.name.label'
+            ])
+            ->add('choices', CollectionType::class, [
+                'entry_type' => TimeSlotChoiceType::class,
+                'entry_options' => ['label' => false],
+                'label' => 'form.time_slot.choices.label',
+                'allow_add' => true,
+                'allow_delete' => true,
+                'by_reference' => false,
+		    ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => TimeSlot::class,
+        ));
+    }
+}

--- a/src/AppBundle/Resources/config/doctrine/Store.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/Store.orm.yml
@@ -83,6 +83,14 @@ AppBundle\Entity\Store:
             joinColumns:
                 pricing_rule_set_id:
                     referencedColumnName: id
+        timeSlot:
+            targetEntity: AppBundle\Entity\TimeSlot
+            cascade:
+                - persist
+            fetch: LAZY
+            joinColumns:
+                time_slot_id:
+                    referencedColumnName: id
     manyToMany:
         owners:
             targetEntity: AppBundle\Entity\ApiUser

--- a/src/AppBundle/Resources/config/doctrine/TimeSlot.Choice.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/TimeSlot.Choice.orm.yml
@@ -1,0 +1,35 @@
+AppBundle\Entity\TimeSlot\Choice:
+    type: entity
+    table: time_slot_choice
+    id:
+        id:
+            type: integer
+            id: true
+            generator:
+                strategy: IDENTITY
+    fields:
+        startTime:
+            type: string
+            column: start_time
+        endTime:
+            type: string
+            column: end_time
+        createdAt:
+            type: datetime
+            column: created_at
+            gedmo:
+                timestampable:
+                    on: create
+        updatedAt:
+            type: datetime
+            column: updated_at
+            gedmo:
+                timestampable:
+                    on: update
+    manyToOne:
+        timeSlot:
+            targetEntity: AppBundle\Entity\TimeSlot
+            joinColumns:
+                time_slot_id:
+                    referencedColumnName: id
+                    nullable: true

--- a/src/AppBundle/Resources/config/doctrine/TimeSlot.orm.yml
+++ b/src/AppBundle/Resources/config/doctrine/TimeSlot.orm.yml
@@ -1,0 +1,30 @@
+AppBundle\Entity\TimeSlot:
+    type: entity
+    table: time_slot
+    id:
+        id:
+            type: integer
+            id: true
+            generator:
+                strategy: IDENTITY
+    fields:
+        name:
+            type: string
+        createdAt:
+            type: datetime
+            column: created_at
+            gedmo:
+                timestampable:
+                    on: create
+        updatedAt:
+            type: datetime
+            column: updated_at
+            gedmo:
+                timestampable:
+                    on: update
+    oneToMany:
+        choices:
+            targetEntity: AppBundle\Entity\TimeSlot\Choice
+            mappedBy: timeSlot
+            cascade:
+                - all

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -117,6 +117,7 @@ adminDashboard.back.title: Back to website
 adminDashboard.promotions.title: Promotions
 
 adminDashboard.pledges.title: Suggestions
+adminDashboard.time_slots.title: Time slots
 
 deliveryForm.noPriceWarning: No price could be calculated. Please enter it.
 deliveryForm.noPriceFromPricingWarning: No price could be calculated from the pricing. Please enter it manually or edit the pricing.
@@ -573,6 +574,9 @@ form.credit_note.name.help: The name of the promotion that will be displayed in 
 form.resend_confirmation_email.submit.label: Send email again
 
 form.embed_settings.with_vehicle.label: Add vehicle choice
+
+form.time_slot.name.label: Name
+form.time_slot.choices.label: Choices
 
 promotion_coupon.used.label: Number of uses
 

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -346,6 +346,7 @@ form.delivery.vehicle.VEHICLE_CARGO_BIKE: Cargo bike
 form.store_type.pricing_rule_set.placeholder: Choose a pricing
 form.store_type.setAsDefault.label: Set as default address
 form.store_type.defaultAddress.label: Default Address
+form.store_type.time_slot.label: Time slot
 form.delivery.vehicle.placeholder: Choose a vehicle type
 form.delivery.pickup.label: Pickup
 form.delivery.dropoff.label: Dropoff

--- a/src/AppBundle/Resources/translations/messages.en.yml
+++ b/src/AppBundle/Resources/translations/messages.en.yml
@@ -578,6 +578,8 @@ form.embed_settings.with_vehicle.label: Add vehicle choice
 
 form.time_slot.name.label: Name
 form.time_slot.choices.label: Choices
+form.time_slot_choice.start_time.label: Start time
+form.time_slot_choice.end_time.label: End time
 
 promotion_coupon.used.label: Number of uses
 
@@ -748,6 +750,8 @@ restricted_diets.LOW_LACTOSE_DIET: Low lactose
 restricted_diets.LOW_SALT_DIET: Low salt
 restricted_diets.VEGAN_DIET: Vegan
 restricted_diets.VEGETARIAN_DIET: Vegetarian
+
+time_slot.human_readable: '%day% between %start% and %end%'
 
 resend_confirmation_email.disclaimer: If you have not received the confirmation email, click on the button.
 

--- a/src/AppBundle/Resources/translations/messages.fr.yml
+++ b/src/AppBundle/Resources/translations/messages.fr.yml
@@ -352,6 +352,7 @@ form.delivery.price.label: Prix
 form.delivery.to_be_confirmed.warning: Vous devez confirmer la commande
 form.delivery.has_order.info: Cette livraison est liée à une commande
 form.delivery.view_order: Voir la commande
+form.delivery.time_slot.label: Tranche horaire
 form.order.accept.label: Accepter
 form.order.accept.help: Lorsque vous aurez accepté la commande, le client sera notifié
   par email.
@@ -592,6 +593,11 @@ form.embed_settings.with_vehicle.label: Ajouter le choix du type de véhicule
 
 form.resend_confirmation_email.submit.label: Renvoyer l'email
 
+form.time_slot.name.label: Nom
+form.time_slot.choices.label: Plages horaires
+form.time_slot_choice.start_time.label: Date de début
+form.time_slot_choice.end_time.label: Date de fin
+
 promotion_coupon.used.label: Nombre d'utilisations
 
 product_option.strategy.free: Gratuit
@@ -805,6 +811,8 @@ restricted_diets.LOW_LACTOSE_DIET: Sans lactose
 restricted_diets.LOW_SALT_DIET: Sans sel
 restricted_diets.VEGAN_DIET: Vegan
 restricted_diets.VEGETARIAN_DIET: Végétarien
+
+time_slot.human_readable: '%day% entre %start% et %end%'
 
 resend_confirmation_email.disclaimer: Vous n'avez pas l'email de confirmation ? Cliquez sur le bouton ci-dessous.
 

--- a/src/AppBundle/Resources/views/admin/nav.html.twig
+++ b/src/AppBundle/Resources/views/admin/nav.html.twig
@@ -75,6 +75,7 @@
             <li><a href="{{ path('admin_promotions') }}">{% trans %}adminDashboard.promotions.title{% endtrans %}</a></li>
             <li><a href="{{ path('admin_api_apps') }}">API</a></li>
             <li><a href="{{ path('admin_restaurants_pledges') }}">{% trans %}adminDashboard.pledges.title{% endtrans %}</a></li>
+            <li><a href="{{ path('admin_time_slots') }}">{% trans %}adminDashboard.time_slots.title{% endtrans %}</a></li>
           </ul>
         </li>
         {% include '@App/_partials/user/account_dropdown.html.twig' %}

--- a/src/AppBundle/Resources/views/admin/time_slot.html.twig
+++ b/src/AppBundle/Resources/views/admin/time_slot.html.twig
@@ -1,0 +1,59 @@
+{% extends "@App/admin.html.twig" %}
+
+{% form_theme form '@App/form/time_slot.html.twig' %}
+
+{% block breadcrumb %}
+  {% set time_slot = form.vars.value %}
+  <li><a href="{{ path('admin_time_slots') }}">{% trans %}adminDashboard.time_slots.title{% endtrans %}</a></li>
+  {% if time_slot.id is not null %}
+  <li>#{{ time_slot.id }}</li>
+  {% else %}
+  <li>{{ 'basics.add'|trans }}</li>
+  {% endif %}
+{% endblock %}
+
+{% block content %}
+{{ form_start(form) }}
+  {{ form_widget(form) }}
+  <button type="submit" class="btn btn-block btn-primary">
+    {{ 'basics.save'|trans }}
+  </button>
+{{ form_end(form) }}
+{% endblock %}
+
+{% block scripts %}
+<script>
+var $collectionHolder;
+
+var $addTagButton = $('<button type="button" class="btn btn-success"><i class="fa fa-plus"></i>  {{ 'basics.add'|trans }}</button>');
+var $newLinkLi = $('<div></div>').append($addTagButton);
+
+function addTagForm($collectionHolder, $newLinkLi) {
+    var prototype = $collectionHolder.data('prototype');
+
+    var index = $collectionHolder.data('index');
+
+    var newForm = prototype;
+
+    newForm = newForm.replace(/__name__/g, index);
+
+    $collectionHolder.data('index', index + 1);
+
+    var $newFormLi = $('<div></div>').append(newForm);
+    $newLinkLi.before($newFormLi);
+}
+
+$(document).ready(function() {
+    $collectionHolder = $('#time_slot_choices');
+
+    $collectionHolder.append($newLinkLi);
+
+    $collectionHolder.data('index', $collectionHolder.find(':input').length);
+
+    $addTagButton.on('click', function(e) {
+        addTagForm($collectionHolder, $newLinkLi);
+    });
+});
+</script>
+{% endblock %}
+

--- a/src/AppBundle/Resources/views/admin/time_slots.html.twig
+++ b/src/AppBundle/Resources/views/admin/time_slots.html.twig
@@ -1,0 +1,40 @@
+{% extends "@App/admin.html.twig" %}
+
+{% block breadcrumb %}
+  <li>{% trans %}adminDashboard.time_slots.title{% endtrans %}</li>
+{% endblock %}
+
+{% block content %}
+
+<p class="text-right">
+  <a href="{{ path('admin_new_time_slot') }}" class="btn btn-success">
+    <i class="fa fa-plus"></i> {{ 'basics.add'|trans }}
+  </a>
+</p>
+
+<table class="table table-condensed task-table">
+  <thead>
+    <th>#</th>
+    <th>{{ 'form.time_slot.name.label'|trans }}</th>
+    <th>{{ 'form.time_slot.choices.label'|trans }}</th>
+  </thead>
+  <tbody>
+  {% for time_slot in time_slots %}
+    <tr>
+      <td>
+        <a href="#">#{{ time_slot.id }}</a>
+      </td>
+      <td>
+        {{ time_slot.name }}
+      </td>
+      <td>
+        {% for choice in time_slot.choices %}
+          <small>{{ choice.startTime }} - {{ choice.endTime }}</small>
+        {% endfor %}
+      </td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+
+{% endblock %}

--- a/src/AppBundle/Resources/views/delivery/form.html.twig
+++ b/src/AppBundle/Resources/views/delivery/form.html.twig
@@ -97,11 +97,21 @@
 
         {{ form_errors(form) }}
 
+        {% if form.timeSlot is defined %}
+          <div class="form-group">
+            {{ form_label(form.timeSlot) }}
+            <div class="col-sm-9">
+              {{ form_widget(form.timeSlot) }}
+            </div>
+          </div>
+
+        {% endif %}
+
         <div class="form-group">
-          <label class="col-sm-2 control-label" for="delivery_distance">
+          <label class="col-sm-3 control-label" for="delivery_distance">
             {% trans %}form.delivery.distance.label{% endtrans %}
           </label>
-          <div class="col-sm-10">
+          <div class="col-sm-9">
             <p class="form-control-static">
               <span id="delivery_distance">
                 {% if delivery.distance is not empty %}
@@ -113,10 +123,10 @@
         </div>
 
         <div class="form-group">
-          <label class="col-sm-2 control-label" for="delivery_duration">
+          <label class="col-sm-3 control-label" for="delivery_duration">
             {% trans %}form.delivery.duration.label{% endtrans %}
           </label>
-          <div class="col-sm-10">
+          <div class="col-sm-9">
             <p class="form-control-static">
               <span id="delivery_duration">
                 {% if delivery.duration is not empty %}

--- a/src/AppBundle/Resources/views/form/delivery.html.twig
+++ b/src/AppBundle/Resources/views/form/delivery.html.twig
@@ -37,7 +37,10 @@ col-sm-9
 {% block task_widget %}
 
   {{ form_row(form.address.streetAddress, { label: false }) }}
-  {{ form_row(form.doneBefore, { label: 'form.delivery.' ~ form.vars.name ~ '.doneBefore.label' }) }}
+
+  {% if form.doneBefore is defined %}
+    {{ form_row(form.doneBefore, { label: 'form.delivery.' ~ form.vars.name ~ '.doneBefore.label' }) }}
+  {% endif %}
 
   {{ form_row(form.address.postalCode) }}
   {{ form_row(form.address.addressLocality) }}
@@ -58,7 +61,10 @@ col-sm-9
   {{ form_widget(form.address.longitude) }}
   {{ form_widget(form.address.id) }}
   {{ form_widget(form.type) }}
-  {{ form_widget(form.doneAfter) }}
+
+  {% if form.doneAfter is defined %}
+    {{ form_widget(form.doneAfter) }}
+  {% endif %}
 
 {% endblock %}
 

--- a/src/AppBundle/Resources/views/form/time_slot.html.twig
+++ b/src/AppBundle/Resources/views/form/time_slot.html.twig
@@ -1,0 +1,13 @@
+{% extends 'bootstrap_3_layout.html.twig' %}
+
+{% block _time_slot_choices_entry_row %}
+  <div class="row">
+    <div class="col-sm-6">
+      {{ form_row(form.startTime) }}
+    </div>
+    <div class="col-sm-6">
+      {{ form_row(form.endTime) }}
+    </div>
+  </div>
+{% endblock %}
+

--- a/src/AppBundle/Resources/views/store/form.html.twig
+++ b/src/AppBundle/Resources/views/store/form.html.twig
@@ -79,6 +79,10 @@
     <hr>
   {% endif %}
 
+  {% if form.timeSlot is defined %}
+    {{ form_row(form.timeSlot) }}
+  {% endif %}
+
   {% if form.address is defined %}
     {{ form_row(form.address.streetAddress) }}
     {{ form_row(form.address.postalCode) }}

--- a/src/AppBundle/Utils/TimeSlotChoiceWithDate.php
+++ b/src/AppBundle/Utils/TimeSlotChoiceWithDate.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace AppBundle\Utils;
+
+use AppBundle\Entity\TimeSlot\Choice;
+use Sylius\Component\Currency\Context\CurrencyContextInterface;
+
+class TimeSlotChoiceWithDate
+{
+    private $choice;
+    private $date;
+
+    public function __construct(Choice $choice, \DateTime $date)
+    {
+        $this->choice = $choice;
+        $this->date = $date;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getChoice()
+    {
+        return $this->choice;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    public function toDateTime()
+    {
+        return $this->choice->toDateTime($this->date);
+    }
+}

--- a/tests/AppBundle/Entity/TimeSlot/ChoiceTest.php
+++ b/tests/AppBundle/Entity/TimeSlot/ChoiceTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\AppBundle\Entity\TimeSlot;
+
+use AppBundle\Entity\Task;
+use AppBundle\Entity\TimeSlot\Choice as TimeSlotChoice;
+use AppBundle\Utils\TimeSlotChoiceWithDate;
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class ChoiceTest extends TestCase
+{
+    public function tearDown()
+    {
+        Carbon::setTestNow();
+    }
+
+    public function testToDateTime()
+    {
+        $choice = new TimeSlotChoice();
+        $choice->setStartTime('11:00:00');
+        $choice->setEndTime('12:00:00');
+
+        Carbon::setTestNow(Carbon::parse('2019-07-30'));
+        $dates = $choice->toDateTime();
+
+        $this->assertThat($dates, $this->isType('array'));
+        $this->assertCount(2, $dates);
+        $this->assertEquals(new \DateTime('2019-07-30 11:00:00'), $dates[0]);
+        $this->assertEquals(new \DateTime('2019-07-30 12:00:00'), $dates[1]);
+
+        $dates = $choice->toDateTime(new \DateTime('2019-07-29'));
+
+        $this->assertThat($dates, $this->isType('array'));
+        $this->assertCount(2, $dates);
+        $this->assertEquals(new \DateTime('2019-07-29 11:00:00'), $dates[0]);
+        $this->assertEquals(new \DateTime('2019-07-29 12:00:00'), $dates[1]);
+    }
+
+    public function testApply()
+    {
+        $choice = new TimeSlotChoice();
+        $choice->setStartTime('11:00:00');
+        $choice->setEndTime('12:00:00');
+
+        $task = new Task();
+
+        Carbon::setTestNow(Carbon::parse('2019-07-30'));
+        $dates = $choice->apply($task);
+
+        $this->assertEquals(new \DateTime('2019-07-30 11:00:00'), $task->getDoneAfter());
+        $this->assertEquals(new \DateTime('2019-07-30 12:00:00'), $task->getDoneBefore());
+
+        $dates = $choice->apply($task, new \DateTime('2019-07-29'));
+
+        $this->assertEquals(new \DateTime('2019-07-29 11:00:00'), $task->getDoneAfter());
+        $this->assertEquals(new \DateTime('2019-07-29 12:00:00'), $task->getDoneBefore());
+    }
+}

--- a/tests/AppBundle/Entity/TimeSlotTest.php
+++ b/tests/AppBundle/Entity/TimeSlotTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\AppBundle\Entity;
+
+use AppBundle\Entity\TimeSlot;
+use AppBundle\Entity\TimeSlot\Choice as TimeSlotChoice;
+use AppBundle\Utils\TimeSlotChoiceWithDate;
+use Carbon\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class TimeSlotTest extends TestCase
+{
+    public function tearDown()
+    {
+        Carbon::setTestNow();
+    }
+
+    public function testGetChoicesWithDatesOnSunday()
+    {
+        $choice1 = new TimeSlotChoice();
+        $choice1->setStartTime('11:00:00');
+        $choice1->setEndTime('12:00:00');
+
+        $slot = new TimeSlot();
+        $slot->addChoice($choice1);
+
+        // Sunday
+        Carbon::setTestNow(Carbon::parse('2019-07-28 19:00:00'));
+
+        $choicesWithDates = $slot->getChoicesWithDates('fr');
+
+        $this->assertCount(2, $choicesWithDates);
+
+        [ $choicesWithDate1, $choicesWithDate2 ] = $choicesWithDates;
+
+        $this->assertTimeSlotChoices(
+            new \DateTime('2019-07-29 11:00:00'),
+            new \DateTime('2019-07-29 12:00:00'),
+            $choicesWithDate1
+        );
+        $this->assertTimeSlotChoices(
+            new \DateTime('2019-07-30 11:00:00'),
+            new \DateTime('2019-07-30 12:00:00'),
+            $choicesWithDate2
+        );
+    }
+
+    public function testGetChoicesWithDatesOnMonday()
+    {
+        $choice1 = new TimeSlotChoice();
+        $choice1->setStartTime('11:00:00');
+        $choice1->setEndTime('12:00:00');
+
+        $slot = new TimeSlot();
+        $slot->addChoice($choice1);
+
+        // Monday
+        Carbon::setTestNow(Carbon::parse('2019-07-29 08:00:00'));
+
+        $choicesWithDates = $slot->getChoicesWithDates('fr');
+
+        $this->assertCount(2, $choicesWithDates);
+
+        [ $choicesWithDate1, $choicesWithDate2 ] = $choicesWithDates;
+
+        $this->assertTimeSlotChoices(
+            new \DateTime('2019-07-29 11:00:00'),
+            new \DateTime('2019-07-29 12:00:00'),
+            $choicesWithDate1
+        );
+        $this->assertTimeSlotChoices(
+            new \DateTime('2019-07-30 11:00:00'),
+            new \DateTime('2019-07-30 12:00:00'),
+            $choicesWithDate2
+        );
+    }
+
+    public function testGetChoicesWithDatesOnMondayTooLate()
+    {
+        $choice1 = new TimeSlotChoice();
+        $choice1->setStartTime('11:00:00');
+        $choice1->setEndTime('12:00:00');
+
+        $slot = new TimeSlot();
+        $slot->addChoice($choice1);
+
+        // Monday
+        Carbon::setTestNow(Carbon::parse('2019-07-29 13:00:00'));
+
+        $choicesWithDates = $slot->getChoicesWithDates('fr');
+
+        $this->assertCount(2, $choicesWithDates);
+
+        [ $choicesWithDate1, $choicesWithDate2 ] = $choicesWithDates;
+
+        $this->assertTimeSlotChoices(
+            new \DateTime('2019-07-30 11:00:00'),
+            new \DateTime('2019-07-30 12:00:00'),
+            $choicesWithDate1
+        );
+        $this->assertTimeSlotChoices(
+            new \DateTime('2019-07-31 11:00:00'),
+            new \DateTime('2019-07-31 12:00:00'),
+            $choicesWithDate2
+        );
+    }
+
+    public function testGetChoicesWithDatesOnDayBeforeBankHoliday()
+    {
+        $choice1 = new TimeSlotChoice();
+        $choice1->setStartTime('11:00:00');
+        $choice1->setEndTime('12:00:00');
+
+        $slot = new TimeSlot();
+        $slot->addChoice($choice1);
+
+        // Day befoe bank holiday
+        Carbon::setTestNow(Carbon::parse('2019-08-14 13:00:00'));
+
+        $choicesWithDates = $slot->getChoicesWithDates('fr');
+
+        $this->assertCount(2, $choicesWithDates);
+
+        [ $choicesWithDate1, $choicesWithDate2 ] = $choicesWithDates;
+
+        $this->assertTimeSlotChoices(
+            new \DateTime('2019-08-16 11:00:00'),
+            new \DateTime('2019-08-16 12:00:00'),
+            $choicesWithDate1
+        );
+        $this->assertTimeSlotChoices(
+            new \DateTime('2019-08-19 11:00:00'),
+            new \DateTime('2019-08-19 12:00:00'),
+            $choicesWithDate2
+        );
+    }
+
+    private function assertTimeSlotChoices(\DateTime $start, \DateTime $end, TimeSlotChoiceWithDate $timeSlotChoice)
+    {
+        [ $choiceWithDateStart, $choiceWithDateEnd ] = $timeSlotChoice->toDateTime();
+
+        $this->assertEquals($start, $choiceWithDateStart);
+        $this->assertEquals($end, $choiceWithDateEnd);
+    }
+}


### PR DESCRIPTION
See #594

This pull request introduces a **fairly simple** mechanism to create time slots. 

A time slot is just a list of time choices.

<img width="633" alt="Capture d’écran 2019-07-30 à 22 09 36" src="https://user-images.githubusercontent.com/1162230/62161545-c5299580-b316-11e9-81e5-50705fd68993.png">

Time slots can be linked to stores. 
If a store is configured with a time slot (optional), then time slots are proposed instead of free time choice.

<img width="630" alt="Capture d’écran 2019-07-30 à 22 11 15" src="https://user-images.githubusercontent.com/1162230/62161661-00c45f80-b317-11e9-86cc-4dfcd87c6fe2.png">

The time slot choices are aware of the working days.

