### PR TITLE
Make businesses more generic

### DIFF
--- a/app/DoctrineMigrations/Version20200412101114.php
+++ b/app/DoctrineMigrations/Version20200412101114.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200412101114 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        $this->addSql('UPDATE restaurant SET type = \'store\' WHERE type = \'shop\'');
+    }
+
+    public function down(Schema $schema) : void
+    {
+
+    }
+}

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -302,11 +302,8 @@ services:
 
   AppBundle\Sylius\Cart\RestaurantCartContext:
     arguments:
-      - "@session"
-      - "@sylius.repository.order"
-      - "@sylius.factory.order"
-      - "@coopcycle.repository.restaurant"
-      - "%sylius_cart_restaurant_session_key_name%"
+      $orderFactory: "@sylius.factory.order"
+      $sessionKeyName: "%sylius_cart_restaurant_session_key_name%"
     tags:
       - { name: sylius.context.cart, priority: 32 }
 
@@ -392,19 +389,10 @@ services:
     arguments:
       - AppBundle\Entity\Task
 
-  AppBundle\Entity\RestaurantRepository:
+  AppBundle\Entity\LocalBusinessRepository:
     factory: ['@doctrine.orm.default_entity_manager', getRepository]
     arguments:
-      - AppBundle\Entity\Restaurant
-    calls:
-      - method: setRestaurantFilter
-        arguments:
-            - '@coopcycle.utils.restaurant_filter'
-
-  AppBundle\Entity\ShopRepository:
-    factory: ['@doctrine.orm.default_entity_manager', getRepository]
-    arguments:
-      - AppBundle\Entity\Shop
+      - AppBundle\Entity\LocalBusiness
     calls:
       - method: setRestaurantFilter
         arguments:
@@ -574,11 +562,6 @@ services:
       $fleetKey: '%tile38_fleet_key%'
 
   AppBundle\EventListener\EnabledFilterConfigurator:
-    arguments:
-      - "@doctrine.orm.entity_manager"
-      - "@security.token_storage"
-      - "@coopcycle.repository.restaurant"
-      - "@annotation_reader"
     tags:
       - { name: kernel.event_listener, event: kernel.request, priority: 5 }
 

--- a/cypress/fixtures/restaurants.yml
+++ b/cypress/fixtures/restaurants.yml
@@ -175,7 +175,7 @@ AppBundle\Entity\Contract:
     flatDeliveryPrice: 350
     feeRate: 0.00
 
-AppBundle\Entity\Restaurant:
+AppBundle\Entity\LocalBusiness:
   crazy_hamburger:
     name: Crazy Hamburger
     address: "@address_1"

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -5,6 +5,7 @@ use AppBundle\Entity\ApiApp;
 use AppBundle\Entity\Base\GeoCoordinates;
 use AppBundle\Entity\ClosingRule;
 use AppBundle\Entity\Order;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\Restaurant;
 use AppBundle\Entity\Address;
 use AppBundle\Entity\DeliveryAddress;
