### PR TITLE
Improve refunds

### DIFF
--- a/app/DoctrineMigrations/Version20200825162252.php
+++ b/app/DoctrineMigrations/Version20200825162252.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20200825162252 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('CREATE TABLE refund (id SERIAL NOT NULL, payment_id INT DEFAULT NULL, amount INT NOT NULL, liable_party VARCHAR(255) NOT NULL, data JSON NOT NULL, comments TEXT DEFAULT NULL, created_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, updated_at TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_5B2C14584C3A3BB ON refund (payment_id)');
+        $this->addSql('COMMENT ON COLUMN refund.data IS \'(DC2Type:json_array)\'');
+        $this->addSql('ALTER TABLE refund ADD CONSTRAINT FK_5B2C14584C3A3BB FOREIGN KEY (payment_id) REFERENCES sylius_payment (id) ON DELETE SET NULL NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'postgresql', 'Migration can only be executed safely on \'postgresql\'.');
+
+        $this->addSql('DROP TABLE refund');
+    }
+}

--- a/app/DoctrineMigrations/Version20200826135116.php
+++ b/app/DoctrineMigrations/Version20200826135116.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use AppBundle\Service\StripeManager;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Stripe;
+
+final class Version20200826135116 extends AbstractMigration
+{
+
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    private function getSetting($name)
+    {
+        $stmt = $this->connection->executeQuery(
+            'SELECT value FROM craue_config_setting WHERE name = :name',
+            [ 'name' => $name ]
+        );
+
+        return $stmt->fetchColumn();
+    }
+
+    private function configureStripe(): bool
+    {
+        $livemode = filter_var($this->getSetting('stripe_livemode'), FILTER_VALIDATE_BOOLEAN);
+        $secretKey = $this->getSetting(sprintf('stripe_%s_secret_key', $livemode ? 'live' : 'test'));
+
+        if (!$secretKey) {
+            return false;
+        }
+
+        Stripe\Stripe::setApiKey($secretKey);
+        Stripe\Stripe::setApiVersion(StripeManager::STRIPE_API_VERSION);
+
+        return true;
+    }
+
+    public function up(Schema $schema) : void
+    {
+        if (!$this->configureStripe()) {
+            return;
+        }
+
+        $stmt = $this->connection->prepare('SELECT id, details FROM sylius_payment WHERE details::jsonb ?? \'refunds\'');
+
+        $stmt->execute();
+
+        while ($payment = $stmt->fetch()) {
+            $details = json_decode($payment['details'], true);
+
+            $stripeOptions = [];
+
+            if (isset($details['stripe_user_id'])) {
+                $stripeOptions['stripe_account'] = $details['stripe_user_id'];
+            }
+
+            foreach ($details['refunds'] as $refund) {
+
+                $stripeRefund = Stripe\Refund::retrieve(
+                    $refund['id'],
+                    $stripeOptions
+                );
+
+                $this->addSql('INSERT INTO refund (payment_id, liable_party, amount, data, created_at, updated_at) VALUES (:payment_id, :liable_party, :amount, :data, :created_at, :updated_at)', [
+                    'payment_id' => $payment['id'],
+                    'liable_party' => 'unknown',
+                    'amount' => $refund['amount'],
+                    'data' => json_encode(['stripe_refund_id' => $refund['id']]),
+                    'created_at' => date('Y-m-d H:i:s', $stripeRefund->created),
+                    'updated_at' => date('Y-m-d H:i:s', $stripeRefund->created),
+                ]);
+            }
+        }
+    }
+
+    public function down(Schema $schema) : void
+    {
+        $this->addSql('DELETE FROM refund');
+    }
+}

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -211,16 +211,14 @@ class AdminController extends Controller
                 $hasClickedRefund =
                     $paymentForm->getClickedButton() && 'refund' === $paymentForm->getClickedButton()->getName();
 
-                $hasExpectedFields =
-                    $paymentForm->has('amount') && $paymentForm->has('refundApplicationFee');
+                $hasExpectedFields = $paymentForm->has('amount');
 
                 if ($hasClickedRefund && $hasExpectedFields) {
 
                     $payment = $paymentForm->getData();
                     $amount = $paymentForm->get('amount')->getData();
-                    $refundApplicationFee = $paymentForm->get('refundApplicationFee')->getData();
 
-                    $orderManager->refundPayment($payment, $amount, $refundApplicationFee);
+                    $orderManager->refundPayment($payment, $amount);
 
                     $this->get('sylius.manager.order')->flush();
 

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -217,8 +217,10 @@ class AdminController extends Controller
 
                     $payment = $paymentForm->getData();
                     $amount = $paymentForm->get('amount')->getData();
+                    $liableParty = $paymentForm->get('liable')->getData();
+                    $comments = $paymentForm->get('comments')->getData();
 
-                    $orderManager->refundPayment($payment, $amount);
+                    $orderManager->refundPayment($payment, $amount, $liableParty, $comments);
 
                     $this->get('sylius.manager.order')->flush();
 

--- a/src/Controller/Utils/RestaurantTrait.php
+++ b/src/Controller/Utils/RestaurantTrait.php
@@ -1077,6 +1077,8 @@ trait RestaurantTrait
 
     public function statsAction($id, Request $request, SlugifyInterface $slugify, TranslatorInterface $translator)
     {
+        $tab = $request->query->get('tab', 'orders');
+
         $restaurant = $this->getDoctrine()
             ->getRepository(LocalBusiness::class)
             ->find($id);
@@ -1104,7 +1106,7 @@ trait RestaurantTrait
         $end->setDate($date->format('Y'), $date->format('m'), $date->format('t'));
         $end->setTime(23, 59, 59);
 
-        $orders = $this->getDoctrine()->getRepository(Order::class)
+        $orders = $this->get('sylius.repository.order')
             ->findOrdersByRestaurantAndDateRange(
                 $restaurant,
                 $start,
@@ -1144,7 +1146,8 @@ trait RestaurantTrait
             'restaurant' => $restaurant,
             'stats' => $stats,
             'start' => $start,
-            'end' => $end
+            'end' => $end,
+            'tab' => $tab,
         ]));
     }
 

