### PR TITLE
android: send both 'notification+data' and 'data-only' (notification) messages

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -499,6 +499,7 @@ services:
     arguments:
       $apns: "@apns_php.push"
       $apnsCertificatePassPhrase: "%apns_certificate_pass_phrase%"
+      $logger: "@logger"
 
   AppBundle\Service\Geocoder:
     arguments:

--- a/src/AppBundle/Service/RemotePushNotificationManager.php
+++ b/src/AppBundle/Service/RemotePushNotificationManager.php
@@ -7,22 +7,26 @@ use AppBundle\Entity\RemotePushToken;
 use Kreait\Firebase\Factory as FirebaseFactory;
 use Kreait\Firebase\Exception\ServiceAccountDiscoveryFailed;
 use Kreait\Firebase\Messaging\CloudMessage;
+use Psr\Log\LoggerInterface;
 
 class RemotePushNotificationManager
 {
     private $firebaseFactory;
     private $apns;
     private static $enabled = true;
+    private $logger;
 
     public function __construct(
         FirebaseFactory $firebaseFactory,
         \ApnsPHP_Push $apns,
-        string $apnsCertificatePassPhrase)
+        string $apnsCertificatePassPhrase,
+        LoggerInterface $logger)
     {
         $this->firebaseFactory = $firebaseFactory;
 
         $apns->setProviderCertificatePassphrase($apnsCertificatePassPhrase);
         $this->apns = $apns;
+        $this->logger = $logger;
     }
 
     public static function isEnabled()
@@ -43,7 +47,7 @@ class RemotePushNotificationManager
     /**
      * @see https://firebase.google.com/docs/cloud-messaging/http-server-ref
      */
