### PR TITLE
Add CSV delimiter detection and set delimiter for CSV reader

### DIFF
--- a/src/AppBundle/Utils/TaskSpreadsheetParser.php
+++ b/src/AppBundle/Utils/TaskSpreadsheetParser.php
@@ -165,7 +165,7 @@ class TaskSpreadsheetParser
         $mimeType = mime_content_type($filename);
 
         if (in_array($mimeType, self::MIME_TYPE_CSV)) {
-            return ReaderEntityFactory::createCSVReader();
+            return $this->createCsvReader($filename);
         }
 
         if (in_array($mimeType, self::MIME_TYPE_ODS)) {
@@ -177,6 +177,34 @@ class TaskSpreadsheetParser
         }
 
         throw new \Exception('Unsupported file type');
+    }
+
+    private function createCsvReader($filename)
+    {
+        $csvReader = ReaderEntityFactory::createCSVReader();
+        $csvReader->setFieldDelimiter($this->getCsvDelimiter($filename));
+
+        return $csvReader;
+    }
+
+    private function getCsvDelimiter($filename)
+    {
+        $delimiters = array(
+            ';' => 0,
+            ',' => 0,
+            "\t" => 0,
+            '|' => 0,
+        );
+
+        $handle = fopen($filename, "r");
+        $firstLine = fgets($handle);
+        fclose($handle);
+
+        foreach ($delimiters as $delimiter => &$count) {
+            $count = count(str_getcsv($firstLine, $delimiter));
+        }
+
+        return array_search(max($delimiters), $delimiters);
     }
 
     private function validateHeader(array $header)

--- a/tests/AppBundle/Resources/spreadsheet/tasks.semicolon.csv
+++ b/tests/AppBundle/Resources/spreadsheet/tasks.semicolon.csv
@@ -1,0 +1,6 @@
+type;address.name;address.telephone;address.description;address.floor;address;after;before;comments;tags
+pickup;"Fleurs Express";"0650208634";"Digicode : 1234";"";"1; rue de Rivoli Paris";15/02/2018 12:00;15/02/2018 14:00;Call customer;important
+dropoff;"Pressing Presto";"0650208634";"";"";"54; rue du Faubourg Saint Denis Paris";2018-02-15 09:00;2018-02-15 10:00;;
+dropoff;"Bar du Coin";"0650208634";"";"";"23; rue du Faubourd du Temple Paris";09:00;12:00;;
+pickup;"Épicerie à domicile";"0650208634";"";"";"59; rue du Faubourg Saint Denis Paris";8h;10h;;
+dropoff;"Couture Illico";"0650208634";"";"";"67; boulevard du Temple Paris";15/02 09:00;15/02 12:00;;

--- a/tests/AppBundle/Utils/TaskSpreadsheetParserTest.php
+++ b/tests/AppBundle/Utils/TaskSpreadsheetParserTest.php
@@ -60,6 +60,16 @@ class TaskSpreadsheetParserTest extends TestCase
         $this->assertCount(5, $tasks);
     }
 
+    public function testCsvSemicolon()
+    {
+        $this->mockDependencies();
+
+        $filename = realpath(__DIR__ . '/../Resources/spreadsheet/tasks.semicolon.csv');
+        $tasks = $this->parser->parse($filename);
+
+        $this->assertCount(5, $tasks);
+    }
+
     public function testCsvWithGeocoderError()
     {
         $this->expectException(\Exception::class);


### PR DESCRIPTION
Fixes #734 

User request was that CSV files using semicolon as separator should be supported.
The [Spout Libary](https://github.com/box/spout) is used for reading CSV files, which is expecting the delimiter to be set if it is not comma (default).
I added a short logic to detect the delimiter (most used character in CSV headline) in the CSV file and setting the delimiter in the reader.
Test for CSV with semicolon was added.
The following separators are supported now and will be auto-detected: comma, semicolon, tab, pipe
