### PR TITLE
Create delivery with multiple dropoffs when using recurrence rules

### DIFF
--- a/app/DoctrineMigrations/Version20210723161106.php
+++ b/app/DoctrineMigrations/Version20210723161106.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20210723161106 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX uniq_527edb25bc2d6b55');
+        $this->addSql('DROP INDEX uniq_527edb254f382b24');
+        $this->addSql('CREATE INDEX IDX_527EDB25BC2D6B55 ON task (previous_task_id)');
+        $this->addSql('CREATE INDEX IDX_527EDB254F382B24 ON task (next_task_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IDX_527EDB25BC2D6B55');
+        $this->addSql('DROP INDEX IDX_527EDB254F382B24');
+        $this->addSql('CREATE UNIQUE INDEX uniq_527edb25bc2d6b55 ON task (previous_task_id)');
+        $this->addSql('CREATE UNIQUE INDEX uniq_527edb254f382b24 ON task (next_task_id)');
+    }
+}

--- a/app/DoctrineMigrations/Version20210723161106.php
+++ b/app/DoctrineMigrations/Version20210723161106.php
@@ -20,16 +20,12 @@ final class Version20210723161106 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $this->addSql('DROP INDEX uniq_527edb25bc2d6b55');
-        $this->addSql('DROP INDEX uniq_527edb254f382b24');
         $this->addSql('CREATE INDEX IDX_527EDB25BC2D6B55 ON task (previous_task_id)');
-        $this->addSql('CREATE INDEX IDX_527EDB254F382B24 ON task (next_task_id)');
     }
 
     public function down(Schema $schema): void
     {
         $this->addSql('DROP INDEX IDX_527EDB25BC2D6B55');
-        $this->addSql('DROP INDEX IDX_527EDB254F382B24');
         $this->addSql('CREATE UNIQUE INDEX uniq_527edb25bc2d6b55 ON task (previous_task_id)');
-        $this->addSql('CREATE UNIQUE INDEX uniq_527edb254f382b24 ON task (next_task_id)');
     }
 }

--- a/features/fixtures/ORM/recurrence_rules.yml
+++ b/features/fixtures/ORM/recurrence_rules.yml
@@ -36,3 +36,25 @@ AppBundle\Entity\Task\RecurrenceRule:
       '@type': 'hydra:Collection'
       'hydra:member': []
     deletedAt: <identity(new \DateTime('yesterday'))>
+  recurrence_rule_4:
+    store: '@store_1'
+    rule: '@rrule_2'
+    template:
+      '@type': 'hydra:Collection'
+      'hydra:member':
+        - 'address':
+            '@id': '/api/addresses/1'
+            'streetAddress': '272, rue Saint Honoré 75001 Paris 1er'
+          'type': 'PICKUP'
+          'after': '11:30'
+          'before': '12:00'
+        - 'address':
+            '@id': '/api/addresses/2'
+            'streetAddress': '18, avenue Ledru-Rollin 75012 Paris 12ème'
+          'after': '12:30'
+          'before': '13:00'
+        - 'address':
+            '@id': '/api/addresses/3'
+            'streetAddress': '18, avenue Ledru-Rollin 75012 Paris 12ème'
+          'after': '12:30'
+          'before': '13:00'

--- a/features/recurrence_rules.feature
+++ b/features/recurrence_rules.feature
@@ -348,7 +348,7 @@ Feature: Task recurrence rules
         "@id":"/api/recurrence_rules",
         "@type":"hydra:Collection",
         "hydra:member": @array@,
-        "hydra:totalItems":2
+        "hydra:totalItems":3
       }
       """
 

--- a/features/recurrence_rules.feature
+++ b/features/recurrence_rules.feature
@@ -416,3 +416,46 @@ Feature: Task recurrence rules
         "hydra:totalItems":2
       }
       """