--- a/src/Domain/Order/Command/Refund.php
+++ b/src/Domain/Order/Command/Refund.php
@@ -2,17 +2,22 @@
 
 namespace AppBundle\Domain\Order\Command;
 
+use AppBundle\Entity\Refund as RefundEntity;
 use Sylius\Component\Payment\Model\PaymentInterface;
 
 class Refund
 {
     private $payment;
     private $amount;
+    private $liableParty;
+    private $comments;
 
-    public function __construct(PaymentInterface $payment, $amount = null)
+    public function __construct(PaymentInterface $payment, $amount = null, $liableParty = RefundEntity::LIABLE_PARTY_PLATFORM, $comments = '')
     {
         $this->payment = $payment;
         $this->amount = $amount;
+        $this->liableParty = $liableParty;
+        $this->comments = $comments;
     }
 
     public function getPayment()
@@ -23,5 +28,15 @@ class Refund
     public function getAmount()
     {
         return $this->amount;
+    }
+
+    public function getLiableParty()
+    {
+        return $this->liableParty;
+    }
+
+    public function getComments()
+    {
+        return $this->comments;
     }
 }

--- a/src/Domain/Order/Command/Refund.php
+++ b/src/Domain/Order/Command/Refund.php
@@ -8,13 +8,11 @@ class Refund
 {
     private $payment;
     private $amount;
-    private $refundApplicationFee;
 
-    public function __construct(PaymentInterface $payment, $amount = null, $refundApplicationFee = false)
+    public function __construct(PaymentInterface $payment, $amount = null)
     {
         $this->payment = $payment;
         $this->amount = $amount;
-        $this->refundApplicationFee = $refundApplicationFee;
     }
 
     public function getPayment()
@@ -25,10 +23,5 @@ class Refund
     public function getAmount()
     {
         return $this->amount;
-    }
-
-    public function getRefundApplicationFee()
-    {
-        return $this->refundApplicationFee;
     }
 }