-    private function fcm($message, array $tokens, $data)
+    private function fcm($notification, array $tokens, $data)
     {
         if (count($tokens) === 0) {
             return;
@@ -52,26 +56,26 @@ class RemotePushNotificationManager
         try {
             $firebaseMessaging = $this->firebaseFactory->createMessaging();
         } catch (ServiceAccountDiscoveryFailed $e) {
-            // TODO Log error
+            $this->logger->error($e);
             return;
         }
 
-
         // @see https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages
         // @see https://developer.android.com/guide/topics/ui/notifiers/notifications#ManageChannels
-        $payload = [
-            'android' => [
-                'priority' => 'high',
-                'notification' => [
-                    'sound' => 'default',
-                    'channel_id' => 'coopcycle_important',
-                ],
-            ],
-            'notification' => [
-                'title' => $message,
-                'body' => $message,
-            ],
+        $payload['android'] = [
+            'priority' => 'high'
         ];
+
+        if (null !== $notification) {
+            $payload['notification'] = [
+                'title' => $notification,
+                'body' => $notification,
+            ];
+            $payload['android']['notification'] = [
+                'sound' => 'default',
+                'channel_id' => 'coopcycle_important',
+            ];
+        }
 
         // TODO Make sure data are key/value pairs as strings
         if (!empty($data)) {
@@ -99,11 +103,11 @@ class RemotePushNotificationManager
         try {
             $firebaseMessaging->sendMulticast($message, $deviceTokens);
         } catch (\Exception $e) {
-            // TODO Log error
+            $this->logger->error($e);
         }
     }
 
-    private function apns($message, array $tokens, $data = [])
+    private function apns($text, array $tokens, $data = [])
     {
         if (count($tokens) === 0) {
             return;
@@ -113,7 +117,7 @@ class RemotePushNotificationManager
 
         // Instantiate a new Message with a single recipient
         $apnsMessage = new \ApnsPHP_Message();
-        $apnsMessage->setText($message);
+        $apnsMessage->setText($text);
         $apnsMessage->setSound();
 
         // Set a custom identifier. To get back this identifier use the getCustomIdentifier() method
@@ -151,10 +155,10 @@ class RemotePushNotificationManager
     }
 
     /**
-     * @param string $message
+     * @param string $textMessage
      * @param mixed $recipients
      */
-    public function send($message, $recipients, $data = [])
+    public function send($textMessage, $recipients, $data = [])
     {
         if (!is_array($recipients)) {
             $recipients = [ $recipients ];
@@ -185,7 +189,16 @@ class RemotePushNotificationManager
             return $token->getPlatform() === 'ios';
         });
 
-        $this->fcm($message, $fcmTokens, $data);
-        $this->apns($message, $apnsTokens, $data);
+        //todo temporary send both "notification+data" and "data-only" messages on android
+        // reasons:
+        // 1. backward compatibility with the old app-versions
+        // 2. app does not always handle the case when "notification+data" is delivered in
+        // the background
+        // when #2 is done and #1 is not relevant any more we should only send "data-only" messages
+
+        $this->fcm($textMessage, $fcmTokens, $data); // send "notification+data" message
+        $this->fcm(null, $fcmTokens, $data); // send "data-only" message
+
+        $this->apns($textMessage, $apnsTokens, $data);
     }
 }

--- a/src/AppBundle/Service/RemotePushNotificationManager.php
+++ b/src/AppBundle/Service/RemotePushNotificationManager.php
@@ -75,11 +75,19 @@ class RemotePushNotificationManager
                 'sound' => 'default',
                 'channel_id' => 'coopcycle_important',
             ];
+
+            if (!empty($data) && array_key_exists('event', $data)) {
+                $event = $data['event'];
+                if (!empty($event['name'])) {
+                    // set a tag, only one notification per tag could be shown
+                    // in the notification center (new notifications replace old ones)
+                    $payload['android']['notification']['tag'] = $event['name'];
+                }
+            }
         }
 
         // TODO Make sure data are key/value pairs as strings
         if (!empty($data)) {
-
             $dataFlat = [];
             foreach ($data as $key => $value) {
                 if (!is_string($value)) {
@@ -189,12 +197,14 @@ class RemotePushNotificationManager
             return $token->getPlatform() === 'ios';
         });
 
-        //todo temporary send both "notification+data" and "data-only" messages on android
+        //todo send both "notification+data" and "data-only" messages on android
+        // until we figure out if we need to handle it differently
         // reasons:
-        // 1. backward compatibility with the old app-versions
-        // 2. app does not always handle the case when "notification+data" is delivered in
-        // the background
-        // when #2 is done and #1 is not relevant any more we should only send "data-only" messages
+        // 1. in the background android is able to handle only "data-only" messages
+        // impact:
+        // for the versions before this change - nothing, they don't handle "data-only" messages at all
+        // for the versions after this change - implementation should expect to receive
+        // both "notification+data" and "data-only" messages and handle them correctly
 
         $this->fcm($textMessage, $fcmTokens, $data); // send "notification+data" message
         $this->fcm(null, $fcmTokens, $data); // send "data-only" message

--- a/tests/AppBundle/Service/RemotePushNotificationManagerTest.php
+++ b/tests/AppBundle/Service/RemotePushNotificationManagerTest.php
@@ -10,6 +10,7 @@ use Kreait\Firebase\Messaging as FirebaseMessaging;
 use Kreait\Firebase\Messaging\CloudMessage;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Psr\Log\NullLogger;
 
 class RemotePushNotificationManagerTest extends TestCase
 {
@@ -45,7 +46,8 @@ class RemotePushNotificationManagerTest extends TestCase
         $this->remotePushNotificationManager = new RemotePushNotificationManager(
             $this->firebaseFactory->reveal(),
             $this->apns->reveal(),
-            'passphrase'
+            'passphrase',
+            new NullLogger()
         );
     }
 


### PR DESCRIPTION
This change would allow android app to handle 'notifications' (if they are sent as 'data-only' messages) in the background and later on (when implemented on the app side) display a notifcation to the user locally without relying on firebase SDK, which gives the app more flexibility. 

This change should not affect current app users, because current version does not handle 'data-only' messages at all, and in a new version: 

- "tasks:changed" event would be handled the same way as now
- "order:created" event would be handled the same in the foreground and in the background a user would see a current notification + the app would be opened if possible (only on android)