### PR TITLE
Fix Docker on Linux, introduce CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,29 @@
+version: 2
+jobs:
+  docker_compose:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - checkout
+      - run:
+          name: Pull containers
+          command: docker-compose pull
+      - run:
+          name: Build containers
+          command: docker-compose build
+      - run:
+          name: Start containers
+          command: docker-compose up -d
+          background: true
+      - run:
+          name: Wait for PHP-FPM
+          command: until docker inspect --format='{{ .State.Health.Status }}' $(docker-compose ps -q php) | grep -wq healthy; do sleep 5; done
+      - run:
+          name: Install app
+          command: make install
+
+workflows:
+  version: 2
+  docker_compose:
+    jobs:
+      - docker_compose

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,10 @@ install:
 	@docker-compose exec php php bin/console doctrine:migrations:version --no-interaction --quiet --add --all
 
 osrm:
-	@[ -d var/osrm ] || mkdir -p var/osrm
-	@wget https://coopcycle.org/osm/paris-france.osm.pbf -O var/osrm/data.osm.pbf
-	@docker-compose run osrm osrm-extract -p /opt/bicycle.lua /data/data.osm.pbf
-	@docker-compose run osrm osrm-partition /data/data.osrm
-	@docker-compose run osrm osrm-customize /data/data.osrm
+	@docker-compose run --rm osrm wget --no-check-certificate https://coopcycle.org/osm/paris-france.osm.pbf -O /data/data.osm.pbf
+	@docker-compose run --rm osrm osrm-extract -p /opt/bicycle.lua /data/data.osm.pbf
+	@docker-compose run --rm osrm osrm-partition /data/data.osrm
+	@docker-compose run --rm osrm osrm-customize /data/data.osrm
 
 phpunit:
 	@docker-compose exec php php bin/console doctrine:schema:update --env=test --force --no-interaction --quiet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,8 +72,8 @@ services:
       STRIPE_PUBLISHABLE_KEY: ${STRIPE_PUBLISHABLE_KEY}
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY}
     volumes:
-      - 'php_cache:/srv/coopcycle/var/cache'
-      - './:/srv/coopcycle:cached'
+      - 'php_cache:/var/www/html/var/cache'
+      - './:/var/www/html:cached'
     cap_add:
       - SYS_ADMIN
 
@@ -86,8 +86,8 @@ services:
       - '80:80'
     volumes:
       - './docker/nginx/conf.d:/etc/nginx/conf.d:ro'
-      - './web:/srv/coopcycle/web:ro'
-      - './vendor:/srv/coopcycle/vendor:ro'
+      - './web:/var/www/html/web:ro'
+      - './vendor:/var/www/html/vendor:ro'
 
   nginx_test:
     image: 'nginx:1.11-alpine'
@@ -98,8 +98,8 @@ services:
       - '9080:80'
     volumes:
       - './docker/nginx_test/conf.d:/etc/nginx/conf.d:ro'
-      - './web:/srv/coopcycle/web:ro'
-      - './vendor:/srv/coopcycle/vendor:ro'
+      - './web:/var/www/html/web:ro'
+      - './vendor:/var/www/html/vendor:ro'
 
   smtp:
     image: namshi/smtp

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -8,7 +8,7 @@ upstream tracking {
 
 server {
 
-    root /srv/coopcycle/web;
+    root /var/www/html/web;
 
     # prevents 502 bad gateway error
     large_client_header_buffers 8 32k;

--- a/docker/nginx_test/conf.d/default.conf
+++ b/docker/nginx_test/conf.d/default.conf
@@ -8,7 +8,7 @@ upstream tracking {
 
 server {
 
-    root /srv/coopcycle/web;
+    root /var/www/html/web;
 
     # prevents 502 bad gateway error
     large_client_header_buffers 8 32k;

--- a/docker/osrm/Dockerfile
+++ b/docker/osrm/Dockerfile
@@ -1,5 +1,9 @@
 FROM osrm/osrm-backend:v5.16.0
 
+# Fix "can't execute 'ssl_helper'"
+# https://github.com/Yelp/dumb-init/issues/73
+RUN apk --no-cache add openssl wget
+
 COPY ./start.sh /usr/local/bin/osrm-start
 
 RUN chmod +x /usr/local/bin/osrm-start

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -84,9 +84,6 @@ RUN chmod +x bin/demo
 ENV APP_ENV dev
 ENV APP_DEBUG 1
 
-# Needed to fix permissions error
-USER 82
-
 RUN composer global require "hirak/prestissimo"
 
 ENTRYPOINT ["docker-app-start"]

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -60,8 +60,6 @@ RUN set -xe \
     && mv composer.phar /usr/local/bin/composer \
     && apk del .fetch-deps
 
-WORKDIR /srv/coopcycle
-
 COPY composer.json ./
 COPY composer.lock ./
 

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -60,6 +60,21 @@ RUN set -xe \
     && mv composer.phar /usr/local/bin/composer \
     && apk del .fetch-deps
 
+# Add healthcheck for PHP-FPM
+# https://github.com/docker-library/php/issues/366
+# https://github.com/renatomefi/php-fpm-healthcheck
+
+RUN apk add --no-cache fcgi
+
+RUN set -xe && echo "pm.status_path = /status" >> /usr/local/etc/php-fpm.d/zz-docker.conf
+
+RUN wget -O /usr/local/bin/php-fpm-healthcheck \
+    https://raw.githubusercontent.com/renatomefi/php-fpm-healthcheck/master/php-fpm-healthcheck \
+    && chmod +x /usr/local/bin/php-fpm-healthcheck
+
+HEALTHCHECK \
+  CMD php-fpm-healthcheck || exit 1
+
 COPY composer.json ./
 COPY composer.lock ./
 


### PR DESCRIPTION
See #789 #436

On Linux, there are problems with the mounted volumes which lead to permission issues. 
Basically, the volumes are mounted as `root` on the host machine.
See moby/moby#2259 & #moby/moby#3124

This pull request is another attempt to fix this. 
- Use `/var/www/html` as the mount folder as in base PHP image (b35c8b0)
- Run PHP-FPM as `root` (c93f2d8)
- Stop creating directories from the host machine (8d9ed69)

Also, it uses CircleCI to test the Docker environment works