--- a/src/Domain/Order/Handler/RefundHandler.php
+++ b/src/Domain/Order/Handler/RefundHandler.php
@@ -30,7 +30,6 @@ class RefundHandler
     {
         $payment = $command->getPayment();
         $amount = $command->getAmount();
-        $refundApplicationFee = $command->getRefundApplicationFee();
 
         $stateMachine = $this->stateMachineFactory->get($payment, PaymentTransitions::GRAPH);
 
@@ -43,7 +42,7 @@ class RefundHandler
 
         $transition = $isPartial ? 'refund_partially' : PaymentTransitions::TRANSITION_REFUND;
 
-        $refund = $this->stripeManager->refund($payment, $amount, $refundApplicationFee);
+        $refund = $this->stripeManager->refund($payment, $amount);
 
         if ($payment->getState() === 'refunded_partially' && $transition !== 'refund_partially') {
             $stateMachine->apply($transition);

--- a/src/Entity/Refund.php
+++ b/src/Entity/Refund.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace AppBundle\Entity;
+
+use AppBundle\Entity\Sylius\Payment;
+use Gedmo\Timestampable\Traits\Timestampable;
+
+class Refund
+{
+    use Timestampable;
+
+    const LIABLE_PARTY_PLATFORM = 'platform';
+    const LIABLE_PARTY_MERCHANT = 'merchant';
+
+    private $id;
+    private $payment;
+    private $liableParty;
+    private $amount;
+    private $comments = '';
+    private $data = [];
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPayment()
+    {
+        return $this->payment;
+    }
+
+    /**
+     * @param mixed $payment
+     *
+     * @return self
+     */
+    public function setPayment($payment)
+    {
+        $this->payment = $payment;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLiableParty()
+    {
+        return $this->liableParty;
+    }
+
+    /**
+     * @param mixed $liableParty
+     *
+     * @return self
+     */
+    public function setLiableParty($liableParty)
+    {
+        $this->liableParty = $liableParty;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getAmount(): int
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @param int $amount
+     *
+     * @return self
+     */
+    public function setAmount(int $amount)
+    {
+        $this->amount = $amount;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param array $data
+     *
+     * @return self
+     */
+    public function setData(array $data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getComments()
+    {
+        return $this->comments;
+    }
+
+    /**
+     * @param mixed $comments
+     *
+     * @return self
+     */
+    public function setComments($comments)
+    {
+        $this->comments = $comments;
+
+        return $this;
+    }
+}

--- a/src/Entity/Sylius/Order.php
+++ b/src/Entity/Sylius/Order.php
@@ -523,6 +523,8 @@ class Order extends BaseOrder implements OrderInterface
             return null;
         }
 
+        // TODO Order payments by creation date
+
         $payment = $this->payments->filter(function (PaymentInterface $payment) use ($state): bool {
             return null === $state || $payment->getState() === $state;
         })->last();
@@ -880,6 +882,22 @@ class Order extends BaseOrder implements OrderInterface
         }
 
         return false;
+    }
+
+    public function getRefunds(): array
+    {
+        $refunds = [];
+        foreach ($this->getPayments() as $payment) {
+            if (PaymentInterface::STATE_COMPLETED === $payment->getState()) {
+                if ($payment->hasRefunds()) {
+                    foreach ($payment->getRefunds() as $refund) {
+                        $refunds[] = $refund;
+                    }
+                }
+            }
+        }
+
+        return $refunds;
     }
 
     /**

--- a/src/Entity/Sylius/Payment.php
+++ b/src/Entity/Sylius/Payment.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Entity\Sylius;
 
 use AppBundle\Sylius\Payment\MercadopagoTrait;
+use AppBundle\Sylius\Payment\RefundTrait;
 use AppBundle\Sylius\Payment\StripeTrait;
 use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Component\Order\Model\OrderInterface;
@@ -13,6 +14,7 @@ class Payment extends BasePayment implements OrderAwareInterface
 {
     use StripeTrait;
     use MercadopagoTrait;
+    use RefundTrait;
 
     protected $order;
     protected $refunds;

--- a/src/Entity/Sylius/Payment.php
+++ b/src/Entity/Sylius/Payment.php
@@ -4,6 +4,7 @@ namespace AppBundle\Entity\Sylius;
 
 use AppBundle\Sylius\Payment\MercadopagoTrait;
 use AppBundle\Sylius\Payment\StripeTrait;
+use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Order\Model\OrderAwareInterface;
 use Sylius\Component\Payment\Model\Payment as BasePayment;
@@ -14,6 +15,14 @@ class Payment extends BasePayment implements OrderAwareInterface
     use MercadopagoTrait;
 
     protected $order;
+    protected $refunds;
+
+    public function __construct()
+    {
+        $this->refunds = new ArrayCollection();
+
+        parent::__construct();
+    }
 
     public function getOrder(): ?OrderInterface
     {

--- a/src/Form/PaymentType.php
+++ b/src/Form/PaymentType.php
@@ -51,13 +51,6 @@ class PaymentType extends AbstractType
                             'mapped' => false,
                         ]);
 
-                        $form->add('refundApplicationFee', CheckboxType::class, [
-                            'label' => 'form.payment.refund_application_fee.label',
-                            'data' => true,
-                            'mapped' => false,
-                            'required' => false,
-                        ]);
-
                         $form->add('refund', SubmitType::class, [
                             'label' => 'form.order.payment_refund.label'
                         ]);

--- a/src/Form/PaymentType.php
+++ b/src/Form/PaymentType.php
@@ -8,7 +8,8 @@ use Sylius\Component\Order\Model\OrderInterface;
 use Sylius\Component\Payment\PaymentTransitions;
 use Sylius\Component\Payment\Model\PaymentInterface;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvents;
@@ -49,6 +50,23 @@ class PaymentType extends AbstractType
                             'help' => 'form.payment.refund_amount.help',
                             'data' => $payment->getRefundAmount(),
                             'mapped' => false,
+                        ]);
+                        $form->add('liable', ChoiceType::class, [
+                            'choices'  => [
+                                'Merchant' => 'merchant',
+                                'Platform' => 'platform',
+                            ],
+                            'label' => 'form.payment.refund_liable.label',
+                            'help' => 'form.payment.refund_liable.help',
+                            'expanded' => true,
+                            'multiple' => false,
+                            'mapped' => false,
+                        ]);
+                        $form->add('comments', TextareaType::class, [
+                            'label' => 'form.payment.refund_comment.label',
+                            'help' => 'form.payment.refund_comment.help',
+                            'mapped' => false,
+                            'attr' => ['rows' => '6'],
                         ]);
 
                         $form->add('refund', SubmitType::class, [

--- a/src/Resources/config/doctrine/Refund.orm.xml
+++ b/src/Resources/config/doctrine/Refund.orm.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd" xmlns:gedmo="http://gediminasm.org/schemas/orm/doctrine-extensions-mapping">
+  <entity name="AppBundle\Entity\Refund" table="refund">
+    <id name="id" type="integer" column="id">
+      <generator strategy="IDENTITY"/>
+    </id>
+    <field name="amount" type="integer" column="amount"/>
+    <field name="liableParty" type="string" column="liable_party"/>
+    <field name="data" type="json_array" column="data"/>
+    <field name="comments" type="text" column="comments" nullable="true"/>
+    <field name="createdAt" type="datetime" column="created_at">
+      <gedmo:timestampable on="create"/>
+    </field>
+    <field name="updatedAt" type="datetime" column="updated_at">
+      <gedmo:timestampable on="update"/>
+    </field>
+    <many-to-one field="payment" target-entity="AppBundle\Entity\Sylius\Payment" inversed-by="refunds">
+      <join-columns>
+        <join-column name="payment_id" referenced-column-name="id" on-delete="SET NULL"/>
+      </join-columns>
+    </many-to-one>
+  </entity>
+</doctrine-mapping>

--- a/src/Resources/config/doctrine/Sylius.Payment.orm.xml
+++ b/src/Resources/config/doctrine/Sylius.Payment.orm.xml
@@ -6,5 +6,10 @@
         <join-column name="order_id" referenced-column-name="id" on-delete="CASCADE" nullable="false"/>
       </join-columns>
     </many-to-one>
+    <one-to-many field="refunds" target-entity="AppBundle\Entity\Refund" mapped-by="payment">
+      <cascade>
+        <cascade-persist/>
+      </cascade>
+    </one-to-many>
   </entity>
 </doctrine-mapping>

--- a/src/Resources/translations/messages.ca.yml
+++ b/src/Resources/translations/messages.ca.yml
@@ -340,10 +340,6 @@ form.order.payment_refund.label: Devolució
 form.order.refund_modal.title: Devolució
 form.payment.refund_amount.label: Import
 form.payment.refund_amount.help: L’import que especifiqueu es retornarà al client
-form.payment.refund_application_fee.label: Comissions de devolució
-form.payment.refund_application_fee.help: "Si marqueu aquesta casella, la comissió\
-  \ que cobra la plataforma al soci es retornarà proporcionalment\n<br>\n<a href=\"\
-  https://stripe.com/docs/connect/direct-charges#issuing-refunds\">Aprèn més</a>\n"
 form.address.addressLocality.label: Ciutat
 form.address.postalCode.label: Codi Postal
 form.address.description.label: Instruccions

--- a/src/Resources/translations/messages.cs.yml
+++ b/src/Resources/translations/messages.cs.yml
@@ -435,10 +435,6 @@ form.order.refuse.refund.alert: Tato objednávka byla placena platební metodou,
   nespravuje předautorizace. Pokud ji odmítnete, bude platba vrácena. Jste si jist?
 form.payment.refund_amount.label: Částka
 form.payment.refund_amount.help: Částka, kterou určíte, bude vrácena zákazníkovi
-form.payment.refund_application_fee.label: Vrácení poplatků
-form.payment.refund_application_fee.help: "Pokud zaškrtnete toto políčko, bude provize,\
-  \ kterou platforma účtuje partnerovi, vrácena proporčně\n<br>\n<a href=\"https://stripe.com/docs/connect/direct-charges#issuing-refunds\"\
-  > Další informace </a>\n"
 form.address.addressLocality.label: Město
 form.address.postalCode.label: PSČ
 form.address.description.label: Instrukce

--- a/src/Resources/translations/messages.de.yml
+++ b/src/Resources/translations/messages.de.yml
@@ -411,7 +411,6 @@ delivery.with_id: 'Versand #%id%'
 profile.username: Benutzername
 form.order.refund_modal.title: Rückzahlung
 form.payment.refund_amount.help: Der von Dir angegebene Betrag wird dem Kunden zurückerstattet
-form.payment.refund_application_fee.label: Gebühren der Rückerstattung
 form.suggest.submit.label: Jetzt vorschlagen
 form.suggest.name.help: Bitte geben Sie den exakten Namen an, damit wir ihn finden
   können
@@ -447,9 +446,6 @@ form.settings.stripe.help: 'Stripe ist ein Zahlungsdienstleister zum Verarbeiten
   ist es nötig Stripe Connect einzurichten. Stripe entnimmt 0,25 Euro + 1,4% pro Zahlung
   als Provision (für eine aktuelle Kostenübersicht, klicke bitte <a href="https://stripe.com/fr/pricing">hier</a>),
   die vom Shopbetreiber bezahlt werden muss. '
-form.payment.refund_application_fee.help: "Wenn Sie diese Auswahlbox aktivieren, wird\
-  \ die Provision der Plattform an den Partner anteilig zurückgegeben.\n<br>\n<a href=\"\
-  https://stripe.com/docs/connect/direct-charges#issuing-refunds\">Learn more</a>\n"
 form.delivery.view_order: Zeige Bestellung
 form.delivery.time_slot.label: Zeitfenster
 form.delivery.has_order.info: Diese Lieferung ist an eine Bestellung geknüpft

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -453,6 +453,10 @@ form.order.refuse.refund.alert: This order was paid with a payment method that d
   you sure?
 form.payment.refund_amount.label: Amount
 form.payment.refund_amount.help: The amount you specify will be refunded to the customer
+form.payment.refund_liable.label: Liable party
+form.payment.refund_liable.help: Which party is liable for the incident?
+form.payment.refund_comment.label: Comments
+form.payment.refund_comment.help: Please describe what happened
 form.payment.refund_application_fee.help: "If you check this box, the commission charged\
   \ by the platform to the partner will be refunded proportionally\n<br>\n<a href=\"\
   https://stripe.com/docs/connect/direct-charges#issuing-refunds\">Learn more</a>\n"
@@ -1053,3 +1057,10 @@ form:
       label: Contact person for the restaurant
     b2b:
       label: Would you like to propose special offers for companies?
+refund.list.amount: Refunded amount
+refund.list.liable_party: Liable party
+refund.list.comments: Comments
+refund.list.debit_total: Total amount due by the platform to the business
+refund.list.refunded_at: Refunded at
+refund.list.disclaimer.admin: "When the platform is responsible for the incident, \
+  it means the platform owes the merchant the amount of the refund, because the merchant actually refunded the customer."

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -453,7 +453,6 @@ form.order.refuse.refund.alert: This order was paid with a payment method that d
   you sure?
 form.payment.refund_amount.label: Amount
 form.payment.refund_amount.help: The amount you specify will be refunded to the customer
-form.payment.refund_application_fee.label: Refund fees
 form.payment.refund_application_fee.help: "If you check this box, the commission charged\
   \ by the platform to the partner will be refunded proportionally\n<br>\n<a href=\"\
   https://stripe.com/docs/connect/direct-charges#issuing-refunds\">Learn more</a>\n"

--- a/src/Resources/translations/messages.es.yml
+++ b/src/Resources/translations/messages.es.yml
@@ -314,10 +314,6 @@ form.order.payment_refund.label: Reembolsar
 form.order.refund_modal.title: Reembolso
 form.payment.refund_amount.label: Suma
 form.payment.refund_amount.help: El importe que especifique será devuelto al cliente
-form.payment.refund_application_fee.label: Reembolsar el pago
-form.payment.refund_application_fee.help: "Si marca esta casilla, la comisión cobrada\
-  \ por la plataforma al socio será reembolsada proporcionalmente\n<br>\n<a href=\"\
-  https://stripe.com/docs/connect/direct-charges#issuing-refunds\">Más información</a>\n"
 form.address.streetAddress.label: Dirección
 form.address.streetAddress.error.noLatLng: Selecciona una dirección en el menú desplegable
 form.address.name.label: Nombre

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -413,11 +413,6 @@ form.order.payment_refund.label: Rembourser
 form.order.refund_modal.title: Remboursement
 form.payment.refund_amount.label: Montant
 form.payment.refund_amount.help: Le montant que vous indiquez sera remboursé au client
-form.payment.refund_application_fee.label: Rembourser les frais
-form.payment.refund_application_fee.help: "Si vous cochez cette case, la commission\
-  \ prélevée par la plateforme au partenaire sera remboursés au pro-rata\n<br>\n<a\
-  \ href=\"https://stripe.com/docs/connect/direct-charges#issuing-refunds\">En savoir\
-  \ plus</a>\n"
 form.delivery_embed.name.label: Nom
 form.delivery_embed.name.help: Votre nom ou le nom de l'entreprise
 form.delivery_embed.telephone.label: Numéro de téléphone

--- a/src/Resources/translations/messages.it.yml
+++ b/src/Resources/translations/messages.it.yml
@@ -309,10 +309,6 @@ restricted_diets.HALAL_DIET: Carne halal
 restricted_diets.HINDU_DIET: Hindu
 restricted_diets.KOSHER_DIET: Kosher
 restricted_diets.LOW_CALORIE_DIET: Calorie basse
-form.payment.refund_application_fee.help: "Se spunti questa casella, la commissione\
-  \ addebitata dalla piattaforma al partner verrà rimborsata proporzionalmente\n<br>\n\
-  <a href=\"https://stripe.com/docs/connect/direct-charges#issuing-refunds\">Learn\
-  \ more</a>\n"
 form.banner.enable.alert: Stai per abilitare i banner
 form.banner.disable.alert: Stai per disabilitare i banner
 form.banner.message.label: Messaggio da mostrare nel banner
@@ -564,7 +560,6 @@ form.order.payment_refund.label: Rimborso
 form.order.refund_modal.title: Rimborso
 form.payment.refund_amount.label: Quantità
 form.payment.refund_amount.help: La quantità specificata sarà rimborsato al cliente
-form.payment.refund_application_fee.label: Tariffe per il rimborso
 form.settings.date_time: Data e ora
 form.settings.brand_name.label: Nome marca
 form.settings.stripe.title: Account Stripe

--- a/src/Resources/translations/messages.pl.yml
+++ b/src/Resources/translations/messages.pl.yml
@@ -145,9 +145,6 @@ task.form.details: Szczegóły zlecenie
 form.delivery.to_be_confirmed.warning: Musisz potwierdzić zamówienie
 form.order.accept.help: Po zaakceptowaniu zamówienia, klient zostanie powiadomiony
   przez email.
-form.payment.refund_application_fee.help: "Jeśli zaznaczysz to pole, prowizja pobierana\
-  \ przez platformę od partnera zostanie zwrócona proporcjonalnie\n<br>\n<a href=\"\
-  https://stripe.com/docs/connect/direct-charges#issuing-refunds\">Dowiedz się więcej</a>\n"
 form.settings.stripe.help: 'Stripe jest serwisem płatniczym, którego używamy do obsługi
   kart kredytowych. Aby używać części e-commerce platformy należy skonfigurować tę
   sekcję, a także Stripe Connect. Stripe pobiera opłatę w wysokości 0,25cts + 1,4%
@@ -430,7 +427,6 @@ form.order.payment_refund.label: Zwrot
 form.order.refund_modal.title: Zwrot
 form.payment.refund_amount.label: Kwota
 form.payment.refund_amount.help: Kwota, którą określiłeś, zostanie zwrócona klientowi
-form.payment.refund_application_fee.label: Opłata za zwrot
 form.address.addressLocality.label: Miasto
 form.address.postalCode.label: Kod pocztowy
 form.address.description.label: 'Informacje dotyczące adresu: np. piętro, nazwa firmy,

--- a/src/Resources/translations/messages.pt-BR.yml
+++ b/src/Resources/translations/messages.pt-BR.yml
@@ -444,11 +444,6 @@ form.order.refuse.refund.alert: Este pedido foi pago por um método que não ger
   pre-autorizações. Se você recusar, este pagamento será reembolsado. Você tem certeza?
 form.payment.refund_amount.label: Valor
 form.payment.refund_amount.help: O valor especificado será reembolsado ao cliente
-form.payment.refund_application_fee.label: Taxas de reembolso
-form.payment.refund_application_fee.help: "Se você confirmar esta caixa, a comissão\
-  \ cobrada pela plataforma ao parceiro será reembolsada proporcionalmente\n<br>\n\
-  <a href=\"https://stripe.com/docs/connect/direct-charges#issuing-refunds\">Leia\
-  \ mais</a>\n"
 form.address.addressLocality.label: Cidade
 form.address.postalCode.label: CEP
 form.address.description.label: Instruções

--- a/src/Service/OrderManager.php
+++ b/src/Service/OrderManager.php
@@ -73,8 +73,8 @@ class OrderManager
         $stateMachine->apply(PaymentTransitions::TRANSITION_COMPLETE);
     }
 
-    public function refundPayment(PaymentInterface $payment, $amount = null, $refundApplicationFee = false)
+    public function refundPayment(PaymentInterface $payment, $amount = null)
     {
-        $this->commandBus->handle(new OrderCommand\Refund($payment, $amount, $refundApplicationFee));
+        $this->commandBus->handle(new OrderCommand\Refund($payment, $amount));
     }
 }

--- a/src/Service/OrderManager.php
+++ b/src/Service/OrderManager.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Service;
 
 use AppBundle\Domain\Order\Command as OrderCommand;
+use AppBundle\Entity\Refund;
 use AppBundle\Sylius\Order\OrderInterface;
 use SimpleBus\SymfonyBridge\Bus\CommandBus;
 use SM\Factory\FactoryInterface as StateMachineFactoryInterface;
@@ -73,8 +74,8 @@ class OrderManager
         $stateMachine->apply(PaymentTransitions::TRANSITION_COMPLETE);
     }
 
-    public function refundPayment(PaymentInterface $payment, $amount = null)
+    public function refundPayment(PaymentInterface $payment, $amount = null, $liableParty = Refund::LIABLE_PARTY_PLATFORM, $comments = '')
     {
-        $this->commandBus->handle(new OrderCommand\Refund($payment, $amount));
+        $this->commandBus->handle(new OrderCommand\Refund($payment, $amount, $liableParty, $comments));
     }
 }

--- a/src/Service/StripeManager.php
+++ b/src/Service/StripeManager.php
@@ -297,7 +297,7 @@ class StripeManager
     /**
      * @return Stripe\Refund
      */
-    public function refund(PaymentInterface $payment, $amount = null, $refundApplicationFee = false)
+    public function refund(PaymentInterface $payment, $amount = null)
     {
         // FIXME
         // Check if the charge was made in test or live mode
@@ -322,13 +322,6 @@ class StripeManager
                 $args['amount'] = $amount;
             }
         }
-
-        // FIXME
-        // When a direct charge was used (without a connected Stripe account)
-        // we have the following error
-        // "refund_application_fee can only be used by the Connect application that created the charge."
-
-        $args['refund_application_fee'] = $refundApplicationFee;
 
         return Stripe\Refund::create($args, $stripeOptions);
     }

--- a/src/Sylius/Payment/RefundTrait.php
+++ b/src/Sylius/Payment/RefundTrait.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace AppBundle\Sylius\Payment;
+
+use AppBundle\Entity\Refund;
+use Stripe\Refund as StripeRefund;
+
+trait RefundTrait
+{
+    public function addRefund(int $amount, string $liableParty, string $comments = '')
+    {
+        $refund = new Refund();
+        $refund->setPayment($this);
+        $refund->setLiableParty($liableParty);
+        $refund->setAmount($amount);
+        $refund->setComments($comments);
+
+        $this->refunds->add($refund);
+
+        return $refund;
+    }
+
+    public function addStripeRefund(StripeRefund $refund)
+    {
+        $refunds = [];
+        if (isset($this->details['refunds'])) {
+            $refunds = $this->details['refunds'];
+        }
+
+        $refunds[] = [
+            'id' => $refund->id,
+            'amount' => $refund->amount,
+        ];
+
+        $this->details = array_merge($this->details, ['refunds' => $refunds]);
+    }
+
+    public function hasRefunds()
+    {
+        return count($this->refunds) > 0;
+    }
+
+    public function getRefunds()
+    {
+        return $this->refunds;
+    }
+
+    public function getRefundTotal()
+    {
+        $total = 0;
+        foreach ($this->getRefunds() as $refund) {
+            $total += $refund->getAmount();
+        }
+
+        return $total;
+    }
+
+    public function getRefundAmount()
+    {
+        return $this->getAmount() - $this->getRefundTotal();
+    }
+}

--- a/src/Sylius/Payment/StripeTrait.php
+++ b/src/Sylius/Payment/StripeTrait.php
@@ -2,7 +2,6 @@
 
 namespace AppBundle\Sylius\Payment;
 
-use Stripe\Refund;
 use Stripe\PaymentIntent;
 use Stripe\Source;
 
@@ -59,51 +58,6 @@ trait StripeTrait
 
             return $this->details['last_error'];
         }