@@ -574,7 +575,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
      */
     public function theRestaurantWithIdHasProducts($id, TableNode $table)
     {
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
 
         $productCodes = array_map(function ($row) {
             return $row['code'];
@@ -585,7 +586,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
             $restaurant->addProduct($product);
         }
 
-        $this->doctrine->getManagerForClass(Restaurant::class)->flush();
+        $this->doctrine->getManagerForClass(LocalBusiness::class)->flush();
     }
 
     /**
@@ -593,7 +594,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
      */
     public function theRestaurantWithIdHasMenu($id, TableNode $table)
     {
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
 
         $menu = $this->getContainer()->get('sylius.factory.taxon')->createNew();
         $menu->setCode(Uuid::uuid4()->toString());
@@ -622,7 +623,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
         $restaurant->addTaxon($menu);
         $restaurant->setMenuTaxon($menu);
 
-        $this->doctrine->getManagerForClass(Restaurant::class)->flush();
+        $this->doctrine->getManagerForClass(LocalBusiness::class)->flush();
     }
 
     /**
@@ -647,7 +648,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
         $userManager = $this->getContainer()->get('fos_user.user_manager');
         $user = $userManager->findUserByUsername($username);
 
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
 
         $user->addRestaurant($restaurant);
         $userManager->updateUser($user);
@@ -656,7 +657,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
     /**
      * FIXME Too complicated, too low level
      */
-    private function createRandomOrder(Restaurant $restaurant, UserInterface $user, \DateTime $shippedAt = null)
+    private function createRandomOrder(LocalBusiness $restaurant, UserInterface $user, \DateTime $shippedAt = null)
     {
         $order = $this->getContainer()->get('sylius.factory.order')
             ->createForRestaurant($restaurant);
@@ -700,7 +701,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
         $userManager = $this->getContainer()->get('fos_user.user_manager');
         $user = $userManager->findUserByUsername($username);
 
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
 
         $order = $this->createRandomOrder($restaurant, $user);
         $order->setState(OrderInterface::STATE_NEW);
@@ -717,7 +718,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
         $userManager = $this->getContainer()->get('fos_user.user_manager');
         $user = $userManager->findUserByUsername($username);
 
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
 
         $order = $this->createRandomOrder($restaurant, $user, new \DateTime($date));
         $order->setState(OrderInterface::STATE_NEW);
@@ -754,7 +755,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
      */
     public function theRestaurantWithIdShouldHaveClosingRules($id, $count)
     {
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
 
         Assert::assertEquals($count, count($restaurant->getClosingRules()));
     }
@@ -854,7 +855,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
         $userManager = $this->getContainer()->get('fos_user.user_manager');
         $user = $userManager->findUserByUsername($username);
 
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
 
         $cart = $this->getContainer()->get('sylius.factory.order')
             ->createForRestaurant($restaurant);
@@ -870,7 +871,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
      */
     public function createCartAtRestaurantWithId($id)
     {
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
 
         $cart = $this->getContainer()->get('sylius.factory.order')
             ->createForRestaurant($restaurant);
@@ -881,7 +882,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
         return $cart;
     }
 
-    private function getLastCartFromRestaurant(Restaurant $restaurant)
+    private function getLastCartFromRestaurant(LocalBusiness $restaurant)
     {
         $carts = $this->getContainer()->get('sylius.repository.order')
             ->findCartsByRestaurant($restaurant);
@@ -901,7 +902,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
      */
     public function thereIsATokenForTheLastCartAtRestaurantWithId($id)
     {
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
         $cart = $this->getLastCartFromRestaurant($restaurant);
 
         $jwtEncoder = $this->getContainer()->get('lexik_jwt_authentication.encoder');
@@ -917,7 +918,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
      */
     public function thereIsAnExpiredTokenForTheLastCartAtRestaurantWithId($id)
     {
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
         $cart = $this->getLastCartFromRestaurant($restaurant);
 
         $jwtEncoder = $this->getContainer()->get('lexik_jwt_authentication.encoder');
@@ -958,7 +959,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
      */
     public function theHeaderContainsATokenForTheLastCartAtRestaurantWithId($headerName, $id)
     {
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
         $cart = $this->getLastCartFromRestaurant($restaurant);
 
         $jwtEncoder = $this->getContainer()->get('lexik_jwt_authentication.encoder');
@@ -975,7 +976,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
      */
     public function theRestaurantWithIdIsClosedBetweenAnd($id, $start, $end)
     {
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
 
         $closingRule = new ClosingRule();
         $closingRule->setRestaurant($restaurant);
@@ -984,7 +985,7 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
 
         $restaurant->addClosingRule($closingRule);
 
-        $em = $this->doctrine->getManagerForClass(Restaurant::class);
+        $em = $this->doctrine->getManagerForClass(LocalBusiness::class);
         $em->flush();
     }
 
@@ -1041,10 +1042,10 @@ class FeatureContext implements Context, SnippetAcceptingContext, KernelAwareCon
      */
     public function enableDepositRefund($id)
     {
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
         $restaurant->setDepositRefundEnabled(true);
 
-        $em = $this->doctrine->getManagerForClass(Restaurant::class);
+        $em = $this->doctrine->getManagerForClass(LocalBusiness::class);
         $em->flush();
     }
 

--- a/features/fixtures/ORM/shops.yml
+++ b/features/fixtures/ORM/shops.yml
@@ -41,39 +41,11 @@ AppBundle\Entity\Contract:
     feeRate: 0.00
 
 AppBundle\Entity\LocalBusiness:
-  restaurant_1:
-    name: 'Nodaiwa'
+  shop_1:
+    type: store
+    name: Flower Express
     address: "@address_1"
     orderingDelayMinutes: 0
     openingHours: ['Mo-Sa 11:30-14:30']
     enabled: true
     contract: "@contract_1"
-  restaurant_2:
-    name: 'Café Barjot'
-    address: "@address_2"
-    openingHours: ['Mo-Sa 11:30-14:30']
-    orderingDelayMinutes: 0
-    enabled: true
-    contract: "@contract_2"
-  restaurant_3:
-    name: 'La Cantina Clandestina'
-    orderingDelayMinutes: 0
-    address: "@address_3"
-    openingHours: ['Mo-Sa 11:30-14:30']
-    enabled: true
-    contract: "@contract_3"
-  restaurant_4:
-    name: 'Wild Buffet'
-    orderingDelayMinutes: 0
-    address: "@address_3"
-    openingHours: ['Mo-Sa 11:30-14:30']
-    enabled: true
-    contract: "@contract_3"
-    __calls:
-      - setDeletedAt:
-        - <identity(new \DateTime('2019-11-12 18:00:00'))>
-  restaurant_5:
-    name: 'I Want This Restaurant'
-    address: "@address_3"
-    enabled: true
-    state: pledge

--- a/features/shops.feature
+++ b/features/shops.feature
@@ -1,0 +1,57 @@
+Feature: Manage shops
+
+  Scenario: Retrieve a store via restaurants endpoint
+    Given the fixtures files are loaded:
+      | sylius_channels.yml |
+      | sylius_locales.yml  |
+      | products.yml        |
+      | shops.yml           |
+    When I add "Accept" header equal to "application/ld+json"
+    And I send a "GET" request to "/api/restaurants/1"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context":"/api/contexts/Restaurant",
+        "@id":"/api/restaurants/1",
+        "@type":"http://schema.org/Store",
+        "id":1,
+        "name":"Flower Express",
+        "description":null,
+        "enabled":true,
+        "depositRefundEnabled":false,
+        "depositRefundOptin":true,
+        "address":{
+          "@id":"/api/addresses/1",
+          "@type":"http://schema.org/Place",
+          "geo":{
+            "latitude":48.864577,
+            "longitude":2.333338
+          },
+          "streetAddress":"272, rue Saint Honoré 75001 Paris 1er",
+          "telephone":null,
+          "name":null
+        },
+        "state":"normal",
+        "telephone":null,
+        "openingHoursSpecification":[
+          {
+            "@type":"OpeningHoursSpecification",
+            "opens":"11:30",
+            "closes":"14:30",
+            "dayOfWeek":[
+              "Monday",
+              "Tuesday",
+              "Wednesday",
+              "Thursday",
+              "Friday",
+              "Saturday"
+            ]
+          }
+        ],
+        "specialOpeningHoursSpecification":[],
+        "availabilities":@array@,
+        "image":@string@
+      }
+      """

--- a/src/AppBundle/Action/CanDeliver.php
+++ b/src/AppBundle/Action/CanDeliver.php
@@ -4,7 +4,7 @@ namespace AppBundle\Action;
 
 use AppBundle\Entity\Address;
 use AppBundle\Entity\Base\GeoCoordinates;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Service\RoutingInterface;
 use Doctrine\Persistence\ManagerRegistry;
 use AppBundle\ExpressionLanguage\ExpressionLanguage;
@@ -36,7 +36,7 @@ class CanDeliver
      */
     public function canDeliverAction($id, $latitude, $longitude, Request $request)
     {
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($id);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($id);
 
         // TODO Manage 404
 

--- a/src/AppBundle/Api/DataProvider/RestaurantCollectionDataProvider.php
+++ b/src/AppBundle/Api/DataProvider/RestaurantCollectionDataProvider.php
@@ -4,7 +4,7 @@ namespace AppBundle\Api\DataProvider;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\CollectionDataProvider;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryResultCollectionExtensionInterface;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Utils\RestaurantFilter;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -42,7 +42,7 @@ final class RestaurantCollectionDataProvider extends CollectionDataProvider
     public function supports(string $resourceClass, string $operationName = null, array $context = []): bool
     {
         $supports = false;
-        if (Restaurant::class === $resourceClass && $operationName === 'get') {
+        if (LocalBusiness::class === $resourceClass && $operationName === 'get') {
             $supports = isset($context['filters']) && isset($context['filters']['coordinate']);
         }
 

--- a/src/AppBundle/Api/DataProvider/RestaurantPledgeFilterExtension.php
+++ b/src/AppBundle/Api/DataProvider/RestaurantPledgeFilterExtension.php
@@ -4,7 +4,7 @@ namespace AppBundle\Api\DataProvider;
 
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
 use ApiPlatform\Core\Bridge\Doctrine\Orm\Util\QueryNameGeneratorInterface;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use Doctrine\ORM\QueryBuilder;
 
 /**
@@ -18,7 +18,7 @@ class RestaurantPledgeFilterExtension implements QueryCollectionExtensionInterfa
         string $resourceClass,
         string $operationName = null)
     {
-        if (Restaurant::class !== $resourceClass) {
+        if (LocalBusiness::class !== $resourceClass) {
             return;
         }
 
@@ -30,6 +30,6 @@ class RestaurantPledgeFilterExtension implements QueryCollectionExtensionInterfa
 
         $queryBuilder
             ->andWhere(sprintf('o.%s != :%s', 'state', $parameterName))
-            ->setParameter($parameterName, Restaurant::STATE_PLEDGE);
+            ->setParameter($parameterName, LocalBusiness::STATE_PLEDGE);
     }
 }

--- a/src/AppBundle/Api/DataTransformer/RestaurantInputDataTransformer.php
+++ b/src/AppBundle/Api/DataTransformer/RestaurantInputDataTransformer.php
@@ -3,7 +3,7 @@
 namespace AppBundle\Api\DataTransformer;
 
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Serializer\AbstractItemNormalizer;
 
@@ -38,10 +38,10 @@ class RestaurantInputDataTransformer implements DataTransformerInterface
      */
     public function supportsTransformation($data, string $to, array $context = []): bool
     {
-        if ($data instanceof Restaurant) {
+        if ($data instanceof LocalBusiness) {
           return false;
         }
 
-        return Restaurant::class === $to && null !== ($context['input']['class'] ?? null);
+        return LocalBusiness::class === $to && null !== ($context['input']['class'] ?? null);
     }
 }

--- a/src/AppBundle/Api/Dto/CartSessionInput.php
+++ b/src/AppBundle/Api/Dto/CartSessionInput.php
@@ -2,12 +2,12 @@
 
 namespace AppBundle\Api\Dto;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 
 final class CartSessionInput
 {
     /**
-     * @var Restaurant
+     * @var LocalBusiness
      */
     public $restaurant;
 }

--- a/src/AppBundle/Api/EventSubscriber/SubresourceDenyAccessListener.php
+++ b/src/AppBundle/Api/EventSubscriber/SubresourceDenyAccessListener.php
@@ -3,7 +3,7 @@
 namespace AppBundle\Api\EventSubscriber;
 
 use AppBundle\Entity\ApiApp;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\EventListener\EventPriorities;
 use ApiPlatform\Core\Security\EventListener\DenyAccessListener;

--- a/src/AppBundle/Command/InitDemoCommand.php
+++ b/src/AppBundle/Command/InitDemoCommand.php
@@ -515,7 +515,7 @@ class InitDemoCommand extends Command
         $this->createTaxCategory('TVA consommation différée', 'tva_conso_differee', 'TVA 5.5%', 'tva_5_5', 0.055);
         $this->createTaxCategory('TVA livraison', 'tva_livraison', 'TVA 20%', 'tva_20', 0.20);
 
-        $em = $this->doctrine->getManagerForClass(Entity\Restaurant::class);
+        $em = $this->doctrine->getManagerForClass(Entity\LocalBusiness::class);
 
         for ($i = 0; $i < 50; $i++) {
 

--- a/src/AppBundle/Controller/AdminController.php
+++ b/src/AppBundle/Controller/AdminController.php
@@ -16,8 +16,8 @@ use AppBundle\Entity\ApiUser;
 use AppBundle\Entity\Delivery;
 use AppBundle\Entity\Restaurant\Pledge;
 use AppBundle\Entity\Delivery\PricingRuleSet;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\PackageSet;
-use AppBundle\Entity\Restaurant;
 use AppBundle\Entity\Store;
 use AppBundle\Entity\TimeSlot;
 use AppBundle\Entity\Tag;
@@ -521,7 +521,7 @@ class AdminController extends Controller
 
     protected function getRestaurantList(Request $request)
     {
-        $repository = $this->getDoctrine()->getRepository(Restaurant::class);
+        $repository = $this->getDoctrine()->getRepository(LocalBusiness::class);
 
         $countAll = $repository
             ->createQueryBuilder('r')->select('COUNT(r)')
@@ -898,13 +898,13 @@ class AdminController extends Controller
      */
     public function searchRestaurantsAction(Request $request)
     {
-        $repository = $this->getDoctrine()->getRepository(Restaurant::class);
+        $repository = $this->getDoctrine()->getRepository(LocalBusiness::class);
 
         $results = $repository->search($request->query->get('q'));
 
         if ($request->query->has('format') && 'json' === $request->query->get('format')) {
 
-            $data = array_map(function (Restaurant $restaurant) {
+            $data = array_map(function (LocalBusiness $restaurant) {
                 return [
                     'id' => $restaurant->getId(),
                     'name' => $restaurant->getName(),
@@ -1327,7 +1327,7 @@ class AdminController extends Controller
 
             $promotion->addRule($promotionRule);
 
-            if (isset($data['restaurant']) && $data['restaurant'] instanceof Restaurant) {
+            if (isset($data['restaurant']) && $data['restaurant'] instanceof LocalBusiness) {
 
                 $isRestaurantRule = $this->get('sylius.factory.promotion_rule')->createNew();
                 $isRestaurantRule->setType(IsRestaurantRuleChecker::TYPE);

--- a/src/AppBundle/Controller/IndexController.php
+++ b/src/AppBundle/Controller/IndexController.php
@@ -4,8 +4,7 @@ namespace AppBundle\Controller;
 
 use AppBundle\Annotation\HideSoftDeleted;
 use AppBundle\Controller\Utils\UserTrait;
-use AppBundle\Entity\RestaurantRepository;
-use AppBundle\Entity\ShopRepository;
+use AppBundle\Entity\LocalBusinessRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,16 +19,14 @@ class IndexController extends AbstractController
      * @Template
      * @HideSoftDeleted
      */
-    public function indexAction(
-        RestaurantRepository $restautantRepository,
-        ShopRepository $shopRepository)
+    public function indexAction(LocalBusinessRepository $repository)
     {
-        $restaurants = $restautantRepository->findAllSorted();
-        $shops = $shopRepository->findAllSorted();
+        $restaurants = $repository->findAllSorted('restaurant');
+        $stores = $repository->findAllSorted('store');
 
         return array(
             'restaurants' => array_slice($restaurants, 0, self::MAX_RESULTS),
-            'shops' => array_slice($shops, 0, self::MAX_RESULTS),
+            'stores' => array_slice($stores, 0, self::MAX_RESULTS),
             'max_results' => self::MAX_RESULTS,
             'show_more' => count($restaurants) > self::MAX_RESULTS,
             'addresses_normalized' => $this->getUserAddresses(),

--- a/src/AppBundle/Controller/LoopEatController.php
+++ b/src/AppBundle/Controller/LoopEatController.php
@@ -4,7 +4,7 @@ namespace AppBundle\Controller;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use AppBundle\Entity\ApiUser;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use Doctrine\ORM\EntityManagerInterface;
 use FOS\UserBundle\Model\UserManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface;
@@ -96,8 +96,8 @@ class LoopEatController extends AbstractController
 
         $subject = $iriConverter->getItemFromIri($payload['sub']);
 
-        if (!$subject instanceof Restaurant && !$subject instanceof ApiUser) {
-            throw new BadRequestHttpException(sprintf('Subject should be an instance of "%s" or "%s"', Restaurant::class, ApiUser::class));
+        if (!$subject instanceof LocalBusiness && !$subject instanceof ApiUser) {
+            throw new BadRequestHttpException(sprintf('Subject should be an instance of "%s" or "%s"', LocalBusiness::class, ApiUser::class));
         }
 
         $data = $this->authorizationCode($request->query->get('code'));
@@ -115,7 +115,7 @@ class LoopEatController extends AbstractController
             $userManager->updateUser($subject);
         }
 
-        if ($subject instanceof Restaurant) {
+        if ($subject instanceof LocalBusiness) {
             $objectManager->flush();
         }
 

--- a/src/AppBundle/Controller/OrderController.php
+++ b/src/AppBundle/Controller/OrderController.php
@@ -4,7 +4,7 @@ namespace AppBundle\Controller;
 
 use AppBundle\Entity\Address;
 use AppBundle\Entity\Delivery;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Form\Checkout\CheckoutAddressType;
 use AppBundle\Form\Checkout\CheckoutPaymentType;
 use AppBundle\Service\OrderManager;

--- a/src/AppBundle/Controller/SitemapController.php
+++ b/src/AppBundle/Controller/SitemapController.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Controller;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use Cocur\Slugify\SlugifyInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -18,7 +18,7 @@ class SitemapController extends AbstractController
     public function indexAction(SlugifyInterface $slugify)
     {
         $restaurants = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->findBy(['enabled' => true]);
 
         // TODO Use locale_regex parameter

--- a/src/AppBundle/Controller/StripeController.php
+++ b/src/AppBundle/Controller/StripeController.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Controller;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\StripeAccount;
 use AppBundle\Service\SettingsManager;
 use AppBundle\Service\StripeManager;

--- a/src/AppBundle/Controller/Utils/AccessControlTrait.php
+++ b/src/AppBundle/Controller/Utils/AccessControlTrait.php
@@ -3,7 +3,7 @@
 namespace AppBundle\Controller\Utils;
 
 use AppBundle\Entity\Delivery;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\Store;
 use AppBundle\Sylius\Order\OrderInterface;
 use AppBundle\Utils\AccessControl;
@@ -25,7 +25,7 @@ trait AccessControlTrait
             }
         }
 
-        if ($object instanceof Restaurant) {
+        if ($object instanceof LocalBusiness) {
             if (!AccessControl::restaurant($this->getUser(), $object)) {
                 throw new AccessDeniedHttpException();
             }

--- a/src/AppBundle/Controller/Utils/RestaurantTrait.php
+++ b/src/AppBundle/Controller/Utils/RestaurantTrait.php
@@ -5,7 +5,7 @@ namespace AppBundle\Controller\Utils;
 use ApiPlatform\Core\Api\IriConverterInterface;
 use AppBundle\Annotation\HideSoftDeleted;
 use AppBundle\Entity\ClosingRule;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\Restaurant\PreparationTimeRule;
 use AppBundle\Entity\ReusablePackaging;
 use AppBundle\Entity\StripeAccount;
@@ -84,7 +84,7 @@ trait RestaurantTrait
         return array_merge($params, $routeParams);
     }
 
-    protected function renderRestaurantForm(Restaurant $restaurant, Request $request,
+    protected function renderRestaurantForm(LocalBusiness $restaurant, Request $request,
         JWTEncoderInterface $jwtEncoder,
         IriConverterInterface $iriConverter)
     {
@@ -100,7 +100,7 @@ trait RestaurantTrait
                         ->find($stripeAccountId);
                     if ($stripeAccount) {
                         $restaurant->addStripeAccount($stripeAccount);
-                        $this->getDoctrine()->getManagerForClass(Restaurant::class)->flush();
+                        $this->getDoctrine()->getManagerForClass(LocalBusiness::class)->flush();
 
                         $this->addFlash(
                             'notice',
@@ -125,8 +125,8 @@ trait RestaurantTrait
 
                 if ($form->getClickedButton() && 'delete' === $form->getClickedButton()->getName()) {
 
-                    $this->getDoctrine()->getManagerForClass(Restaurant::class)->remove($restaurant);
-                    $this->getDoctrine()->getManagerForClass(Restaurant::class)->flush();
+                    $this->getDoctrine()->getManagerForClass(LocalBusiness::class)->remove($restaurant);
+                    $this->getDoctrine()->getManagerForClass(LocalBusiness::class)->flush();
 
                     return $this->redirectToRoute($routes['restaurants']);
                 }
@@ -155,8 +155,8 @@ trait RestaurantTrait
                     }
                 }
 
-                $this->getDoctrine()->getManagerForClass(Restaurant::class)->persist($restaurant);
-                $this->getDoctrine()->getManagerForClass(Restaurant::class)->flush();
+                $this->getDoctrine()->getManagerForClass(LocalBusiness::class)->persist($restaurant);
+                $this->getDoctrine()->getManagerForClass(LocalBusiness::class)->flush();
 
                 $this->addFlash(
                     'notice',
@@ -228,7 +228,7 @@ trait RestaurantTrait
 
     public function restaurantAction($id, Request $request, JWTEncoderInterface $jwtEncoder, IriConverterInterface $iriConverter)
     {
-        $repository = $this->getDoctrine()->getRepository(Restaurant::class);
+        $repository = $this->getDoctrine()->getRepository(LocalBusiness::class);
 
         $restaurant = $repository->find($id);
 
@@ -240,7 +240,7 @@ trait RestaurantTrait
     public function newRestaurantAction(Request $request, JWTEncoderInterface $jwtEncoder, IriConverterInterface $iriConverter)
     {
         // TODO Check roles
-        $restaurant = new Restaurant();
+        $restaurant = new LocalBusiness();
 
         return $this->renderRestaurantForm($restaurant, $request, $jwtEncoder, $iriConverter);
     }
@@ -248,7 +248,7 @@ trait RestaurantTrait
     protected function renderRestaurantDashboard(
         Request $request,
         JWTManagerInterface $jwtManager,
-        Restaurant $restaurant)
+        LocalBusiness $restaurant)
     {
         $this->accessControl($restaurant);
 
@@ -281,7 +281,7 @@ trait RestaurantTrait
             'layout' => $request->attributes->get('layout'),
             'restaurant' => $restaurant,
             'restaurant_normalized' => $this->get('serializer')->normalize($restaurant, 'jsonld', [
-                'resource_class' => Restaurant::class,
+                'resource_class' => LocalBusiness::class,
                 'operation_type' => 'item',
                 'item_operation_name' => 'get',
                 'groups' => ['restaurant']
@@ -307,7 +307,7 @@ trait RestaurantTrait
     public function restaurantDashboardAction($restaurantId, Request $request, JWTManagerInterface $jwtManager)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($restaurantId);
 
         return $this->renderRestaurantDashboard($request, $jwtManager, $restaurant);
@@ -316,7 +316,7 @@ trait RestaurantTrait
     public function restaurantMenuTaxonsAction($id, Request $request)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($id);
 
         $routes = $request->attributes->get('routes');
@@ -338,7 +338,7 @@ trait RestaurantTrait
     public function activateRestaurantMenuTaxonAction($restaurantId, $menuId, Request $request)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($restaurantId);
 
         $menuTaxon = $this->get('sylius.repository.taxon')
@@ -346,7 +346,7 @@ trait RestaurantTrait
 
         $restaurant->setMenuTaxon($menuTaxon);
 
-        $this->getDoctrine()->getManagerForClass(Restaurant::class)->flush();
+        $this->getDoctrine()->getManagerForClass(LocalBusiness::class)->flush();
 
         $this->addFlash(
             'notice',
@@ -364,7 +364,7 @@ trait RestaurantTrait
     public function deleteRestaurantMenuTaxonChildAction($restaurantId, $menuId, $sectionId, Request $request)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($restaurantId);
 
         $menuTaxon = $this->get('sylius.repository.taxon')->find($menuId);
@@ -385,7 +385,7 @@ trait RestaurantTrait
     public function newRestaurantMenuTaxonAction($id, Request $request)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($id);
 
         $routes = $request->attributes->get('routes');
@@ -407,7 +407,7 @@ trait RestaurantTrait
             $this->get('sylius.repository.taxon')->add($menuTaxon);
 
             $restaurant->addTaxon($menuTaxon);
-            $this->getDoctrine()->getManagerForClass(Restaurant::class)->flush();
+            $this->getDoctrine()->getManagerForClass(LocalBusiness::class)->flush();
 
             return $this->redirectToRoute($routes['menu_taxon'], [
                 'restaurantId' => $restaurant->getId(),
@@ -434,7 +434,7 @@ trait RestaurantTrait
         $routes = $request->attributes->get('routes');
 
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($restaurantId);
 
         $menuTaxon = $this->get('sylius.repository.taxon')
@@ -566,7 +566,7 @@ trait RestaurantTrait
     public function restaurantPlanningAction($id, Request $request)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($id);
 
         $form = $this->createForm(ClosingRuleType::class);
@@ -605,7 +605,7 @@ trait RestaurantTrait
     public function restaurantProductsAction($id, Request $request)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($id);
 
         $routes = $request->attributes->get('routes');
@@ -632,7 +632,7 @@ trait RestaurantTrait
     public function restaurantProductAction($restaurantId, $productId, Request $request)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($restaurantId);
 
         $product = $this->get('sylius.repository.product')
@@ -678,7 +678,7 @@ trait RestaurantTrait
     public function newRestaurantProductAction($id, Request $request)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($id);
 
         $product = $this->get('sylius.factory.product')
@@ -718,7 +718,7 @@ trait RestaurantTrait
     public function restaurantProductOptionsAction($id, Request $request)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($id);
 
         $routes = $request->attributes->get('routes');
@@ -733,7 +733,7 @@ trait RestaurantTrait
     public function restaurantProductOptionAction($restaurantId, $optionId, Request $request)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($restaurantId);
 
         $productOption = $this->get('sylius.repository.product_option')
@@ -782,7 +782,7 @@ trait RestaurantTrait
     public function newRestaurantProductOptionAction($id, Request $request)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($id);
 
         $productOption = $this->get('sylius.factory.product_option')
@@ -821,7 +821,7 @@ trait RestaurantTrait
         JWTEncoderInterface $jwtEncoder)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($id);
 
         $redirectUri = $this->generateUrl(
@@ -892,7 +892,7 @@ trait RestaurantTrait
     public function preparationTimeAction($id, Request $request, PreparationTimeCalculator $calculator)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($id);
 
         $routes = $request->attributes->get('routes');
@@ -933,7 +933,7 @@ trait RestaurantTrait
                 }
             }
 
-            $em = $this->getDoctrine()->getManagerForClass(Restaurant::class);
+            $em = $this->getDoctrine()->getManagerForClass(LocalBusiness::class);
             $em->flush();
 
             return $this->redirectToRoute($routes['success'], ['id' => $id]);
@@ -950,7 +950,7 @@ trait RestaurantTrait
     public function statsAction($id, Request $request, SlugifyInterface $slugify, TranslatorInterface $translator)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($id);
 
         $this->accessControl($restaurant);
@@ -1018,7 +1018,7 @@ trait RestaurantTrait
     public function restaurantDepositRefundAction($id, Request $request)
     {
         $restaurant = $this->getDoctrine()
-            ->getRepository(Restaurant::class)
+            ->getRepository(LocalBusiness::class)
             ->find($id);
 
         $this->accessControl($restaurant);
@@ -1028,7 +1028,7 @@ trait RestaurantTrait
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
 
-            $this->getDoctrine()->getManagerForClass(Restaurant::class)->flush();
+            $this->getDoctrine()->getManagerForClass(LocalBusiness::class)->flush();
 
             $this->addFlash(
                 'notice',

--- a/src/AppBundle/Doctrine/EventSubscriber/PostSoftDeleteSubscriber.php
+++ b/src/AppBundle/Doctrine/EventSubscriber/PostSoftDeleteSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Doctrine\EventSubscriber;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\Sylius\Order;
 use AppBundle\Entity\Sylius\OrderItem;
 use AppBundle\Entity\Sylius\Product;
@@ -64,7 +64,7 @@ class PostSoftDeleteSubscriber implements EventSubscriber
             $unitOfWork->computeChangeSets();
         }
 
-        if ($entity instanceof Restaurant) {
+        if ($entity instanceof LocalBusiness) {
 
             // FIXME Use OrderInterface
             $orderRepository = $objectManager->getRepository(Order::class);

--- a/src/AppBundle/Domain/Order/Reactor/SendRemotePushNotification.php
+++ b/src/AppBundle/Domain/Order/Reactor/SendRemotePushNotification.php
@@ -4,7 +4,7 @@ namespace AppBundle\Domain\Order\Reactor;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use AppBundle\Domain\Order\Event\OrderCreated;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Message\PushNotification;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -66,10 +66,10 @@ class SendRemotePushNotification
         }
     }
 
-    private function normalizeRestaurant(Restaurant $restaurant)
+    private function normalizeRestaurant(LocalBusiness $restaurant)
     {
         $restaurantNormalized = $this->serializer->normalize($restaurant, 'jsonld', [
-            'resource_class' => Restaurant::class,
+            'resource_class' => LocalBusiness::class,
             'operation_type' => 'item',
             'item_operation_name' => 'get'
         ]);

--- a/src/AppBundle/Entity/ApiUser.php
+++ b/src/AppBundle/Entity/ApiUser.php
@@ -187,14 +187,14 @@ class ApiUser extends BaseUser implements JWTUserInterface, ChannelAwareInterfac
         return $this;
     }
 
-    public function addRestaurant(Restaurant $restaurant)
+    public function addRestaurant(LocalBusiness $restaurant)
     {
         $this->restaurants->add($restaurant);
 
         return $this;
     }
 
-    public function ownsRestaurant(Restaurant $restaurant)
+    public function ownsRestaurant(LocalBusiness $restaurant)
     {
         return $this->restaurants->contains($restaurant);
     }

--- a/src/AppBundle/Entity/Contract.php
+++ b/src/AppBundle/Entity/Contract.php
@@ -13,7 +13,7 @@ class Contract
     private $id;
 
     /**
-     * @var Restaurant
+     * @var LocalBusiness
      */
     private $restaurant;
 
@@ -89,7 +89,7 @@ class Contract
     private $restaurantPaysStripeFee = true;
 
     /**
-     * @return Restaurant
+     * @return LocalBusiness
      */
     public function getRestaurant()
     {
@@ -97,9 +97,9 @@ class Contract
     }
 
     /**
-     * @param Restaurant $restaurant
+     * @param LocalBusiness $restaurant
      */
-    public function setRestaurant(Restaurant $restaurant)
+    public function setRestaurant(LocalBusiness $restaurant)
     {
         $this->restaurant = $restaurant;
     }

--- a/src/AppBundle/Entity/LocalBusinessRepository.php
+++ b/src/AppBundle/Entity/LocalBusinessRepository.php
@@ -9,7 +9,7 @@ use Doctrine\ORM\QueryBuilder;
 use Sylius\Component\Order\Model\OrderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-abstract class LocalBusinessRepository extends EntityRepository
+class LocalBusinessRepository extends EntityRepository
 {
     private $restaurantFilter;
 
@@ -149,9 +149,9 @@ abstract class LocalBusinessRepository extends EntityRepository
         return $qb->getQuery()->getSingleScalarResult();
     }
 
-    public function findAllSorted()
+    public function findAllSorted($type = 'restaurant')
     {
-        $matches = $this->findAll();
+        $matches = $this->findBy(['type' => $type]);
 
         // 1 - opened restaurants
         // 2 - closed restaurants

--- a/src/AppBundle/Entity/Restaurant.php
+++ b/src/AppBundle/Entity/Restaurant.php
@@ -2,132 +2,15 @@
 
 namespace AppBundle\Entity;
 
-use ApiPlatform\Core\Annotation\ApiFilter;
-use ApiPlatform\Core\Annotation\ApiProperty;
-use ApiPlatform\Core\Annotation\ApiResource;
-use ApiPlatform\Core\Annotation\ApiSubresource;
-use AppBundle\Action\MyRestaurants;
-use AppBundle\Action\Restaurant\Close as CloseRestaurant;
-use AppBundle\Action\Restaurant\Menu;
-use AppBundle\Action\Restaurant\Menus;
-use AppBundle\Annotation\Enabled;
-use AppBundle\Api\Controller\Restaurant\ChangeState;
-use AppBundle\Api\Dto\RestaurantInput;
-// use AppBundle\Entity\Base\FoodEstablishment;
-use AppBundle\Entity\Base\LocalBusiness as BaseLocalBusiness;
-use AppBundle\Validator\Constraints as CustomAssert;
-use Carbon\Carbon;
-use Carbon\CarbonPeriod;
-use Doctrine\Common\Collections\ArrayCollection;
-use Gedmo\SoftDeleteable\Traits\SoftDeleteableEntity;
-use Gedmo\Timestampable\Traits\Timestampable;
-use AppBundle\LoopEat\OAuthCredentialsTrait as LoopEatOAuthCredentialsTrait;
-use Sylius\Component\Product\Model\ProductInterface;
-use Sylius\Component\Product\Model\ProductOptionInterface;
-use Sylius\Component\Taxonomy\Model\TaxonInterface;
-use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
-use Symfony\Component\HttpFoundation\File\File;
-use Symfony\Component\HttpFoundation\File\UploadedFile;
-use Symfony\Component\Serializer\Annotation\Groups;
-use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
-use Symfony\Component\Validator\Validation;
-use Vich\UploaderBundle\Mapping\Annotation as Vich;
-
 /**
- * A restaurant.
  *
- * @see http://schema.org/Restaurant Documentation on Schema.org
- *
- * @ApiResource(iri="http://schema.org/Restaurant",
- *   attributes={
- *     "denormalization_context"={"groups"={"order_create", "restaurant_update"}},
- *     "normalization_context"={"groups"={"restaurant", "address", "order"}}
- *   },
- *   collectionOperations={
- *     "get"={"method"="GET"},
- *     "me_restaurants"={
- *       "method"="GET",
- *       "path"="/me/restaurants",
- *       "controller"=MyRestaurants::class
- *     }
- *   },
- *   itemOperations={
- *     "get"={"method"="GET"},
- *     "restaurant_menu"={
- *       "method"="GET",
- *       "path"="/restaurants/{id}/menu",
- *       "controller"=Menu::class,
- *       "normalization_context"={"groups"={"restaurant_menu"}},
- *     },
- *     "restaurant_menus"={
- *       "method"="GET",
- *       "path"="/restaurants/{id}/menus",
- *       "controller"=Menus::class,
- *       "normalization_context"={"groups"={"restaurant_menus"}},
- *     },
- *     "put"={
- *       "method"="PUT",
- *       "input"=RestaurantInput::class,
- *       "denormalization_context"={"groups"={"restaurant_update"}},
- *       "access_control"="is_granted('ROLE_ADMIN') or (is_granted('ROLE_RESTAURANT') and user.ownsRestaurant(object))"
- *     },
- *     "close"={
- *       "method"="PUT",
- *       "path"="/restaurants/{id}/close",
- *       "controller"=CloseRestaurant::class,
- *       "access_control"="is_granted('ROLE_ADMIN') or (is_granted('ROLE_RESTAURANT') and user.ownsRestaurant(object))",
- *     }
- *   },
- *   subresourceOperations={
- *     "orders_get_subresource"={
- *       "security"="is_granted('ROLE_ADMIN') or (is_granted('ROLE_RESTAURANT') and user.ownsRestaurant(object))"
- *     },
- *   },
- * )
  */
 class Restaurant extends LocalBusiness
 {
-    /**
-     * @ApiSubresource
-     */
-    protected $orders;
-
-    /**
-     * @ApiSubresource
-     */
-    protected $products;
-
     public function __construct()
     {
-        parent::__construct();
-
         $this->type = 'restaurant';
-        $this->orders = new ArrayCollection();
-        $this->products = new ArrayCollection();
-    }
 
-    public function getOrders()
-    {
-        return $this->orders;
-    }
-
-    public function getProducts()
-    {
-        return $this->products;
-    }
-
-    public function hasProduct(ProductInterface $product)
-    {
-        return $this->products->contains($product);
-    }
-
-    public function addProduct(ProductInterface $product)
-    {
-        $product->setRestaurant($this);
-
-        if (!$this->products->contains($product)) {
-            $this->products->add($product);
-        }
+        parent::__construct();
     }
 }

--- a/src/AppBundle/Entity/Restaurant/Pledge.php
+++ b/src/AppBundle/Entity/Restaurant/Pledge.php
@@ -2,11 +2,10 @@
 
 namespace AppBundle\Entity\Restaurant;
 
+use AppBundle\Entity\Restaurant\PledgeVote;
+use AppBundle\Entity\LocalBusiness;
 use Doctrine\Common\Collections\ArrayCollection;
 use FOS\UserBundle\Model\UserInterface;
-use AppBundle\Entity\Restaurant\PledgeVote;
-use AppBundle\Entity\Restaurant;
-use Exception;
 
 class Pledge {
 
@@ -206,16 +205,16 @@ class Pledge {
         return false;
     }
 
-    public function accept(): Restaurant
+    public function accept(): LocalBusiness
     {
         if ($this->getState() !== 'new') {
-            throw new Exception('Unvalid pledge state, it should be set to new');
+            throw new \Exception('Unvalid pledge state, it should be set to new');
         }
 
-        $restaurant = new Restaurant();
+        $restaurant = new LocalBusiness();
         $restaurant->setName($this->getName());
         $restaurant->setAddress($this->getAddress());
-        $restaurant->setState(Restaurant::STATE_PLEDGE);
+        $restaurant->setState(LocalBusiness::STATE_PLEDGE);
         $restaurant->setPledge($this);
         $restaurant->setEnabled(true);
 

--- a/src/AppBundle/Entity/Restaurant/PreparationTimeRule.php
+++ b/src/AppBundle/Entity/Restaurant/PreparationTimeRule.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Entity\Restaurant;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Serializer\Annotation\Groups;
 

--- a/src/AppBundle/Entity/RestaurantRepository.php
+++ b/src/AppBundle/Entity/RestaurantRepository.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace AppBundle\Entity;
-
-class RestaurantRepository extends LocalBusinessRepository
-{
-
-}

--- a/src/AppBundle/Entity/RestaurantStripeAccount.php
+++ b/src/AppBundle/Entity/RestaurantStripeAccount.php
@@ -22,7 +22,7 @@ class RestaurantStripeAccount
         return $this->restaurant;
     }
 
-    public function setRestaurant(Restaurant $restaurant)
+    public function setRestaurant(LocalBusiness $restaurant)
     {
         $this->restaurant = $restaurant;
 

--- a/src/AppBundle/Entity/ReusablePackaging.php
+++ b/src/AppBundle/Entity/ReusablePackaging.php
@@ -30,7 +30,7 @@ class ReusablePackaging implements StockableInterface
         return $this->restaurant;
     }
 
-    public function setRestaurant(Restaurant $restaurant)
+    public function setRestaurant(LocalBusiness $restaurant)
     {
         $this->restaurant = $restaurant;
 

--- a/src/AppBundle/Entity/Shop.php
+++ b/src/AppBundle/Entity/Shop.php
@@ -2,12 +2,15 @@
 
 namespace AppBundle\Entity;
 
-class Shop extends Restaurant
+/**
+ *
+ */
+class Shop extends LocalBusiness
 {
     public function __construct()
     {
-        parent::__construct();
-
         $this->type = 'shop';
+
+        parent::__construct();
     }
 }

--- a/src/AppBundle/Entity/ShopRepository.php
+++ b/src/AppBundle/Entity/ShopRepository.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace AppBundle\Entity;
-
-class ShopRepository extends LocalBusinessRepository
-{
-
-}

--- a/src/AppBundle/Entity/Sylius/Order.php
+++ b/src/AppBundle/Entity/Sylius/Order.php
@@ -20,7 +20,7 @@ use AppBundle\Api\Dto\CartItemInput;
 use AppBundle\Entity\Address;
 use AppBundle\Entity\ApiUser;
 use AppBundle\Entity\Delivery;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Filter\OrderDateFilter;
 use AppBundle\Sylius\Order\AdjustmentInterface;
 use AppBundle\Sylius\Order\OrderInterface;
@@ -384,12 +384,12 @@ class Order extends BaseOrder implements OrderInterface
     /**
      * {@inheritdoc}
      */
-    public function getRestaurant(): ?Restaurant
+    public function getRestaurant(): ?LocalBusiness
     {
         return $this->restaurant;
     }
 
-    public function setRestaurant(?Restaurant $restaurant): void
+    public function setRestaurant(?LocalBusiness $restaurant): void
     {
         $this->restaurant = $restaurant;
     }

--- a/src/AppBundle/Entity/Sylius/OrderRepository.php
+++ b/src/AppBundle/Entity/Sylius/OrderRepository.php
@@ -3,7 +3,7 @@
 namespace AppBundle\Entity\Sylius;
 
 use AppBundle\Entity\Delivery;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\Task;
 use AppBundle\Sylius\Order\OrderInterface;
 use Doctrine\ORM\Query\Expr\Join;
@@ -14,7 +14,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 class OrderRepository extends BaseOrderRepository
 {
-    public function findCartsByRestaurant(Restaurant $restaurant)
+    public function findCartsByRestaurant(LocalBusiness $restaurant)
     {
         return $this->createQueryBuilder('o')
             ->andWhere('o.state = :state')
@@ -39,7 +39,7 @@ class OrderRepository extends BaseOrderRepository
         return $qb->getQuery()->getResult();
     }
 
-    public function findOrdersByRestaurantAndDateRange(Restaurant $restaurant, \DateTime $start, \DateTime $end)
+    public function findOrdersByRestaurantAndDateRange(LocalBusiness $restaurant, \DateTime $start, \DateTime $end)
     {
         $qb = $this->createQueryBuilder('o');
         $qb

--- a/src/AppBundle/Entity/Sylius/Product.php
+++ b/src/AppBundle/Entity/Sylius/Product.php
@@ -4,7 +4,7 @@ namespace AppBundle\Entity\Sylius;
 
 use ApiPlatform\Core\Annotation\ApiProperty;
 use ApiPlatform\Core\Annotation\ApiResource;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\ReusablePackaging;
 use AppBundle\Sylius\Product\ProductInterface;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -78,7 +78,7 @@ class Product extends BaseProduct implements ProductInterface
     /**
      * {@inheritdoc}
      */
-    public function getRestaurant(): ?Restaurant
+    public function getRestaurant(): ?LocalBusiness
     {
         return $this->restaurant->get(0);
     }
@@ -86,7 +86,7 @@ class Product extends BaseProduct implements ProductInterface
     /**
      * {@inheritdoc}
      */
-    public function setRestaurant(?Restaurant $restaurant): void
+    public function setRestaurant(?LocalBusiness $restaurant): void
     {
         $this->restaurant->clear();
         $this->restaurant->add($restaurant);

--- a/src/AppBundle/Entity/Sylius/ProductOption.php
+++ b/src/AppBundle/Entity/Sylius/ProductOption.php
@@ -3,7 +3,7 @@
 namespace AppBundle\Entity\Sylius;
 
 use AppBundle\DataType\NumRange;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Sylius\Product\ProductOptionInterface;
 use AppBundle\Validator\Constraints\ProductOption as AssertProductOption;
 use Sylius\Component\Product\Model\ProductOption as BaseProductOption;
@@ -80,7 +80,7 @@ class ProductOption extends BaseProductOption implements ProductOptionInterface
         return $this->additional;
     }
 
-    public function setRestaurant(Restaurant $restaurant)
+    public function setRestaurant(LocalBusiness $restaurant)
     {
         $restaurant->addProductOption($this);
     }

--- a/src/AppBundle/EventListener/EnabledFilterConfigurator.php
+++ b/src/AppBundle/EventListener/EnabledFilterConfigurator.php
@@ -2,8 +2,8 @@
 
 namespace AppBundle\EventListener;
 
-use AppBundle\Entity\Restaurant;
-use AppBundle\Entity\RestaurantRepository;
+use AppBundle\Entity\LocalBusiness;
+use AppBundle\Entity\LocalBusinessRepository;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\Cache\ItemInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -24,7 +24,7 @@ class EnabledFilterConfigurator
     public function __construct(
         EntityManagerInterface $em,
         TokenStorageInterface $tokenStorage,
-        RestaurantRepository $restaurantRepository,
+        LocalBusinessRepository $restaurantRepository,
         Reader $reader,
         CacheInterface $enabledFilterConfiguratorCache)
     {
@@ -57,7 +57,7 @@ class EnabledFilterConfigurator
                     $restaurants = $this->restaurantRepository->findByCustomer($user);
                 }
 
-                return array_map(function (Restaurant $restaurant) {
+                return array_map(function (LocalBusiness $restaurant) {
                     return $restaurant->getId();
                 }, $restaurants);
             });

--- a/src/AppBundle/EventListener/Upload/UploadListener.php
+++ b/src/AppBundle/EventListener/Upload/UploadListener.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\EventListener\Upload;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\Sylius\Product;
 use AppBundle\Service\SettingsManager;
 use Doctrine\Persistence\ManagerRegistry;
@@ -46,7 +46,7 @@ final class UploadListener
 
         $objectClass = null;
         if ($type === 'restaurant') {
-            $objectClass = Restaurant::class;
+            $objectClass = LocalBusiness::class;
         } elseif ($type === 'product') {
             $objectClass = Product::class;
         } else {

--- a/src/AppBundle/EventSubscriber/ProfileSubscriber.php
+++ b/src/AppBundle/EventSubscriber/ProfileSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\EventSubscriber;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\Store;
 use Doctrine\Common\Collections\Collection;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +21,7 @@ class ProfileSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * @return Restaurant|Store
+     * @return LocalBusiness|Store
      */
     private function findResourceInSession(Request $request, Collection $items, $sessionKey)
     {

--- a/src/AppBundle/Form/PreparationTimeRulesType.php
+++ b/src/AppBundle/Form/PreparationTimeRulesType.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Form;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -31,7 +31,7 @@ class PreparationTimeRulesType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'data_class' => Restaurant::class,
+            'data_class' => LocalBusiness::class,
         ));
     }
 }

--- a/src/AppBundle/Form/Restaurant/DepositRefundSettingsType.php
+++ b/src/AppBundle/Form/Restaurant/DepositRefundSettingsType.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Form\Restaurant;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -21,7 +21,7 @@ class DepositRefundSettingsType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'data_class' => Restaurant::class,
+            'data_class' => LocalBusiness::class,
         ));
     }
 }

--- a/src/AppBundle/Form/RestaurantType.php
+++ b/src/AppBundle/Form/RestaurantType.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Form;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -119,7 +119,7 @@ class RestaurantType extends LocalBusinessType
         parent::configureOptions($resolver);
 
         $resolver->setDefaults(array(
-            'data_class' => Restaurant::class,
+            'data_class' => LocalBusiness::class,
             'loopeat_enabled' => $this->loopeatEnabled,
         ));
     }

--- a/src/AppBundle/Form/Sylius/Promotion/CreditNoteType.php
+++ b/src/AppBundle/Form/Sylius/Promotion/CreditNoteType.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Form\Sylius\Promotion;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Form\Type\MoneyType;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
@@ -31,7 +31,7 @@ class CreditNoteType extends AbstractType
                 'help' => 'form.credit_note.name.help'
             ])
             ->add('restaurant', EntityType::class, [
-                'class' => Restaurant::class,
+                'class' => LocalBusiness::class,
                 'choice_label' => 'name',
                 'help' => 'form.credit_note.restaurant.help',
                 'required' => false,

--- a/src/AppBundle/LoopEat/Client.php
+++ b/src/AppBundle/LoopEat/Client.php
@@ -3,7 +3,7 @@
 namespace AppBundle\LoopEat;
 
 use AppBundle\Entity\ApiUser;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use GuzzleHttp\Client as BaseClient;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
@@ -92,7 +92,7 @@ class Client extends BaseClient
         return json_decode((string) $response->getBody(), true);
     }
 
-    public function grab(ApiUser $customer, Restaurant $restaurant, $quantity = 1)
+    public function grab(ApiUser $customer, LocalBusiness $restaurant, $quantity = 1)
     {
         for ($i = 0; $i < $quantity; $i++) {
 

--- a/src/AppBundle/Resources/config/doctrine/ApiUser.orm.xml
+++ b/src/AppBundle/Resources/config/doctrine/ApiUser.orm.xml
@@ -26,7 +26,7 @@
         <join-column name="channel_id" referenced-column-name="id" nullable="true"/>
       </join-columns>
     </many-to-one>
-    <many-to-many field="restaurants" target-entity="AppBundle\Entity\Restaurant" inversed-by="owners">
+    <many-to-many field="restaurants" target-entity="AppBundle\Entity\LocalBusiness" inversed-by="owners">
       <cascade>
         <cascade-all/>
       </cascade>

--- a/src/AppBundle/Resources/config/doctrine/ClosingRule.orm.xml
+++ b/src/AppBundle/Resources/config/doctrine/ClosingRule.orm.xml
@@ -7,7 +7,7 @@
     <field name="startDate" type="datetime" column="start_date" nullable="false"/>
     <field name="endDate" type="datetime" column="end_date" nullable="false"/>
     <field name="reason" type="string" column="reason" nullable="true"/>
-    <many-to-one field="restaurant" target-entity="AppBundle\Entity\Restaurant" inversed-by="closingRules">
+    <many-to-one field="restaurant" target-entity="AppBundle\Entity\LocalBusiness" inversed-by="closingRules">
       <join-columns>
         <join-column name="restaurant_id" referenced-column-name="id"/>
       </join-columns>

--- a/src/AppBundle/Resources/config/doctrine/Contract.orm.xml
+++ b/src/AppBundle/Resources/config/doctrine/Contract.orm.xml
@@ -19,7 +19,7 @@
         <option name="default">0</option>
       </options>
     </field>
-    <one-to-one field="restaurant" target-entity="AppBundle\Entity\Restaurant" inversed-by="contract">
+    <one-to-one field="restaurant" target-entity="AppBundle\Entity\LocalBusiness" inversed-by="contract">
       <cascade>
         <cascade-persist/>
       </cascade>

--- a/src/AppBundle/Resources/config/doctrine/LocalBusiness.orm.xml
+++ b/src/AppBundle/Resources/config/doctrine/LocalBusiness.orm.xml
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd" xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
-  <entity name="AppBundle\Entity\LocalBusiness" inheritance-type="SINGLE_TABLE" table="restaurant">
-    <discriminator-column name="type" type="string" />
-    <discriminator-map>
-        <discriminator-mapping value="restaurant" class="AppBundle\Entity\Restaurant" />
-        <discriminator-mapping value="shop" class="AppBundle\Entity\Shop" />
-    </discriminator-map>
+  <entity name="AppBundle\Entity\LocalBusiness" table="restaurant" repository-class="AppBundle\Entity\LocalBusinessRepository">
     <id name="id" type="integer" column="id">
       <generator strategy="IDENTITY"/>
     </id>
     <indexes>
       <index name="restaurant_enabled_index" columns="id,enabled"/>
     </indexes>
+    <field name="type" type="string" column="type"/>
     <field name="name" type="string" column="name" nullable="true"/>
     <field name="description" type="text" column="description" nullable="true"/>
     <field name="enabled" type="boolean" column="enabled" nullable="false">

--- a/src/AppBundle/Resources/config/doctrine/Restaurant.Pledge.orm.xml
+++ b/src/AppBundle/Resources/config/doctrine/Restaurant.Pledge.orm.xml
@@ -17,7 +17,7 @@
         <join-column name="address_id" referenced-column-name="id"/>
       </join-columns>
     </one-to-one>
-    <one-to-one field="restaurant" target-entity="AppBundle\Entity\Restaurant" inversed-by="pledge">
+    <one-to-one field="restaurant" target-entity="AppBundle\Entity\LocalBusiness" inversed-by="pledge">
       <cascade>
         <cascade-all/>
       </cascade>

--- a/src/AppBundle/Resources/config/doctrine/Restaurant.PreparationTimeRule.orm.xml
+++ b/src/AppBundle/Resources/config/doctrine/Restaurant.PreparationTimeRule.orm.xml
@@ -9,7 +9,7 @@
       <gedmo:sortable-position/>
     </field>
     <field name="time" type="string" column="time"/>
-    <many-to-one field="restaurant" target-entity="AppBundle\Entity\Restaurant" inversed-by="preparationTimeRules">
+    <many-to-one field="restaurant" target-entity="AppBundle\Entity\LocalBusiness" inversed-by="preparationTimeRules">
       <join-columns>
         <join-column name="restaurant_id" referenced-column-name="id" on-delete="SET NULL"/>
       </join-columns>

--- a/src/AppBundle/Resources/config/doctrine/Restaurant.orm.xml
+++ b/src/AppBundle/Resources/config/doctrine/Restaurant.orm.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-  <entity repository-class="AppBundle\Entity\RestaurantRepository" name="AppBundle\Entity\Restaurant">
-  </entity>
-</doctrine-mapping>

--- a/src/AppBundle/Resources/config/doctrine/RestaurantStripeAccount.orm.xml
+++ b/src/AppBundle/Resources/config/doctrine/RestaurantStripeAccount.orm.xml
@@ -8,7 +8,7 @@
       <generator strategy="IDENTITY"/>
     </id>
     <field name="livemode" type="boolean" column="livemode"/>
-    <many-to-one field="restaurant" target-entity="AppBundle\Entity\Restaurant" inversed-by="stripeAccounts">
+    <many-to-one field="restaurant" target-entity="AppBundle\Entity\LocalBusiness" inversed-by="stripeAccounts">
       <join-columns>
         <join-column name="restaurant_id" referenced-column-name="id"/>
       </join-columns>

--- a/src/AppBundle/Resources/config/doctrine/ReusablePackaging.orm.xml
+++ b/src/AppBundle/Resources/config/doctrine/ReusablePackaging.orm.xml
@@ -9,7 +9,7 @@
     <field name="onHold" type="integer" column="on_hold"/>
     <field name="onHand" type="integer" column="on_hand"/>
     <field name="tracked" type="boolean" column="tracked"/>
-    <many-to-one field="restaurant" target-entity="AppBundle\Entity\Restaurant" inversed-by="reusablePackagings">
+    <many-to-one field="restaurant" target-entity="AppBundle\Entity\LocalBusiness" inversed-by="reusablePackagings">
       <join-columns>
         <join-column name="restaurant_id" referenced-column-name="id"/>
       </join-columns>

--- a/src/AppBundle/Resources/config/doctrine/Shop.orm.xml
+++ b/src/AppBundle/Resources/config/doctrine/Shop.orm.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-  <entity repository-class="AppBundle\Entity\ShopRepository"  name="AppBundle\Entity\Shop">
-  </entity>
-</doctrine-mapping>

--- a/src/AppBundle/Resources/config/doctrine/Sylius.Order.orm.xml
+++ b/src/AppBundle/Resources/config/doctrine/Sylius.Order.orm.xml
@@ -48,7 +48,7 @@
         <join-column name="customer_id" referenced-column-name="id" nullable="true"/>
       </join-columns>
     </many-to-one>
-    <many-to-one field="restaurant" target-entity="AppBundle\Entity\Restaurant" inversed-by="orders">
+    <many-to-one field="restaurant" target-entity="AppBundle\Entity\LocalBusiness" inversed-by="orders">
       <join-columns>
         <join-column name="restaurant_id" referenced-column-name="id" nullable="true"/>
       </join-columns>

--- a/src/AppBundle/Resources/config/doctrine/Sylius.Product.orm.xml
+++ b/src/AppBundle/Resources/config/doctrine/Sylius.Product.orm.xml
@@ -39,7 +39,7 @@
         <join-column name="reusable_packaging_id" referenced-column-name="id" nullable="true"/>
       </join-columns>
     </many-to-one>
-    <many-to-many field="restaurant" target-entity="AppBundle\Entity\Restaurant" inversed-by="products">
+    <many-to-many field="restaurant" target-entity="AppBundle\Entity\LocalBusiness" inversed-by="products">
       <join-table name="restaurant_product">
         <join-columns>
           <join-column name="product_id" referenced-column-name="id" unique="true"/>

--- a/src/AppBundle/Resources/views/index/index.html.twig
+++ b/src/AppBundle/Resources/views/index/index.html.twig
@@ -72,23 +72,23 @@
 </section>
 {% endif %}
 
-{% if shops|length > 0 %}
+{% if stores|length > 0 %}
 <section class="homepage-restaurants">
   <div class="container">
     <h2 class="homepage-restaurants__title">{% trans %}index.our_shops{% endtrans %}</h2>
     {% if show_more %}
     <div class="homepage-restaurants__show-more text-left">
-      <a href="{{ path('shops') }}">{% trans %}index.view_all_shops{% endtrans %} →</a>
+      <a href="{{ path('stores') }}">{% trans %}index.view_all_shops{% endtrans %} →</a>
     </div>
     {% endif %}
     <div class="row display-flex restaurant-list">
-      {% for restaurant in shops %}
+      {% for restaurant in stores %}
         <div class="col-xs-12 col-md-4 display-flex">
-          {% include "@App/_partials/restaurant/list_thumbnail.html.twig" with { local_business_type: 'shop' } %}
+          {% include "@App/_partials/restaurant/list_thumbnail.html.twig" with { local_business_type: 'store' } %}
         </div>
       {% endfor %}
-      {% if shops|length < max_results %}
-        {% set pad = (max_results - shops|length) %}
+      {% if stores|length < max_results %}
+        {% set pad = (max_results - stores|length) %}
         {% for i in range(0, (pad - 1)) %}
           <div class="col-xs-12 col-md-4 display-flex">
             <div class="thumbnail restaurant-item">
@@ -104,7 +104,7 @@
     </div>
     {% if show_more %}
     <div class="homepage-restaurants__show-more text-right">
-      <a href="{{ path('shops') }}">{% trans %}index.view_all_shops{% endtrans %} →</a>
+      <a href="{{ path('stores') }}">{% trans %}index.view_all_shops{% endtrans %} →</a>
     </div>
     {% endif %}
   </div>

--- a/src/AppBundle/Resources/views/restaurant/index.html.twig
+++ b/src/AppBundle/Resources/views/restaurant/index.html.twig
@@ -14,7 +14,11 @@
 <div class="container">
 
   <div class="homepage-restaurants__show-more text-left">
-    <a href="{{ path('restaurants') }}">← {% trans %}index.view_all_restaurants{% endtrans %}</a>
+    {% if restaurant.type == 'store' %}
+      <a href="{{ path('stores') }}">← {% trans %}index.view_all_shops{% endtrans %}</a>
+    {% else %}
+      <a href="{{ path('restaurants') }}">← {% trans %}index.view_all_restaurants{% endtrans %}</a>
+    {% endif %}
   </div>
 
   {% if not restaurant.enabled %}

--- a/src/AppBundle/Serializer/RestaurantNormalizer.php
+++ b/src/AppBundle/Serializer/RestaurantNormalizer.php
@@ -4,7 +4,7 @@ namespace AppBundle\Serializer;
 
 use ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer;
 use AppBundle\Entity\ClosingRule;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Utils\OpeningHoursSpecification;
 use AppBundle\Utils\PriceFormatter;
 use Cocur\Slugify\SlugifyInterface;
@@ -65,7 +65,7 @@ class RestaurantNormalizer implements NormalizerInterface, DenormalizerInterface
         return false;
     }
 
-    private function shouldAddOpeningHoursSpecification(Restaurant $object, array $context = array())
+    private function shouldAddOpeningHoursSpecification(LocalBusiness $object, array $context = array())
     {
         return isset($context['groups'])
             && $this->containsGroups($context, ['restaurant', 'store', 'restaurant_seo'])
@@ -75,6 +75,10 @@ class RestaurantNormalizer implements NormalizerInterface, DenormalizerInterface
     public function normalize($object, $format = null, array $context = array())
     {
         $data = $this->normalizer->normalize($object, $format, $context);
+
+        if (isset($data['@type']) && $object->getType() === 'store') {
+            $data['@type'] = 'http://schema.org/Store';
+        }
 
         // FIXME Stop checking groups manually
         if ($this->shouldAddOpeningHoursSpecification($object, $context)) {
@@ -116,7 +120,7 @@ class RestaurantNormalizer implements NormalizerInterface, DenormalizerInterface
         return $data;
     }
 
-    private function normalizeForSeo(Restaurant $object, $data)
+    private function normalizeForSeo(LocalBusiness $object, $data)
     {
         $data['@context'] = 'http://schema.org';
 
@@ -177,7 +181,7 @@ class RestaurantNormalizer implements NormalizerInterface, DenormalizerInterface
 
     public function supportsNormalization($data, $format = null)
     {
-        return $this->normalizer->supportsNormalization($data, $format) && $data instanceof Restaurant;
+        return $this->normalizer->supportsNormalization($data, $format) && $data instanceof LocalBusiness;
     }
 
     public function denormalize($data, $class, $format = null, array $context = array())
@@ -189,6 +193,6 @@ class RestaurantNormalizer implements NormalizerInterface, DenormalizerInterface
 
     public function supportsDenormalization($data, $type, $format = null)
     {
-        return $this->normalizer->supportsDenormalization($data, $type, $format) && $type === Restaurant::class;
+        return $this->normalizer->supportsDenormalization($data, $type, $format) && $type === LocalBusiness::class;
     }
 }

--- a/src/AppBundle/Sylius/Cart/RestaurantCartContext.php
+++ b/src/AppBundle/Sylius/Cart/RestaurantCartContext.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Sylius\Cart;
 
-use AppBundle\Entity\RestaurantRepository;
+use AppBundle\Entity\LocalBusinessRepository;
 use Sylius\Component\Order\Context\CartContextInterface;
 use Sylius\Component\Order\Context\CartNotFoundException;
 use Sylius\Component\Order\Model\OrderInterface;
@@ -31,7 +31,7 @@ final class RestaurantCartContext implements CartContextInterface
         SessionInterface $session,
         OrderRepositoryInterface $orderRepository,
         FactoryInterface $orderFactory,
-        RestaurantRepository $restaurantRepository,
+        LocalBusinessRepository $restaurantRepository,
         string $sessionKeyName)
     {
         $this->session = $session;

--- a/src/AppBundle/Sylius/Order/OrderFactory.php
+++ b/src/AppBundle/Sylius/Order/OrderFactory.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Sylius\Order;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Service\SettingsManager;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Resource\Factory\FactoryInterface;
@@ -40,7 +40,7 @@ class OrderFactory implements FactoryInterface
         return $order;
     }
 
-    public function createForRestaurant(Restaurant $restaurant)
+    public function createForRestaurant(LocalBusiness $restaurant)
     {
         $order = $this->createNew();
         $order->setRestaurant($restaurant);

--- a/src/AppBundle/Sylius/Order/OrderInterface.php
+++ b/src/AppBundle/Sylius/Order/OrderInterface.php
@@ -4,7 +4,7 @@ namespace AppBundle\Sylius\Order;
 
 use AppBundle\Entity\Address;
 use AppBundle\Entity\Delivery;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\Sylius\OrderEvent;
 use Doctrine\Common\Collections\Collection;
 use Sylius\Component\Channel\Model\ChannelAwareInterface;
@@ -55,9 +55,9 @@ interface OrderInterface extends
     public function getRevenue(): int;
 
     /**
-     * @return Restaurant
+     * @return LocalBusiness|null
      */
-    public function getRestaurant(): ?Restaurant;
+    public function getRestaurant(): ?LocalBusiness;
 
     /**
      * @return Address|null

--- a/src/AppBundle/Sylius/Product/ProductInterface.php
+++ b/src/AppBundle/Sylius/Product/ProductInterface.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Sylius\Product;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use Sylius\Component\Product\Model\ProductInterface as BaseProductInterface;
 use Sylius\Component\Product\Model\ProductOptionValueInterface;
 
@@ -13,14 +13,14 @@ interface ProductInterface extends BaseProductInterface
     const STRATEGY_OPTION_VALUE = 'option_value';
 
     /**
-     * @return Restaurant
+     * @return LocalBusiness
      */
-    public function getRestaurant(): ?Restaurant;
+    public function getRestaurant(): ?LocalBusiness;
 
     /**
-     * @param Restaurant $restaurant
+     * @param LocalBusiness $restaurant
      */
-    public function setRestaurant(?Restaurant $restaurant): void;
+    public function setRestaurant(?LocalBusiness $restaurant): void;
 
     public function hasOptionValue(ProductOptionValueInterface $optionValue): bool;
 }

--- a/src/AppBundle/Sylius/Promotion/Checker/Rule/IsRestaurantRuleChecker.php
+++ b/src/AppBundle/Sylius/Promotion/Checker/Rule/IsRestaurantRuleChecker.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Sylius\Promotion\Checker\Rule;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use Doctrine\Persistence\ManagerRegistry;
 use Sylius\Component\Promotion\Checker\Rule\RuleCheckerInterface;
 use Sylius\Component\Promotion\Model\PromotionSubjectInterface;
@@ -31,7 +31,7 @@ class IsRestaurantRuleChecker implements RuleCheckerInterface
             return false;
         }
 
-        $restaurant = $this->doctrine->getRepository(Restaurant::class)->find($configuration['restaurant_id']);
+        $restaurant = $this->doctrine->getRepository(LocalBusiness::class)->find($configuration['restaurant_id']);
 
         if (null === $restaurant) {
             return false;

--- a/src/AppBundle/Utils/AccessControl.php
+++ b/src/AppBundle/Utils/AccessControl.php
@@ -3,7 +3,7 @@
 namespace AppBundle\Utils;
 
 use AppBundle\Entity\Delivery;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\Store;
 use AppBundle\Sylius\Order\OrderInterface;
 use FOS\UserBundle\Model\UserInterface;
@@ -27,7 +27,7 @@ class AccessControl
         return $isAdmin || $ownsRestaurant || $isCustomer;
     }
 
-    public static function restaurant(UserInterface $user, Restaurant $restaurant)
+    public static function restaurant(UserInterface $user, LocalBusiness $restaurant)
     {
         $isAdmin = $user->hasRole('ROLE_ADMIN');
         $ownsRestaurant = $user->ownsRestaurant($restaurant);

--- a/src/AppBundle/Utils/MenuEditor.php
+++ b/src/AppBundle/Utils/MenuEditor.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Utils;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 
@@ -11,7 +11,7 @@ class MenuEditor
     private $restaurant;
     private $menu;
 
-    public function __construct(Restaurant $restaurant, $menu)
+    public function __construct(LocalBusiness $restaurant, $menu)
     {
         $this->restaurant = $restaurant;
         $this->menu = $menu;

--- a/src/AppBundle/Utils/PreparationTimeCalculator.php
+++ b/src/AppBundle/Utils/PreparationTimeCalculator.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Utils;
 
 use AppBundle\Entity\LocalBusiness;
-use AppBundle\Entity\Restaurant;
 use AppBundle\Sylius\Order\OrderInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 

--- a/src/AppBundle/Utils/RestaurantFilter.php
+++ b/src/AppBundle/Utils/RestaurantFilter.php
@@ -4,7 +4,7 @@ namespace AppBundle\Utils;
 
 use AppBundle\Entity\Address;
 use AppBundle\Entity\Base\GeoCoordinates;
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Service\RoutingInterface;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\Stopwatch\Stopwatch;
@@ -46,7 +46,7 @@ class RestaurantFilter
         }
 
         // Sort by distance
-        usort($matches, function (Restaurant $a, Restaurant $b) use ($hash) {
+        usort($matches, function (LocalBusiness $a, LocalBusiness $b) use ($hash) {
             return $hash[$a] < $hash[$b] ? -1 : 1;
         });
 

--- a/src/AppBundle/Validator/Constraints/IsActivableRestaurantValidator.php
+++ b/src/AppBundle/Validator/Constraints/IsActivableRestaurantValidator.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Validator\Constraints;
 
-use AppBundle\Entity\Restaurant;
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Service\SettingsManager;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -29,7 +29,7 @@ class IsActivableRestaurantValidator extends ConstraintValidator
                 ->addViolation();
         }
 
-        if ($object->getState() === Restaurant::STATE_PLEDGE) {
+        if ($object->getState() === LocalBusiness::STATE_PLEDGE) {
             return;
         }
 

--- a/tests/AppBundle/Controller/RestaurantControllerTest.php
+++ b/tests/AppBundle/Controller/RestaurantControllerTest.php
@@ -7,6 +7,8 @@ use AppBundle\DataType\NumRange;
 use AppBundle\Entity\Address;
 use AppBundle\Entity\Contract;
 use AppBundle\Entity\Base\GeoCoordinates;
+use AppBundle\Entity\LocalBusiness;
+use AppBundle\Entity\LocalBusinessRepository;
 use AppBundle\Entity\Restaurant;
 use AppBundle\Entity\Sylius\Order;
 use AppBundle\Sylius\Order\OrderItemInterface;
@@ -72,12 +74,12 @@ class RestaurantControllerTest extends WebTestCase
         $this->orderModifier = $this->prophesize(OrderModifierInterface::class);
         $this->orderTimeHelper = $this->prophesize(OrderTimeHelper::class);
 
-        $this->restaurantRepository = $this->prophesize(EntityRepository::class);
+        $this->localBusinessRepository = $this->prophesize(LocalBusinessRepository::class);
 
         $this->doctrine = $this->prophesize(ManagerRegistry::class);
         $this->doctrine
-            ->getRepository(Restaurant::class)
-            ->willReturn($this->restaurantRepository->reveal());
+            ->getRepository(LocalBusiness::class)
+            ->willReturn($this->localBusinessRepository->reveal());
 
         // Use the "real" serializer
         $this->serializer = static::$kernel->getContainer()->get('serializer');
@@ -113,7 +115,8 @@ class RestaurantControllerTest extends WebTestCase
             $this->orderItemQuantityModifier->reveal(),
             $this->orderModifier->reveal(),
             $this->orderTimeHelper->reveal(),
-            $this->serializer
+            $this->serializer,
+            $this->localBusinessRepository->reveal()
         );
 
         $this->controller->setContainer($container->reveal());
@@ -166,7 +169,7 @@ class RestaurantControllerTest extends WebTestCase
 
         $restaurant->addProduct($product->reveal());
 
-        $this->restaurantRepository->find(1)->willReturn($restaurant);
+        $this->localBusinessRepository->find(1)->willReturn($restaurant);
 
         $cartContext = $this->prophesize(CartContextInterface::class);
         $translator = $this->prophesize(TranslatorInterface::class);

--- a/tests/AppBundle/Sylius/Cart/RestaurantCartContextTest.php
+++ b/tests/AppBundle/Sylius/Cart/RestaurantCartContextTest.php
@@ -5,7 +5,7 @@ namespace Tests\AppBundle\Sylius\Cart;
 use AppBundle\Sylius\Order\OrderInterface;
 use AppBundle\Sylius\Order\OrderFactory;
 use AppBundle\Entity\Restaurant;
-use AppBundle\Entity\RestaurantRepository;
+use AppBundle\Entity\LocalBusinessRepository;
 use AppBundle\Sylius\Cart\RestaurantCartContext;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Order\Context\CartNotFoundException;
@@ -27,7 +27,7 @@ class RestaurantCartContextTest extends TestCase
         $this->session = $this->prophesize(SessionInterface::class);
         $this->orderRepository = $this->prophesize(OrderRepositoryInterface::class);
         $this->orderFactory = $this->prophesize(OrderFactory::class);
-        $this->restaurantRepository = $this->prophesize(RestaurantRepository::class);
+        $this->restaurantRepository = $this->prophesize(LocalBusinessRepository::class);
 
         $this->context = new RestaurantCartContext(
             $this->session->reveal(),

--- a/tests/AppBundle/Sylius/Promotion/Checker/Rule/IsRestaurantRuleCheckerTest.php
+++ b/tests/AppBundle/Sylius/Promotion/Checker/Rule/IsRestaurantRuleCheckerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\AppBundle\Sylius\Promotion\Checker\Rule;
 
+use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\Restaurant;
 use AppBundle\Sylius\Order\OrderInterface;
 use AppBundle\Sylius\Promotion\Checker\Rule\IsRestaurantRuleChecker;
@@ -17,7 +18,7 @@ class IsRestaurantRuleCheckerTest extends TestCase
         $this->objectRepository = $this->prophesize(ObjectRepository::class);
 
         $this->doctrine = $this->prophesize(ManagerRegistry::class);
-        $this->doctrine->getRepository(Restaurant::class)->willReturn($this->objectRepository->reveal());
+        $this->doctrine->getRepository(LocalBusiness::class)->willReturn($this->objectRepository->reveal());
 
         $this->ruleChecker = new IsRestaurantRuleChecker(
             $this->doctrine->reveal()


### PR DESCRIPTION
This pull request is the very first step towards a generic management of all kind of businesses. 

It drops Doctrine inheritance between `LocalBusiness` → `Restaurant`, because API Platform is not working correctly, and object oriented inheritance is not useful here except for purity. 

Everything is now managed via the `LocalBusiness` class.
The previous `/api/restaurants/*` endpoints are preserved for backward compatibility. 

See #1311 

