### PR TITLE
Use a form collection in DeliveryType

### DIFF
--- a/js/app/delivery/embed-start.js
+++ b/js/app/delivery/embed-start.js
@@ -6,7 +6,11 @@ import './embed-start.scss'
 
 const getDateTimePickerContainer = trigger => trigger.parentNode
 
-$.each(['pickup', 'dropoff'], function(index, type) {
+const taskForms = Array
+  .from(document.querySelectorAll('[data-form="task"]'))
+  .map(el => el.getAttribute('id').replace('delivery_', ''))
+
+taskForms.forEach(function(type) {
 
   const doneBeforeEl = document.querySelector(`#delivery_${type}_doneBefore`)
 

--- a/js/app/delivery/form.scss
+++ b/js/app/delivery/form.scss
@@ -6,7 +6,10 @@
 @import "~font-awesome/scss/_animated.scss";
 
 .delivery__form__task {
+
   position: relative;
+  margin-bottom: 3em;
+
   @media (max-width: $screen-sm-max) {
     padding-top: 24px;
   }

--- a/js/app/forms/delivery.js
+++ b/js/app/forms/delivery.js
@@ -2,6 +2,7 @@ import moment from 'moment'
 import ClipboardJS from 'clipboard'
 import { createStore } from 'redux'
 import _ from 'lodash'
+import axios from 'axios'
 
 import AddressBook from '../delivery/AddressBook'
 import DateTimePicker from '../widgets/DateTimePicker'
@@ -94,8 +95,8 @@ function createAddressWidget(name, type, cb) {
 
       store.dispatch({
         type: 'SET_ADDRESS',
-        taskType: type,
-        address
+        taskIndex: getTaskIndex(type),
+        value: address
       })
     },
     onClear: () => {
@@ -103,7 +104,7 @@ function createAddressWidget(name, type, cb) {
       showRememberAddress(name, type)
       store.dispatch({
         type: 'CLEAR_ADDRESS',
-        taskType: type,
+        taskIndex: getTaskIndex(type),
       })
     }
   })
@@ -128,6 +129,10 @@ function getDatePickerKey(name, type) {
   return 'before'
 }
 
+function getTaskType(name, type) {
+  return document.querySelector(`#${name}_${type}_type`).value.toUpperCase()
+}
+
 function createDatePickerWidget(name, type) {
 
   const datePickerEl = document.querySelector(`#${name}_${type}_doneBefore`)
@@ -137,7 +142,7 @@ function createDatePickerWidget(name, type) {
     timeSlotEl.addEventListener('change', e => {
       store.dispatch({
         type: 'SET_TIME_SLOT',
-        taskType: type,
+        taskIndex: getTaskIndex(type),
         value: e.target.value
       })
     })
@@ -150,7 +155,7 @@ function createDatePickerWidget(name, type) {
       datePickerEl.value = date.format('YYYY-MM-DD HH:mm:ss')
       store.dispatch({
         type: 'SET_BEFORE',
-        taskType: type,
+        taskIndex: getTaskIndex(type),
         value: date.format()
       })
     }
@@ -246,31 +251,34 @@ function parseWeight(value) {
   return parseInt((floatValue * 1000), 10)
 }
 
+function replaceTasks(state, index, key, value) {
+  const newTasks = state.tasks.slice()
+  newTasks[index] = {
+    ...newTasks[index],
+    [key]: value
+  }
+
+  return newTasks
+}
+
+const getTaskIndex = (key) => parseInt(key.replace('tasks_', ''), 10)
+
 function reducer(state = {}, action) {
   switch (action.type) {
   case 'SET_ADDRESS':
     return {
       ...state,
-      [ action.taskType ]: {
-        ...state[action.taskType],
-        address: action.address
-      }
+      tasks: replaceTasks(state, action.taskIndex, 'address', action.value),
     }
   case 'SET_TIME_SLOT':
     return {
       ...state,
-      [ action.taskType ]: {
-        ...state[action.taskType],
-        timeSlot: action.value
-      }
+      tasks: replaceTasks(state, action.taskIndex, 'timeSlot', action.value),
     }
   case 'SET_BEFORE':
     return {
       ...state,
-      [ action.taskType ]: {
-        ...state[action.taskType],
-        before: action.value
-      }
+      tasks: replaceTasks(state, action.taskIndex, 'before', action.value),
     }
   case 'SET_WEIGHT':
     return {
@@ -285,12 +293,27 @@ function reducer(state = {}, action) {
   case 'CLEAR_ADDRESS':
     return {
       ...state,
-      [ action.taskType ]: _.omit({ ...state[action.taskType] }, ['address'])
+      tasks: state.tasks.map((task, index) => {
+        if (index === action.taskIndex) {
+          return _.omit({ ...task }, ['address'])
+        }
+
+        return task
+      }),
     }
   default:
     return state
   }
 }
+
+const loadTags = _.once(() => {
+
+  return axios({
+    method: 'get',
+    url: window.Routing.generate('admin_tags', { format: 'json' }),
+  })
+  .then(response => response.data)
+})
 
 export default function(name, options) {
 
@@ -313,22 +336,40 @@ export default function(name, options) {
     let preloadedState = {
       store: `/api/stores/${storeId}`, // FIXME The data attribute should contain the IRI
       weight: weightEl ? parseWeight(weightEl.value) : 0,
-      pickup: {
-        address: null,
-        [ getDatePickerKey(name, 'pickup') ]: getDatePickerValue(name, 'pickup')
-      },
-      dropoff: {
-        address: null,
-        [ getDatePickerKey(name, 'dropoff') ]: getDatePickerValue(name, 'dropoff')
-      },
+      tasks: [],
       packages: []
     }
 
-    createAddressWidget(name, 'pickup', address => preloadedState.pickup.address = address)
-    createDatePickerWidget(name, 'pickup')
+    // tasks_0, tasks_1...
+    const taskForms = Array.from(el.querySelectorAll('[data-form="task"]'))
 
-    createAddressWidget(name, 'dropoff', address => preloadedState.dropoff.address = address)
-    createDatePickerWidget(name, 'dropoff')
+    taskForms.forEach((taskEl) => {
+
+      const taskForm = taskEl.getAttribute('id').replace(name + '_', '')
+
+      const task = {
+        type: getTaskType(name, taskForm),
+        address: null,
+        [ getDatePickerKey(name, taskForm) ]: getDatePickerValue(name, taskForm)
+      }
+
+      preloadedState.tasks.push(task)
+
+      createAddressWidget(name, taskForm, address => {
+        const index = preloadedState.tasks.indexOf(task)
+        if (-1 !== index) {
+          preloadedState.tasks[index].address = address
+        }
+      })
+      createDatePickerWidget(name, taskForm)
+
+      const tagsEl = document.querySelector(`#${name}_${taskForm}_tagsAsString`)
+      if (tagsEl) {
+        loadTags().then(tags => {
+          createTagsWidget(name, taskForm, tags)
+        })
+      }
+    })
 
     store = createStore(reducer, preloadedState)
 
@@ -342,16 +383,6 @@ export default function(name, options) {
           value: parseWeight(e.target.value)
         })
       }, 350))
-    }
-
-    const pickupTagsEl = document.querySelector(`#${name}_pickup_tagsAsString`)
-    const dropoffTagsEl = document.querySelector(`#${name}_dropoff_tagsAsString`)
-
-    if (pickupTagsEl && dropoffTagsEl) {
-      $.getJSON(window.Routing.generate('admin_tags', { format: 'json' }), function(tags) {
-        createTagsWidget(name, 'pickup', tags)
-        createTagsWidget(name, 'dropoff', tags)
-      })
     }
 
     new ClipboardJS('#copy', {
@@ -369,7 +400,9 @@ export default function(name, options) {
 
     el.addEventListener('submit', (e) => {
 
-      _.find(['pickup', 'dropoff'], type => {
+      _.find(taskForms, taskEl => {
+
+        const type = taskEl.getAttribute('id').replace(name + '_', '')
 
         const isNewAddrInput = document.querySelector(`#${name}_${type}_address_isNewAddress`)
         if (!isNewAddrInput) {

--- a/js/app/forms/delivery.js
+++ b/js/app/forms/delivery.js
@@ -329,15 +329,17 @@ export default function(name, options) {
     const weightEl = document.querySelector(`#${name}_weight`)
 
     // Intialize Redux store
-    let storeId
-    if (el.dataset.store) {
-      storeId = el.dataset.store
-    }
     let preloadedState = {
-      store: `/api/stores/${storeId}`, // FIXME The data attribute should contain the IRI
       weight: weightEl ? parseWeight(weightEl.value) : 0,
       tasks: [],
       packages: []
+    }
+
+    if (el.dataset.store) {
+      preloadedState = {
+        ...preloadedState,
+        store: el.dataset.store
+      }
     }
 
     // tasks_0, tasks_1...

--- a/src/Controller/Utils/StoreTrait.php
+++ b/src/Controller/Utils/StoreTrait.php
@@ -303,11 +303,11 @@ trait StoreTrait
 
     private function handleRememberAddress(Store $store, FormInterface $form)
     {
-        foreach (['pickup', 'dropoff'] as $taskType) {
-            $addressForm = $form->get($taskType)->get('address');
+        foreach ($form->get('tasks') as $form) {
+            $addressForm = $form->get('address');
             $rememberAddress = $addressForm->has('rememberAddress') && $addressForm->get('rememberAddress')->getData();
             if ($rememberAddress) {
-                $task = $form->get($taskType)->getData();
+                $task = $form->getData();
                 $store->addAddress($task->getAddress());
             }
         }

--- a/src/Form/DeliveryEmbedType.php
+++ b/src/Form/DeliveryEmbedType.php
@@ -71,4 +71,11 @@ class DeliveryEmbedType extends DeliveryType
             }
         });
     }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver->setDefault('with_tags', false);
+    }
 }

--- a/src/Form/DeliveryType.php
+++ b/src/Form/DeliveryType.php
@@ -85,31 +85,19 @@ class DeliveryType extends AbstractType
                 $delivery->getDropoff()->setDoneBefore($dropoffBefore);
             }
 
-            $form->add('pickup', TaskType::class, [
-                'mapped' => false,
-                'label' => 'form.delivery.pickup.label',
-                'constraints' => [
-                    new Assert\Valid()
+            $form->add('tasks', CollectionType::class, [
+                'entry_type' => TaskType::class,
+                'entry_options' => [
+                    'constraints' => [
+                        new Assert\Valid()
+                    ],
+                    'with_tags' => $options['with_tags'],
+                    'with_addresses' => null !== $store ? $store->getAddresses() : [],
+                    'with_remember_address' => $options['with_remember_address'],
+                    'with_time_slot' => $this->getTimeSlot($options, $store),
+                    'with_recipient_details' => $options['with_dropoff_recipient_details'],
+                    'with_doorstep' => $options['with_dropoff_doorstep'],
                 ],
-                'data' => $delivery->getPickup(),
-                'with_tags' => $options['with_tags'],
-                'with_addresses' => null !== $store ? $store->getAddresses() : [],
-                'with_remember_address' => $options['with_remember_address'],
-                'with_time_slot' => $this->getTimeSlot($options, $store),
-            ]);
-            $form->add('dropoff', TaskType::class, [
-                'mapped' => false,
-                'label' => 'form.delivery.dropoff.label',
-                'constraints' => [
-                    new Assert\Valid()
-                ],
-                'data' => $delivery->getDropoff(),
-                'with_tags' => $options['with_tags'],
-                'with_addresses' => null !== $store ? $store->getAddresses() : [],
-                'with_recipient_details' => $options['with_dropoff_recipient_details'],
-                'with_doorstep' => $options['with_dropoff_doorstep'],
-                'with_remember_address' => $options['with_remember_address'],
-                'with_time_slot' => $this->getTimeSlot($options, $store),
             ]);
         });
 

--- a/src/Form/TaskType.php
+++ b/src/Form/TaskType.php
@@ -100,7 +100,7 @@ class TaskType extends AbstractType
             $builder->add('tagsAsString', TextType::class, [
                 'mapped' => false,
                 'required' => false,
-                'label' => 'Tags'
+                'label' => 'adminDashboard.tags.title'
             ]);
         }
 

--- a/templates/delivery/form.html.twig
+++ b/templates/delivery/form.html.twig
@@ -35,7 +35,7 @@
 
   <div class="row">
     <div class="col-md-7">
-      {{ form_row(form.pickup) }}
+      {{ form_widget(form.tasks) }}
     </div>
     <div class="col-md-5">
       <div class="form-horizontal">
@@ -53,32 +53,23 @@
           </div>
         </div>
         {% endif %}
-      </div>
-    </div>
-  </div>
 
-  <hr>
-
-  <div class="row">
-    <div class="col-md-7">
-      {{ form_row(form.dropoff) }}
-    </div>
-    <div class="col-md-5">
-      {% if not is_new %}
-      <div class="alert alert-info">
-        <a href="{{ url('public_delivery', { hashid: delivery|hashid }) }}" target="_blank" id="tracking_link">{% trans %}delivery.tracking_link{% endtrans %} <i class="fa fa-external-link"></i></a>
-        <a href="#" class="pull-right" id="copy" data-clipboard-target="#tracking_link"><i class="fa fa-clipboard" aria-hidden="true"></i></a>
-      </div>
-      {% endif %}
-      <div class="embed-responsive embed-responsive-16by9">
-        <div class="embed-responsive-item" id="map"></div>
-        <div class="map-distance-overlay">
-          <span class="mr-2">{% trans %}form.delivery.distance.label{% endtrans %}</span>
-          <span id="delivery_distance">
-            {% if delivery.distance is not empty %}
-              {{ delivery.distance|meters_to_kilometers }}
-            {% endif %}
-          </span>
+        {% if not is_new %}
+        <div class="alert alert-info">
+          <a href="{{ url('public_delivery', { hashid: delivery|hashid }) }}" target="_blank" id="tracking_link">{% trans %}delivery.tracking_link{% endtrans %} <i class="fa fa-external-link"></i></a>
+          <a href="#" class="pull-right" id="copy" data-clipboard-target="#tracking_link"><i class="fa fa-clipboard" aria-hidden="true"></i></a>
+        </div>
+        {% endif %}
+        <div class="embed-responsive embed-responsive-16by9">
+          <div class="embed-responsive-item" id="map"></div>
+          <div class="map-distance-overlay">
+            <span class="mr-2">{% trans %}form.delivery.distance.label{% endtrans %}</span>
+            <span id="delivery_distance">
+              {% if delivery.distance is not empty %}
+                {{ delivery.distance|meters_to_kilometers }}
+              {% endif %}
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/templates/delivery/form.html.twig
+++ b/templates/delivery/form.html.twig
@@ -25,7 +25,7 @@
 {% set delivery = form.vars.value %}
 {% set is_new = delivery.id is null %}
 
-{{ form_start(form, { attr: { 'data-store': delivery.store is not empty ? delivery.store.id : null } }) }}
+{{ form_start(form, { attr: { 'data-store': delivery.store is not empty ? delivery.store|get_iri_from_item : null } }) }}
 
   {% if is_granted('ROLE_ADMIN') and not is_new and delivery.order is not empty %}
     {% include '_partials/delivery/order_alert.html.twig' with { order: delivery.order } %}

--- a/templates/embed/delivery/start.html.twig
+++ b/templates/embed/delivery/start.html.twig
@@ -16,8 +16,7 @@
 
     {{ form_errors(form) }}
 
-    {{ form_row(form.pickup) }}
-    {{ form_row(form.dropoff) }}
+    {{ form_widget(form.tasks) }}
 
     {% if form.vehicle is defined %}
       {{ form_row(form.vehicle) }}

--- a/templates/form/delivery.html.twig
+++ b/templates/form/delivery.html.twig
@@ -74,67 +74,11 @@ col-md-9
   {{ block('vehicle_widget') }}
 {% endblock %}
 
-{# Pickup #}
-
-{% block _delivery_pickup_row %}
-  {{ block('task_row') }}
-{% endblock %}
-
-{% block _delivery_pickup_widget %}
-  {{ block('task_widget') }}
-{% endblock %}
-
-{% block _delivery_pickup_type_widget %}
-  {{ block('hidden_widget') }}
-{% endblock %}
-
-{% block _delivery_pickup_doneAfter_widget %}
-  {{ block('hidden_widget') }}
-{% endblock %}
-
-{% block _delivery_pickup_doneBefore_widget %}
-  {{ block('hidden_widget') }}
-  <div id="{{ form.vars.id ~ '_widget' }}"></div>
-{% endblock %}
-
-{% block _delivery_pickup_tagsAsString_widget %}
-<div id="{{ form.vars.id ~ '_widget' }}"></div>
-{{ block('hidden_widget') }}
-{% endblock %}
-
-{# Dropoff #}
-
-{% block _delivery_dropoff_row %}
-  {{ block('task_row') }}
-{% endblock %}
-
-{% block _delivery_dropoff_widget %}
-  {{ block('task_widget') }}
-{% endblock %}
-
-{% block _delivery_dropoff_type_widget %}
-  {{ block('hidden_widget') }}
-{% endblock %}
-
-{% block _delivery_dropoff_doneAfter_widget %}
-  {{ block('hidden_widget') }}
-{% endblock %}
-
 {% block _delivery_weight_widget %}
   <div class="input-group">
     {{ block('form_widget_simple') }}
     <span class="input-group-addon">{{ 'basics.kilos'|trans }}</span>
   </div>
-{% endblock %}
-
-{% block _delivery_dropoff_doneBefore_widget %}
-  {{ block('hidden_widget') }}
-  <div id="{{ form.vars.id ~ '_widget' }}"></div>
-{% endblock %}
-
-{% block _delivery_dropoff_tagsAsString_widget %}
-<div id="{{ form.vars.id ~ '_widget' }}"></div>
-{{ block('hidden_widget') }}
 {% endblock %}
 
 {% block _delivery_packages_widget %}
@@ -163,4 +107,30 @@ col-md-9
     data-delete
     data-target="#{{ form.vars.id }}"><i class="fa fa-trash-o"></i></button>
 </div>
+{% endblock %}
+
+{% block _delivery_tasks_entry_row %}
+  {{ block('task_row') }}
+{% endblock %}
+
+{% block _delivery_tasks_entry_widget %}
+  {{ block('task_widget') }}
+{% endblock %}
+
+{% block _delivery_tasks_entry_type_widget %}
+  {{ block('hidden_widget') }}
+{% endblock %}
+
+{% block _delivery_tasks_entry_doneAfter_widget %}
+  {{ block('hidden_widget') }}
+{% endblock %}
+
+{% block _delivery_tasks_entry_doneBefore_widget %}
+  {{ block('hidden_widget') }}
+  <div id="{{ form.vars.id ~ '_widget' }}"></div>
+{% endblock %}
+
+{% block _delivery_tasks_entry_tagsAsString_widget %}
+<div id="{{ form.vars.id ~ '_widget' }}"></div>
+{{ block('hidden_widget') }}
 {% endblock %}

--- a/templates/form/delivery_embed.html.twig
+++ b/templates/form/delivery_embed.html.twig
@@ -8,7 +8,7 @@
   {{ form_row(form.address) }}
 
   {% if form.doneBefore is defined %}
-    {{ form_row(form.doneBefore, { label: 'form.delivery.' ~ form.vars.name ~ '.doneBefore.label' }) }}
+    {{ form_row(form.doneBefore, { label: 'form.delivery.' ~ (form.vars.data.type|lower) ~ '.doneBefore.label' }) }}
   {% endif %}
 
   {% if form.timeSlot is defined %}
@@ -30,7 +30,6 @@
 </div>
 {% endblock %}
 
-
 {% block _delivery_vehicle_widget %}
 <div class="alert alert-info">
   {{ 'form.delivery_embed.vehicle.disclaimer'|trans }}
@@ -38,23 +37,11 @@
 {{ block('vehicle_widget') }}
 {% endblock %}
 
-{# Pickup #}
-
-{% block _delivery_pickup_row %}
+{% block _delivery_tasks_entry_row %}
   {{ block('task_embed_row') }}
 {% endblock %}
 
-{% block _delivery_pickup_label %}
-  <h3>{{ label|trans }}</h3>
-{% endblock %}
-
-{# Dropoff #}
-
-{% block _delivery_dropoff_row %}
-  {{ block('task_embed_row') }}
-{% endblock %}
-
-{% block _delivery_dropoff_label %}
+{% block _delivery_tasks_entry_label %}
   <h3>{{ label|trans }}</h3>
 {% endblock %}
 


### PR DESCRIPTION
This is an intermediary pull request for #2610

It removes the `pickup`/`dropoff` properties from the form, and manages it as an array of tasks. 