### PR TITLE
update max-width and width of modal container

### DIFF
--- a/js/sdk/modal.css
+++ b/js/sdk/modal.css
@@ -21,8 +21,8 @@
 .coopcycle-modal__container {
   background-color: #fff;
   /*padding: 15px;*/
-  max-width: 500px;
-  width: 50%;
+  max-width: 80%;
+  width: 80%;
   max-height: 100vh;
   height: 75%;
   border-radius: 4px;


### PR DESCRIPTION
On mobile browsers the popup is too shrunk.

![image](https://user-images.githubusercontent.com/51931067/97803029-66e91200-1c3f-11eb-8054-f8a75d96432e.png)

The code update should have it look like this on mobile:
![image](https://user-images.githubusercontent.com/51931067/97803039-7700f180-1c3f-11eb-9ad8-ee4febbf9960.png)

And on computers should look like this:
![image](https://user-images.githubusercontent.com/51931067/97803050-9435c000-1c3f-11eb-9c0d-10b8136abe14.png)