-    }
-
-    public function addRefund(Refund $refund)
-    {
-        $refunds = [];
-        if (isset($this->details['refunds'])) {
-            $refunds = $this->details['refunds'];
-        }
-
-        $refunds[] = [
-            'id' => $refund->id,
-            'amount' => $refund->amount,
-        ];
-
-        $this->details = array_merge($this->details, ['refunds' => $refunds]);
-    }
-
-    public function hasRefunds()
-    {
-        return isset($this->details['refunds']) && is_array($this->details['refunds']) && count($this->details['refunds']) > 0;
-    }
-
-    public function getRefunds()
-    {
-        if (isset($this->details['refunds'])) {
-
-            return $this->details['refunds'];
-        }
-
-        return [];
-    }
-
-    public function getRefundTotal()
-    {
-        $total = 0;
-        foreach ($this->getRefunds() as $refund) {
-            $total += $refund['amount'];
-        }
-
-        return $total;
-    }
-
-    public function getRefundAmount()
-    {
-        return $this->getAmount() - $this->getRefundTotal();
     }
 
     public function setPaymentIntent(PaymentIntent $intent)

--- a/templates/order/_partials/payment_form.html.twig
+++ b/templates/order/_partials/payment_form.html.twig
@@ -17,14 +17,6 @@
       <div class="modal-body">
         {% if payment_form.amount is defined %}
           {{ form_row(payment_form.amount) }}
