### PR TITLE
Harmonizing task export and import

### DIFF
--- a/src/Spreadsheet/AbstractSpreadsheetParser.php
+++ b/src/Spreadsheet/AbstractSpreadsheetParser.php
@@ -95,7 +95,7 @@ abstract class AbstractSpreadsheetParser
         return array_search(max($delimiters), $delimiters);
     }
 
-    abstract protected function validateHeader(array $header);
+    abstract public function validateHeader(array $header);
 
     abstract public function getExampleData(): array;
 

--- a/src/Spreadsheet/DeliverySpreadsheetParser.php
+++ b/src/Spreadsheet/DeliverySpreadsheetParser.php
@@ -90,7 +90,7 @@ class DeliverySpreadsheetParser extends AbstractSpreadsheetParser
         return $deliveries;
     }
 
-    protected function validateHeader(array $header)
+    public function validateHeader(array $header)
     {
         $hasPickupAddress = in_array('pickup.address', $header);
         $hasDropoffAddress = in_array('dropoff.address', $header);

--- a/src/Spreadsheet/ProductSpreadsheetParser.php
+++ b/src/Spreadsheet/ProductSpreadsheetParser.php
@@ -85,7 +85,7 @@ class ProductSpreadsheetParser extends AbstractSpreadsheetParser
         }, $data);
     }
 