+
+  Scenario: Apply recurrence rule creates delivery
+    Given the fixtures files are loaded:
+      | sylius_channels.yml  |
+      | users.yml            |
+      | addresses.yml        |
+      | recurrence_rules.yml |
+    And the user "bob" has role "ROLE_ADMIN"
+    And the user "bob" is authenticated
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "POST" request to "/api/recurrence_rules/4/between" with body:
+      """
+      {
+        "after": "2021-02-12T00:00:00+01:00",
+        "before": "2021-02-12T23:59:59+01:00"
+      }
+      """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context":"/api/contexts/RecurrenceRule",
+        "@id":"/api/recurrence_rules",
+        "@type":"hydra:Collection",
+        "hydra:member":[
+          {
+            "@id":"/api/tasks/1",
+            "@type":"Task"
+          },
+          {
+            "@id":"/api/tasks/2",
+            "@type":"Task"
+          },
+          {
+            "@id":"/api/tasks/3",
+            "@type":"Task"
+          }
+        ],
+        "hydra:totalItems":3
+      }
+      """

--- a/src/Action/Task/RecurrenceRuleBetween.php
+++ b/src/Action/Task/RecurrenceRuleBetween.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Action\Task;
 
+use AppBundle\Entity\Delivery;
 use AppBundle\Entity\Task;
 use Doctrine\ORM\EntityManagerInterface;
 use Recurr\Transformer\ArrayTransformer;
@@ -72,6 +73,12 @@ class RecurrenceRuleBetween
             $task->setRecurrenceRule($data);
             $this->entityManager->persist($task);
             $tasks[] = $task;
+        }
+
+        if (count($tasks) > 1 && $tasks[0]->isPickup()) {
+            $delivery = Delivery::createWithTasks(...$tasks);
+            $data->getStore()->addDelivery($delivery);
+            $this->entityManager->persist($delivery);
         }
 
         $this->entityManager->flush();

--- a/src/Entity/Delivery.php
+++ b/src/Entity/Delivery.php
@@ -157,6 +157,14 @@ class Delivery extends TaskCollection implements TaskCollectionInterface
         $this->packages = new ArrayCollection();
     }
 
+    public function addTask(Task $task, $position = null)
+    {
+        $task->setDelivery($this);
+
+        return parent::addTask($task, $position);
+    }
+
+
     public function getOrder()
     {
         return $this->order;
@@ -243,25 +251,17 @@ class Delivery extends TaskCollection implements TaskCollectionInterface
         $delivery->removeTask($delivery->getPickup());
         $delivery->removeTask($delivery->getDropoff());
 
-        if (func_num_args() > 2) {
+        if (count($tasks) > 2) {
 
-            for ($i = 0; $i < count($tasks); $i++) {
+            $pickup = array_shift($tasks);
 
-                $current = $tasks[$i];
-                $prev = $i > 0 ? $tasks[$i - 1] : null;
-                $next = $i < (count($tasks) - 1) ? $tasks[$i + 1] : null;
+            $delivery->addTask($pickup);
 
-                if ($prev) {
-                    $current->setPrevious($prev);
-                }
+            foreach ($tasks as $dropoff) {
 
-                if ($next) {
-                    $current->setNext($next);
-                }
+                $dropoff->setPrevious($pickup);
 
-                $current->setDelivery($delivery);
-
-                $delivery->addTask($current);
+                $delivery->addTask($dropoff);
             }
 
 

--- a/src/Entity/DeliveryRepository.php
+++ b/src/Entity/DeliveryRepository.php
@@ -27,25 +27,25 @@ class DeliveryRepository extends EntityRepository
         }
 
         $qbToday = (clone $qb)
-            ->andWhere('t.type = :dropoff')
-            ->andWhere('t.doneAfter > :after')
-            ->andWhere('t.doneBefore < :before')
-            ->setParameter('dropoff', Task::TYPE_DROPOFF)
+            ->andWhere('t.type = :pickup')
+            ->andWhere('t.doneAfter >= :after')
+            ->andWhere('t.doneBefore <= :before')
+            ->setParameter('pickup', Task::TYPE_PICKUP)
             ->setParameter('after', $today->copy()->hour(0)->minute(0)->second(0))
             ->setParameter('before', $today->copy()->hour(23)->minute(59)->second(59));
 
         $qbUpcoming = (clone $qb)
-            ->andWhere('t.type = :dropoff')
-            ->andWhere('t.doneAfter > :after')
-            ->setParameter('dropoff', Task::TYPE_DROPOFF)
+            ->andWhere('t.type = :pickup')
+            ->andWhere('t.doneAfter >= :after')
+            ->setParameter('pickup', Task::TYPE_PICKUP)
             ->setParameter('after', $today->copy()->add(1, 'day')->hour(0)->minute(0)->second(0))
             ->orderBy('t.doneBefore', 'asc')
             ;
 
         $qbPast = (clone $qb)
-            ->andWhere('t.type = :dropoff')
+            ->andWhere('t.type = :pickup')
             ->andWhere('t.doneBefore < :after')
-            ->setParameter('dropoff', Task::TYPE_DROPOFF)
+            ->setParameter('pickup', Task::TYPE_PICKUP)
             ->setParameter('after', $today->copy()->sub(1, 'day')->hour(23)->minute(59)->second(59))
             ;
 

--- a/src/Resources/config/doctrine/Task.orm.xml
+++ b/src/Resources/config/doctrine/Task.orm.xml
@@ -26,16 +26,16 @@
     <field name="updatedAt" type="datetime" column="updated_at">
       <gedmo:timestampable on="update"/>
     </field>
-    <one-to-one field="previous" target-entity="AppBundle\Entity\Task">
+    <many-to-one field="previous" target-entity="AppBundle\Entity\Task">
       <join-columns>
         <join-column name="previous_task_id" referenced-column-name="id"/>
       </join-columns>
-    </one-to-one>
-    <one-to-one field="next" target-entity="AppBundle\Entity\Task">
+    </many-to-one>
+    <many-to-one field="next" target-entity="AppBundle\Entity\Task">
       <join-columns>
         <join-column name="next_task_id" referenced-column-name="id"/>
       </join-columns>
-    </one-to-one>
+    </many-to-one>
     <one-to-many field="events" target-entity="AppBundle\Entity\TaskEvent" mapped-by="task">
       <cascade>
         <cascade-all/>

--- a/src/Resources/config/doctrine/Task.orm.xml
+++ b/src/Resources/config/doctrine/Task.orm.xml
@@ -31,11 +31,11 @@
         <join-column name="previous_task_id" referenced-column-name="id"/>
       </join-columns>
     </many-to-one>
-    <many-to-one field="next" target-entity="AppBundle\Entity\Task">
+    <one-to-one field="next" target-entity="AppBundle\Entity\Task">
       <join-columns>
         <join-column name="next_task_id" referenced-column-name="id"/>
       </join-columns>
-    </many-to-one>
+    </one-to-one>
     <one-to-many field="events" target-entity="AppBundle\Entity\TaskEvent" mapped-by="task">
       <cascade>
         <cascade-all/>

--- a/tests/AppBundle/Entity/DeliveryTest.php
+++ b/tests/AppBundle/Entity/DeliveryTest.php
@@ -26,18 +26,6 @@ class DeliveryTest extends TestCase
         $this->assertCount(2, $delivery->getTasks());
     }
 
-    public function testAddTaskThrowsException()
-    {
-        $this->expectException(\RuntimeException::class);
-
-        $delivery = new Delivery();
-
-        $task = new Task();
-        $task->setType(Task::TYPE_PICKUP);
-
-        $delivery->addTask($task);
-    }
-
     public function testToExpressionLanguageValues()
     {
         $pickupAddress = new Address();
@@ -206,13 +194,12 @@ class DeliveryTest extends TestCase
         // Delivery::getDropoff() returns the *LAST* dropoff to stay BC
         $this->assertSame($tasks[3], $delivery->getDropoff());
 
+        // Only dropoffs should have link with pickup
         $this->assertSame($tasks[0], $tasks[1]->getPrevious());
-        $this->assertSame($tasks[2], $tasks[1]->getNext());
+        $this->assertSame($tasks[0], $tasks[2]->getPrevious());
+        $this->assertSame($tasks[0], $tasks[3]->getPrevious());
 
-        $this->assertSame($tasks[1], $tasks[2]->getPrevious());
-        $this->assertSame($tasks[3], $tasks[2]->getNext());
-
-        $this->assertNull($tasks[3]->getNext());
+        $this->assertNull($tasks[0]->getNext());
 
         foreach ($tasks as $task) {
             $this->assertSame($delivery, $task->getDelivery());


### PR DESCRIPTION
See #2610 

When using recurrence rules, if the list of task starts with a pickup, a delivery will be created, that links the tasks together. 

This allows to: 

#### show tasks with the same color in the dispatch

<img width="556" alt="Capture d’écran 2021-07-24 à 13 27 58" src="https://user-images.githubusercontent.com/1162230/126867109-d741ccba-1b7f-455c-9da6-1de893203dd2.png">

#### show all tasks of the delivery in the list

<img width="619" alt="Capture d’écran 2021-07-24 à 13 27 33" src="https://user-images.githubusercontent.com/1162230/126867130-aabc1624-fbae-40db-a4de-e64cdfecff6d.png">

#### show all tasks of the delivery in the details

<img width="725" alt="Capture d’écran 2021-07-24 à 13 32 55" src="https://user-images.githubusercontent.com/1162230/126867144-28dffd6f-fd50-4e40-8124-6c1f9116f299.png">