-          {{ form_row(payment_form.refundApplicationFee) }}
-          <div class="form-group">
-            <div class="col-sm-10 col-sm-offset-2">
-              <p class="help-block">
-                <i class="fa fa-info-circle"></i> {% trans %}form.payment.refund_application_fee.help{% endtrans %}
-              </p>
-            </div>
-          </div>
         {% endif %}
       </div>
       <div class="modal-footer">

--- a/templates/order/_partials/payment_form.html.twig
+++ b/templates/order/_partials/payment_form.html.twig
@@ -1,4 +1,4 @@
-{% form_theme payment_form 'bootstrap_3_horizontal_layout.html.twig' %}
+{% form_theme payment_form 'bootstrap_3_layout.html.twig' %}
 
 {% set payment = payment_form.vars.value %}
 {% set refund_modal_id = 'refund-modal-' ~ payment.id %}
@@ -17,6 +17,12 @@
       <div class="modal-body">
         {% if payment_form.amount is defined %}
           {{ form_row(payment_form.amount) }}
+        {% endif %}
+        {% if payment_form.liable is defined %}
+          {{ form_row(payment_form.liable) }}
+        {% endif %}
+        {% if payment_form.comments is defined %}
+          {{ form_row(payment_form.comments) }}
         {% endif %}
       </div>
       <div class="modal-footer">