-    protected function validateHeader(array $header)
+    public function validateHeader(array $header)
     {
         $expected = [
             'name',

--- a/src/Spreadsheet/TaskSpreadsheetParser.php
+++ b/src/Spreadsheet/TaskSpreadsheetParser.php
@@ -178,7 +178,7 @@ class TaskSpreadsheetParser extends AbstractSpreadsheetParser
         return $tasks;
     }
 
-    protected function validateHeader(array $header)
+    public function validateHeader(array $header)
     {
         $hasAddress = in_array('address', $header);
         $hasStreetAddress = in_array('address.streetAddress', $header);
@@ -195,10 +195,6 @@ class TaskSpreadsheetParser extends AbstractSpreadsheetParser
 
         if ($hasLatLong && $hasAddressLatLng) {
             throw new \Exception('You must provide an "latlong" or a "address.latlng" column, not both');
-        }
-
-        if (($hasAddress || $hasStreetAddress) && ($hasLatLong || $hasAddressLatLng)) {
-            throw new \Exception('You must provide an "address" (alternatively "address.streetAddress") or a "latlong" (alternatively "address.latlng") column, not both');
         }
     }
 

--- a/src/Spreadsheet/TaskSpreadsheetParser.php
+++ b/src/Spreadsheet/TaskSpreadsheetParser.php
@@ -93,7 +93,7 @@ class TaskSpreadsheetParser extends AbstractSpreadsheetParser
 
             $address = null;
 
-            //Using isset() in order to parse spreadsheet with both address and coordinates columns later
+            // Using isset() in order to parse spreadsheet with both address and coordinates columns later
             $addressHeader = 'address';
             if (isset($record['address.streetAddress'])) {
                 $addressHeader = 'address.streetAddress';
@@ -108,16 +108,15 @@ class TaskSpreadsheetParser extends AbstractSpreadsheetParser
 
             $latlngHeader = 'latlong';
             if (isset($record['address.latlng'])) {
-                $latlngHeader = 'address.latlng';}
-
+                $latlngHeader = 'address.latlng';
+            }
 
             if (isset($record[$latlngHeader]) && !empty($record[$latlngHeader])) {
                 [ $latitude, $longitude ] = array_map('floatval', explode(',', $record[$latlngHeader]));
-            //*
                 if (!$address = $this->geocoder->reverse($latitude, $longitude)) {
                     // TODO Translate
                     throw new \Exception(sprintf('Could not reverse geocode %s', $record[$latlngHeader]));
-                }/**/
+                }
             }
 
             if (isset($record['address.name']) && !empty($record['address.name'])) {

--- a/src/Spreadsheet/TaskSpreadsheetParser.php
+++ b/src/Spreadsheet/TaskSpreadsheetParser.php
@@ -93,19 +93,31 @@ class TaskSpreadsheetParser extends AbstractSpreadsheetParser
 
             $address = null;
 
-            if (isset($record['address']) && !empty($record['address'])) {
-                if (!$address = $this->geocoder->geocode($record['address'])) {
+            //Using isset() in order to parse spreadsheet with both address and coordinates columns later
+            $addressHeader = 'address';
+            if (isset($record['address.streetAddress'])) {
+                $addressHeader = 'address.streetAddress';
+            }
+
+            if (isset($record[$addressHeader]) && !empty($record[$addressHeader])) {
+                if (!$address = $this->geocoder->geocode($record[$addressHeader])) {
                     // TODO Translate
-                    throw new \Exception(sprintf('Could not geocode address %s', $record['address']));
+                    throw new \Exception(sprintf('Could not geocode address %s', $record[$addressHeader]));
                 }
             }
 
-            if (isset($record['latlong']) && !empty($record['latlong'])) {
-                [ $latitude, $longitude ] = array_map('floatval', explode(',', $record['latlong']));
+            $latlngHeader = 'latlong';
+            if (isset($record['address.latlng'])) {
+                $latlngHeader = 'address.latlng';}
+
+
+            if (isset($record[$latlngHeader]) && !empty($record[$latlngHeader])) {
+                [ $latitude, $longitude ] = array_map('floatval', explode(',', $record[$latlngHeader]));
+            //*
                 if (!$address = $this->geocoder->reverse($latitude, $longitude)) {
                     // TODO Translate
-                    throw new \Exception(sprintf('Could not reverse geocode %s', $record['latlong']));
-                }
+                    throw new \Exception(sprintf('Could not reverse geocode %s', $record[$latlngHeader]));
+                }/**/
             }
 
             if (isset($record['address.name']) && !empty($record['address.name'])) {
@@ -170,14 +182,24 @@ class TaskSpreadsheetParser extends AbstractSpreadsheetParser
     protected function validateHeader(array $header)
     {
         $hasAddress = in_array('address', $header);
+        $hasStreetAddress = in_array('address.streetAddress', $header);
         $hasLatLong = in_array('latlong', $header);
+        $hasAddressLatLng = in_array('address.latlng', $header);
 
-        if (!$hasAddress && !$hasLatLong) {
-            throw new \Exception('You must provide an "address" or a "latlong" column');
+        if (!$hasAddress && !$hasLatLong && !$hasStreetAddress && !$hasAddressLatLng) {
+            throw new \Exception('You must provide an "address" (alternatively "address.streetAddress") or a "latlong" (alternatively "address.latlng") column');
         }
 
-        if ($hasAddress && $hasLatLong) {
-            throw new \Exception('You must provide an "address" or a "latlong" column, not both');
+        if ($hasAddress && $hasStreetAddress) {
+            throw new \Exception('You must provide an "address" or a "address.streetAddress" column, not both');
+        }
+
+        if ($hasLatLong && $hasAddressLatLng) {
+            throw new \Exception('You must provide an "latlong" or a "address.latlng" column, not both');
+        }
+
+        if (($hasAddress || $hasStreetAddress) && ($hasLatLong || $hasAddressLatLng)) {
+            throw new \Exception('You must provide an "address" (alternatively "address.streetAddress") or a "latlong" (alternatively "address.latlng") column, not both');
         }
     }
 

--- a/tests/AppBundle/Spreadsheet/TaskSpreadsheetParserTest.php
+++ b/tests/AppBundle/Spreadsheet/TaskSpreadsheetParserTest.php
@@ -206,4 +206,42 @@ class TaskSpreadsheetParserTest extends TestCase
 
         parent::testCanParseExampleData();
     }
+
+    public function testValidateHeaderThrowsException()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('You must provide an "address" (alternatively "address.streetAddress") or a "latlong" (alternatively "address.latlng") column');
+
+        $this->mockDependencies();
+
+        $this->parser->validateHeader([
+            'foo',
+        ]);
+    }
+
+    public function testValidateHeaderWithStreetAddress()
+    {
+        $this->mockDependencies();
+
+        $this->assertNull($this->parser->validateHeader([
+            'address.streetAddress',
+        ]));
+        $this->assertNull($this->parser->validateHeader([
+            'address',
+        ]));
+    }
+
+    public function testValidateHeaderWithStreetAddressAndLatlng()
+    {
+        $this->mockDependencies();
+
+        $this->assertNull($this->parser->validateHeader([
+            'address.streetAddress',
+            'address.latlng',
+        ]));
+        $this->assertNull($this->parser->validateHeader([
+            'address',
+            'latlong',
+        ]));
+    }
 }


### PR DESCRIPTION
This PR is the follow up of  #681. It allows use of both "technical" and "meaningful" label in header of task import spreadsheet (i.e. "address.streetAddress", "address", "adress.latlng" and "latlong"). 
One must still use either address or geocoordinates, but not both at the same time, though.