### PR TITLE
Add make fresh for cleaning up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ migrations-diff:
 	@docker-compose exec php php bin/console doctrine:migrations:diff
 
 migrations-migrate:
+	@composer install
 	@docker-compose exec php php bin/console doctrine:migrations:migrate
 	@docker-compose exec php php bin/console doctrine:schema:update --env=test --force --no-interaction
 

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,4 @@ email-preview:
 	@docker-compose exec php php bin/console coopcycle:email:preview > /tmp/coopcycle_email_layout.html && open /tmp/coopcycle_email_layout.html
 
 fresh:
-	-docker ps -a -q | xargs docker stop
-	-docker ps -a -q | xargs docker rm
-	-docker rmi $(docker images -q)
-	-docker volume rm $(docker volume list)
-	-docker network rm $(docker network list)
+	@docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,3 @@ fresh:
 	-docker rmi $(docker images -q)
 	-docker volume rm $(docker volume list)
 	-docker network rm $(docker network list)
-	"$(MAKE)" install

--- a/Makefile
+++ b/Makefile
@@ -26,9 +26,16 @@ migrations-diff:
 	@docker-compose exec php php bin/console doctrine:migrations:diff
 
 migrations-migrate:
-	@composer install
 	@docker-compose exec php php bin/console doctrine:migrations:migrate
 	@docker-compose exec php php bin/console doctrine:schema:update --env=test --force --no-interaction
 
 email-preview:
 	@docker-compose exec php php bin/console coopcycle:email:preview > /tmp/coopcycle_email_layout.html && open /tmp/coopcycle_email_layout.html
+
+fresh:
+	-docker ps -a -q | xargs docker stop
+	-docker ps -a -q | xargs docker rm
+	-docker rmi $(docker images -q)
+	-docker volume rm $(docker volume list)
+	-docker network rm $(docker network list)
+	"$(MAKE)" install


### PR DESCRIPTION
Related to issues #436 and #141 

Notice that #141 is already fixed with `make migrations-migrate`

But `make fresh` basically helps cleaning up everything docker for a fresh install.