--- a/templates/restaurant/_partials/refunds.html.twig
+++ b/templates/restaurant/_partials/refunds.html.twig
@@ -1,0 +1,47 @@
+{% if is_granted('ROLE_ADMIN') %}
+<div class="alert alert-info">
+  {{ 'refund.list.disclaimer.admin'|trans }}
+</div>
+{% endif %}
+
+<table class="table table-condensed">
+  <thead>
+    <th>{{ 'order.export.heading.order_number'|trans }}</th>
+    <th>{{ 'order.export.heading.completed_at'|trans }}</th>
+    <th>{{ 'refund.list.refunded_at'|trans }}</th>
+    <th>{{ 'refund.list.liable_party'|trans }}</th>
+    <th class="text-right">{{ 'order.export.heading.total_incl_tax'|trans }}</th>
+    <th class="text-right">{{ 'refund.list.amount'|trans }}</th>
+    <th class="text-right">{{ 'refund.list.comments'|trans }}</th>
+  </thead>
+  <tbody>
+    {% set total_credit = 0 %}
+    {% for refund in refunds %}
+      {% if refund.liableParty == 'platform' %}
+        {% set total_credit = total_credit + refund.amount %}
+      {% endif %}
+      <tr class="{{ refund.liableParty == 'merchant' ? 'text-muted' : '' }}">
+        <td>{{ refund.payment.order.number }}</td>
+        <td>{{ refund.payment.order.shippedAt|date('Y-m-d H:i') }}</td>
+        <td>{{ refund.createdAt|date('Y-m-d H:i') }}</td>
+        <td>{{ refund.liableParty }}</td>
+        <td class="text-right" width="10%">{{ refund.payment.order.total|price_format }}</td>
+        <td class="text-right" width="10%">{{ refund.amount|price_format }}</td>
+        <td class="text-right" width="10%">
+          {% if refund.comments is not empty %}
+          <button class="button-icon" data-toggle="tooltip" data-placement="left" title="{{ refund.comments|e('html_attr') }}">
+            <i class="fa fa-lg fa-comments-o"></i>
+          </button>
+          {% endif %}
+        </td>
+      </tr>
+    {% endfor %}
+  </tbody>
+  <tfoot>
+    <tr>
+      <td colspan="5" class="text-right">{{ 'refund.list.debit_total'|trans }}</td>
+      <td class="text-right"><strong>{{ total_credit|price_format }}</strong></td>
+      <td></td>
+    </tr>
+  </tfoot>
+</table>

