### PR TITLE
Update wording Planning → Holidays

### DIFF
--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -238,7 +238,7 @@ restaurant.list.products: Products
 restaurant.list.product_options: Options
 restaurant.list.menus: Menus
 restaurant.list.activeMenu: Active menu
-restaurant.list.planning: Planning
+restaurant.list.planning: Holidays
 restaurant.list.settings: Settings
 restaurant.list.norestaurant: There are no restaurants yet
 restaurant.list.createNewRestaurant: Create a new restaurant


### PR DESCRIPTION
In British English, the term `Holidays` conveys the right meaning instead of `Planning`. 