### PR TITLE
add argentina cash-delivery-option

### DIFF
--- a/src/Command/SetupCommand.php
+++ b/src/Command/SetupCommand.php
@@ -279,7 +279,7 @@ class SetupCommand extends Command
             [
                 'code' => 'CASH_ON_DELIVERY',
                 'name' => 'Cash on delivery',
-                'countries' => ['mx'],
+                'countries' => ['mx','ar'],
             ],
         ];
 


### PR DESCRIPTION
The PR add cash payment method in Argentina instances 