--- a/templates/restaurant/stats.html.twig
+++ b/templates/restaurant/stats.html.twig
@@ -23,6 +23,25 @@
   </div>
 </div>
 
+{% set refunds = [] %}
+{% for order in stats %}
+  {% if order.hasRefunds() %}
+    {% set refunds = refunds|merge(order.getRefunds()) %}
+  {% endif %}
+{% endfor %}
+
+<ul class="nav nav-tabs mb-4">
+  <li role="presentation" {% if tab == 'orders' %}class="active"{% endif %}>
+    <a href="{{ path(stats_route, (app.request.query.all())|merge({ id: restaurant.id, tab: 'orders' })) }}">{{ 'restaurant.list.orders'|trans }} ({{ stats|length }})</a>
+  </li>
+  <li role="presentation" {% if tab == 'refunds' %}class="active"{% endif %}>
+    <a href="{{ path(stats_route, (app.request.query.all())|merge({ id: restaurant.id, tab: 'refunds' })) }}">Refunds ({{ refunds|length }})</a>
+  </li>
+</ul>
+
+{% if tab == 'refunds' %}
+  {% include 'restaurant/_partials/refunds.html.twig' %}
+{% else %}
 <table class="table table-condensed">
   <thead>
     {% for column in stats.columns %}
@@ -61,6 +80,7 @@
     </tr>
   </tfoot>
 </table>
+{% endif %}
 
 {% endblock %}
 

--- a/tests/AppBundle/Domain/Order/Handler/RefundHandlerTest.php
+++ b/tests/AppBundle/Domain/Order/Handler/RefundHandlerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\AppBundle\Domain\Order\Handler;
+
+use AppBundle\Domain\Order\Command\Refund as RefundCommand;
+use AppBundle\Domain\Order\Event\OrderCreated;
+use AppBundle\Domain\Order\Handler\RefundHandler;
+use AppBundle\Entity\Refund;
+use AppBundle\Entity\Sylius\Payment;
+use AppBundle\Service\StripeManager;
+use AppBundle\Sylius\Order\OrderInterface;
+use Doctrine\Common\Collections\Collection;
+use Prophecy\PhpUnit\ProphecyTrait;
+use SimpleBus\Message\Recorder\RecordsMessages;
+use SM\Factory\FactoryInterface;
+use Stripe;
+use Sylius\Component\Payment\Model\PaymentInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Prophecy\Argument;
+
+class RefundHandlerTest extends KernelTestCase
+{
+    use ProphecyTrait;
+
+    private $stripeManager;
+    private $stateMachineFactory;
+    private $eventRecorder;
+
+    private $handler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        self::bootKernel();
+
+        $this->stripeManager = $this->prophesize(StripeManager::class);
+        // @see https://symfony.com/blog/new-in-symfony-4-1-simpler-service-testing
+        $this->stateMachineFactory = self::$container->get(FactoryInterface::class);
+        $this->eventRecorder = $this->prophesize(RecordsMessages::class);
+
+        $this->handler = new RefundHandler(
+            $this->stripeManager->reveal(),
+            $this->stateMachineFactory,
+            $this->eventRecorder->reveal()
+        );
+    }
+
+    public function testRefund()
+    {
+        $order = $this->prophesize(OrderInterface::class);
+
+        $order
+            ->getTotal()
+            ->willReturn(2000);
+
+        $payment = new Payment();
+        $payment->setState(PaymentInterface::STATE_COMPLETED);
+        $payment->setOrder($order->reveal());
+
+        $stripeRefund = Stripe\Refund::constructFrom([
+            'id' => 're_123456',
+            'amount' => 500,
+        ]);
+
+        $this->stripeManager
+            ->refund($payment, 500)
+            ->willReturn($stripeRefund)
+            ->shouldBeCalled();
+
+        $command = new RefundCommand($payment, 500, Refund::LIABLE_PARTY_PLATFORM, 'Lorem ipsum');
+
+        $this->assertFalse($payment->hasRefunds());
+
+        call_user_func_array($this->handler, [ $command ]);
+
+        $this->assertTrue($payment->hasRefunds());
+        $this->assertCount(1, $payment->getRefunds());
+        $this->assertInstanceOf(Collection::class, $payment->getRefunds());
+
+        $this->assertEquals(Refund::LIABLE_PARTY_PLATFORM, $payment->getRefunds()->get(0)->getLiableParty());
+        $this->assertEquals(['stripe_refund_id' => 're_123456'], $payment->getRefunds()->get(0)->getData());
+    }
+}

--- a/tests/AppBundle/Entity/Sylius/PaymentTest.php
+++ b/tests/AppBundle/Entity/Sylius/PaymentTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\AppBundle\Entity\Sylius;
+
+use AppBundle\Entity\Refund;
+use AppBundle\Entity\Sylius\Payment;
+use PHPUnit\Framework\TestCase;
+
+class PaymentTest extends TestCase
+{
+    public function testRefunds()
+    {
+        $payment = new Payment();
+        $payment->setAmount(2000);
+
+        $payment->addRefund(500, Refund::LIABLE_PARTY_PLATFORM);
+
+        $this->assertTrue($payment->hasRefunds());
+        $this->assertEquals(500, $payment->getRefundTotal());
+        $this->assertEquals(1500, $payment->getRefundAmount());
+    }
+}


### PR DESCRIPTION
Fixes #1447

When creating a refund, it is now possible to specify which party is responsible for the incident. The checkbox to refund application fee has been deprecated because it was causing confusion & problems. 

<img width="600" alt="Capture d’écran 2020-08-27 à 15 09 16" src="https://user-images.githubusercontent.com/1162230/91446141-556a3f00-e877-11ea-8665-202d4f0a2e4b.png">

A new tab is available on the restaurant stats screen, listing the refunds, and showing the total amount due by the platform to the business for the refunds (when the platform is reponsible for the incident)



