### PR TITLE
Move packages at task level

### DIFF
--- a/app/DoctrineMigrations/Version20211215104949.php
+++ b/app/DoctrineMigrations/Version20211215104949.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20211215104949 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE task_package (id SERIAL NOT NULL, task_id INT NOT NULL, package_id INT NOT NULL, quantity INT NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX IDX_C1894D7F8DB60186 ON task_package (task_id)');
+        $this->addSql('CREATE INDEX IDX_C1894D7FF44CABFF ON task_package (package_id)');
+        $this->addSql('ALTER TABLE task_package ADD CONSTRAINT FK_C1894D7F8DB60186 FOREIGN KEY (task_id) REFERENCES task (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE task_package ADD CONSTRAINT FK_C1894D7FF44CABFF FOREIGN KEY (package_id) REFERENCES package (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        $stmt = $this->connection->prepare('SELECT t.delivery_id, t.id AS task_id, tci.position, dp.package_id, dp.quantity FROM delivery_package dp JOIN task_collection_item tci ON dp.delivery_id = tci.parent_id JOIN task t ON tci.task_id = t.id WHERE t.type = \'DROPOFF\'');
+        $stmt->execute();
+
+        $deliveryPackages = [];
+        while ($deliveryPackage = $stmt->fetch()) {
+            if (!isset($deliveryPackages[$deliveryPackage['delivery_id']])) {
+                $deliveryPackages[$deliveryPackage['delivery_id']] = $deliveryPackage;
+            } else {
+                // In case of multiple dropoffs, we will move packages to the *FIRST* dropoff
+                if ($deliveryPackage['position'] < $deliveryPackages[$deliveryPackage['delivery_id']]['position']) {
+                    $deliveryPackages[$deliveryPackage['delivery_id']] = $deliveryPackage;
+                }
+            }
+        }
+
+        foreach ($deliveryPackages as $deliveryPackage) {
+            $this->addSql('INSERT INTO task_package (task_id, package_id, quantity) VALUES (:task_id, :package_id, :quantity)', [
+                'task_id' => $deliveryPackage['task_id'],
+                'package_id' => $deliveryPackage['package_id'],
+                'quantity' => $deliveryPackage['quantity'],
+            ]);
+        }
+
+        $this->addSql('DROP TABLE delivery_package');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE delivery_package (id SERIAL NOT NULL, delivery_id INT NOT NULL, package_id INT NOT NULL, quantity INT NOT NULL, PRIMARY KEY(id))');
+        $this->addSql('CREATE INDEX idx_d476d84bf44cabff ON delivery_package (package_id)');
+        $this->addSql('CREATE INDEX idx_d476d84b12136921 ON delivery_package (delivery_id)');
+        $this->addSql('ALTER TABLE delivery_package ADD CONSTRAINT fk_d476d84bf44cabff FOREIGN KEY (package_id) REFERENCES package (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE delivery_package ADD CONSTRAINT fk_d476d84b12136921 FOREIGN KEY (delivery_id) REFERENCES delivery (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        $stmt = $this->connection->prepare('SELECT t.delivery_id, t.id AS task_id, tci.position, tp.package_id, tp.quantity FROM task_package tp JOIN task_collection_item tci ON tp.task_id = tci.task_id JOIN task t ON tci.task_id = t.id');
+        $stmt->execute();
+
+        $packagesByDelivery = [];
+
+        while ($taskPackage = $stmt->fetch()) {
+            $packagesByDelivery[$taskPackage['delivery_id']][] = $taskPackage;
+        }
+
+        $packagesByDeliveryComputed = [];
+        foreach ($packagesByDelivery as $deliveryId => $item) {
+            $packagesByDeliveryComputed[$deliveryId] = array_reduce($item, function ($carry, $item) {
+                if (isset($carry[$item['package_id']])) {
+                    $carry[$item['package_id']] += $item['quantity'];
+                } else {
+                    $carry[$item['package_id']] = $item['quantity'];
+                }
+
+                return $carry;
+            }, []);
+        }
+
+        foreach ($packagesByDeliveryComputed as $deliveryId => $packages) {
+            foreach ($packages as $packageId => $quantity) {
+                $this->addSql('INSERT INTO delivery_package (delivery_id, package_id, quantity) VALUES (:delivery_id, :package_id, :quantity)', [
+                    'delivery_id' => $deliveryId,
+                    'package_id' => $packageId,
+                    'quantity' => $quantity,
+                ]);
+            }
+        }
+
+        $this->addSql('DROP TABLE task_package');
+    }
+}

--- a/features/pricing_rules.feature
+++ b/features/pricing_rules.feature
@@ -142,3 +142,53 @@ Feature: Pricing rules
         "result":true
       }
       """
+
+  Scenario: Evaluate pricing rule with packages in task (JWT)
+    Given the current time is "2020-06-09 12:00:00"
+    Given the fixtures files are loaded:
+      | sylius_channels.yml |
+      | stores.yml          |
+    And the user "admin" is loaded:
+      | email      | admin@coopcycle.org |
+      | password   | 123456            |
+    And the user "admin" has role "ROLE_ADMIN"
+    And the user "admin" is authenticated
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "admin" sends a "POST" request to "/api/pricing_rules/3/evaluate" with body:
+      """
+      {
+        "pickup": {
+          "address": {
+            "streetAddress": "24, Rue de la Paix Paris",
+            "latLng": [48.870134, 2.332221]
+          },
+          "timeSlot": "2020-06-09 17:00-18:00"
+        },
+        "dropoff": {
+          "address": {
+            "streetAddress": "48, Rue de Rivoli Paris",
+            "latLng": [48.857127, 2.354766]
+          },
+          "timeSlot": "2020-06-09 17:00-18:00",
+          "packages": [
+            {"type": "XL", "quantity": 2}
+          ]
+        }
+      }
+      """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context":{
+          "@vocab":@string@,
+          "hydra":@string@,
+          "result":"YesNoOutput/result"
+        },
+        "@type":"YesNoOutput",
+        "@id":@string@,
+        "result":true
+      }
+      """

--- a/features/retail_prices.feature
+++ b/features/retail_prices.feature
@@ -135,6 +135,53 @@ Feature: Retail prices
       }
       """
 
+  Scenario: Get delivery price with packages in task (JWT)
+    Given the fixtures files are loaded:
+      | sylius_channels.yml |
+      | sylius_taxation.yml |
+      | stores.yml          |
+    And the setting "subject_to_vat" has value "1"
+    And the user "admin" is loaded:
+      | email      | admin@coopcycle.org |
+      | password   | 123456            |
+    And the user "admin" has role "ROLE_ADMIN"
+    And the user "admin" is authenticated
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "admin" sends a "POST" request to "/api/retail_prices/calculate" with body:
+      """
+      {
+        "store":"/api/stores/3",
+        "pickup": {
+          "address": "24, Rue de la Paix Paris",
+          "before": "tomorrow 13:00"
+        },
+        "dropoff": {
+          "address": "48, Rue de Rivoli Paris",
+          "before": "tomorrow 15:00",
+          "packages": [
+            {"type": "XL", "quantity": 2}
+          ]
+        }
+      }
+      """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context":"/api/contexts/RetailPrice",
+        "@id":@string@,
+        "@type":"RetailPrice",
+        "amount":1299,
+        "currency":"EUR",
+        "tax":{
+          "amount":217,
+          "included": true
+        }
+      }
+      """
+
   Scenario: Get delivery price with latlLng (JWT)
     Given the fixtures files are loaded:
       | sylius_channels.yml |

--- a/js/app/delivery/embed-start.js
+++ b/js/app/delivery/embed-start.js
@@ -34,14 +34,14 @@ taskForms.forEach(function(type) {
     isNewAddressControl: document.querySelector(`#delivery_${type}_address_isNewAddress`),
   })
 
+  const packages = document.querySelector(`#delivery_${type}_packages`)
+
+  if (packages) {
+    const packagesRequired = JSON.parse(packages.dataset.packagesRequired)
+    createPackagesWidget(`delivery_${type}`, packagesRequired)
+  }
+
 })
-
-const packages = document.querySelector(`#delivery_packages`)
-
-if (packages) {
-  const packagesRequired = JSON.parse(packages.dataset.packagesRequired)
-  createPackagesWidget('delivery', packagesRequired)
-}
 
 function setBillingAddressRequired(required) {
   if (required) {

--- a/js/app/forms/delivery.js
+++ b/js/app/forms/delivery.js
@@ -290,10 +290,10 @@ function reducer(state = {}, action) {
       ...state,
       weight: action.value
     }
-  case 'SET_PACKAGES':
+  case 'SET_TASK_PACKAGES':
     return {
       ...state,
-      packages: action.packages
+      tasks: replaceTasks(state, action.taskIndex, 'packages', action.packages)
     }
   case 'CLEAR_ADDRESS':
     return {
@@ -394,6 +394,12 @@ function initSubForm(name, taskEl, preloadedState) {
       })
     }
   }
+
+  const packages = document.querySelector(`#${name}_${taskForm}_packages`)
+  if (packages) {
+    const packagesRequired = JSON.parse(packages.dataset.packagesRequired)
+    createPackagesWidget(`${name}_${taskForm}`, packagesRequired, packages => store.dispatch({ type: 'SET_TASK_PACKAGES', taskIndex, packages }))
+  }
 }
 
 export default function(name, options) {
@@ -449,13 +455,6 @@ export default function(name, options) {
         return document.getElementById('tracking_link').getAttribute('href')
       }
     })
-
-    const packages = document.querySelector(`#${name}_packages`)
-
-    if (packages) {
-      const packagesRequired = JSON.parse(packages.dataset.packagesRequired)
-      createPackagesWidget(name, packagesRequired, packages => store.dispatch({ type: 'SET_PACKAGES', packages }))
-    }
 
     el.addEventListener('submit', (e) => {
 

--- a/js/app/forms/delivery.js
+++ b/js/app/forms/delivery.js
@@ -176,7 +176,7 @@ function createPackageForm(name, $list, cb) {
   var counter = $list.data('widget-counter') || $list.children().length
   var newWidget = $list.attr('data-prototype')
 
-  newWidget = newWidget.replace(/__name__/g, counter)
+  newWidget = newWidget.replace(/__package__/g, counter)
 
   counter++
   $list.data('widget-counter', counter)

--- a/src/Entity/Delivery.php
+++ b/src/Entity/Delivery.php
@@ -359,18 +359,11 @@ class Delivery extends TaskCollection implements TaskCollectionInterface
             return;
         }
 
-        $items = $this->getItems();
-
-        $firstDropoff = null;
-        foreach ($items as $item) {
-            if ($item->getTask()->getType() === Task::TYPE_DROPOFF) {
-                $firstDropoff = $item->getTask();
+        foreach ($this->getTasks() as $task) {
+            if ($task->isDropoff()) {
+                $task->addPackageWithQuantity($package, $quantity);
                 break;
             }
-        }
-
-        if ($firstDropoff) {
-            $firstDropoff->addPackageWithQuantity($package, $quantity);
         }
     }
 

--- a/src/Entity/Delivery.php
+++ b/src/Entity/Delivery.php
@@ -13,6 +13,7 @@ use AppBundle\Api\Filter\DeliveryOrderFilter;
 use AppBundle\Entity\Package;
 use AppBundle\Entity\Package\PackagesAwareInterface;
 use AppBundle\Entity\Package\PackagesAwareTrait;
+use AppBundle\Entity\Package\PackageWithQuantity;
 use AppBundle\Entity\Sylius\Order;
 use AppBundle\Entity\Task\CollectionInterface as TaskCollectionInterface;
 use AppBundle\ExpressionLanguage\PackagesResolver;
@@ -343,12 +344,24 @@ class Delivery extends TaskCollection implements TaskCollectionInterface, Packag
     {
         $packages = new ArrayCollection();
 
+        $hash = new \SplObjectStorage();
+
         foreach ($this->getTasks() as $task) {
             if ($task->hasPackages()) {
                 foreach ($task->getPackages() as $package) {
-                    $packages->add($package);
+                    $object = $package->getPackage();
+                    if (isset($hash[$object])) {
+                        $hash[$object] += $package->getQuantity();
+                    } else {
+                        $hash[$object] = $package->getQuantity();
+                    }
                 }
             }
+        }
+
+        foreach ($hash as $package) {
+            $quantity = $hash[$package];
+            $packages->add(new PackageWithQuantity($package, $quantity));
         }
 
         return $packages;

--- a/src/Entity/Delivery.php
+++ b/src/Entity/Delivery.php
@@ -11,6 +11,7 @@ use AppBundle\Action\Delivery\Drop as DropDelivery;
 use AppBundle\Action\Delivery\Pick as PickDelivery;
 use AppBundle\Api\Filter\DeliveryOrderFilter;
 use AppBundle\Entity\Package;
+use AppBundle\Entity\Package\PackagesAwareInterface;
 use AppBundle\Entity\Package\PackagesAwareTrait;
 use AppBundle\Entity\Sylius\Order;
 use AppBundle\Entity\Task\CollectionInterface as TaskCollectionInterface;
@@ -99,7 +100,7 @@ use Symfony\Component\Serializer\Annotation\Groups;
  * @AssertDelivery
  * @AssertCheckDelivery(groups={"delivery_check"})
  */
-class Delivery extends TaskCollection implements TaskCollectionInterface
+class Delivery extends TaskCollection implements TaskCollectionInterface, PackagesAwareInterface
 {
     use PackagesAwareTrait;
 

--- a/src/Entity/Package/PackageWithQuantity.php
+++ b/src/Entity/Package/PackageWithQuantity.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace AppBundle\Form\Entity;
+namespace AppBundle\Entity\Package;
 
 use AppBundle\Entity\Package;
 
@@ -9,9 +9,10 @@ class PackageWithQuantity
     private $package;
     private $quantity = 0;
 
-    public function __construct(Package $package = null)
+    public function __construct(Package $package = null, $quantity = 0)
     {
         $this->package = $package;
+        $this->quantity = $quantity;
     }
 
     /**

--- a/src/Entity/Package/PackagesAwareInterface.php
+++ b/src/Entity/Package/PackagesAwareInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AppBundle\Entity\Package;
+
+use AppBundle\Entity\Package;
+
+interface PackagesAwareInterface
+{
+    public function getPackages();
+
+    public function addPackageWithQuantity(Package $package, $quantity = 1);
+}

--- a/src/Entity/Package/PackagesAwareTrait.php
+++ b/src/Entity/Package/PackagesAwareTrait.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Entity\Package;
 
 use AppBundle\Entity\Package;
-use AppBundle\Entity\Task\Package as TaskPackage;
 
 trait PackagesAwareTrait
 {
@@ -12,36 +11,6 @@ trait PackagesAwareTrait
     public function hasPackages()
     {
         return count($this->getPackages()) > 0;
-    }
-
-    public function addPackageWithQuantity(Package $package, $quantity = 1)
-    {
-        if (0 === $quantity) {
-            return;
-        }
-
-        $wrappedPackage = $this->resolvePackage($package);
-        $wrappedPackage->setQuantity($wrappedPackage->getQuantity() + $quantity);
-
-        if (!$this->packages->contains($wrappedPackage)) {
-            $this->packages->add($wrappedPackage);
-        }
-    }
-
-    protected function resolvePackage(Package $package): TaskPackage
-    {
-        if ($this->hasPackage($package)) {
-            foreach ($this->packages as $taskPackage) {
-                if ($taskPackage->getPackage() === $package) {
-                    return $taskPackage;
-                }
-            }
-        }
-
-        $taskPackage = new TaskPackage($this);
-        $taskPackage->setPackage($package);
-
-        return $taskPackage;
     }
 
     public function hasPackage(Package $package)

--- a/src/Entity/Package/PackagesAwareTrait.php
+++ b/src/Entity/Package/PackagesAwareTrait.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace AppBundle\Entity\Package;
+
+use AppBundle\Entity\Package;
+use AppBundle\Entity\Task\Package as TaskPackage;
+
+trait PackagesAwareTrait
+{
+    protected $packages;
+
+    public function hasPackages()
+    {
+        return count($this->getPackages()) > 0;
+    }
+
+    public function addPackageWithQuantity(Package $package, $quantity = 1)
+    {
+        if (0 === $quantity) {
+            return;
+        }
+
+        $wrappedPackage = $this->resolvePackage($package);
+        $wrappedPackage->setQuantity($wrappedPackage->getQuantity() + $quantity);
+
+        if (!$this->packages->contains($wrappedPackage)) {
+            $this->packages->add($wrappedPackage);
+        }
+    }
+
+    protected function resolvePackage(Package $package): TaskPackage
+    {
+        if ($this->hasPackage($package)) {
+            foreach ($this->packages as $taskPackage) {
+                if ($taskPackage->getPackage() === $package) {
+                    return $taskPackage;
+                }
+            }
+        }
+
+        $taskPackage = new TaskPackage($this);
+        $taskPackage->setPackage($package);
+
+        return $taskPackage;
+    }
+
+    public function hasPackage(Package $package)
+    {
+        foreach ($this->getPackages() as $p) {
+            if ($p->getPackage() === $package) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getQuantityForPackage(Package $package)
+    {
+        foreach ($this->getPackages() as $p) {
+            if ($p->getPackage() === $package) {
+                return $p->getQuantity();
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/Entity/Task.php
+++ b/src/Entity/Task.php
@@ -17,12 +17,14 @@ use AppBundle\Api\Filter\TaskDateFilter;
 use AppBundle\Api\Filter\TaskFilter;
 use AppBundle\DataType\TsRange;
 use AppBundle\Domain\Task\Event as TaskDomainEvent;
+use AppBundle\Entity\Package;
 use AppBundle\Entity\Task\Group as TaskGroup;
 use AppBundle\Entity\Task\RecurrenceRule;
 use AppBundle\Entity\Model\TaggableInterface;
 use AppBundle\Entity\Model\TaggableTrait;
 use AppBundle\Entity\Model\OrganizationAwareInterface;
 use AppBundle\Entity\Model\OrganizationAwareTrait;
+use AppBundle\Entity\Package\PackagesAwareTrait;
 use AppBundle\Validator\Constraints\Task as AssertTask;
 use AppBundle\Vroom\Job as VroomJob;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -175,6 +177,7 @@ class Task implements TaggableInterface, OrganizationAwareInterface
 {
     use TaggableTrait;
     use OrganizationAwareTrait;
+    use PackagesAwareTrait;
 
     const TYPE_DROPOFF = 'DROPOFF';
     const TYPE_PICKUP = 'PICKUP';
@@ -297,6 +300,7 @@ class Task implements TaggableInterface, OrganizationAwareInterface
     {
         $this->events = new ArrayCollection();
         $this->images = new ArrayCollection();
+        $this->packages = new ArrayCollection();
     }
 
     public function getId()
@@ -772,5 +776,10 @@ class Task implements TaggableInterface, OrganizationAwareInterface
     public function getMetadata()
     {
         return $this->metadata;
+    }
+
+    public function getPackages()
+    {
+        return $this->packages;
     }
 }

--- a/src/Entity/Task/Package.php
+++ b/src/Entity/Task/Package.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace AppBundle\Entity\Delivery;
+namespace AppBundle\Entity\Task;
 
-use AppBundle\Entity\Delivery;
+use AppBundle\Entity\Task;
 
 class Package
 {
     protected $id;
     protected $package;
-    protected $delivery;
+    protected $task;
     protected $quantity = 0;
 
-    public function __construct(Delivery $delivery = null)
+    public function __construct(Task $task = null)
     {
-        $this->delivery = $delivery;
+        $this->task = $task;
     }
 
     /**
@@ -47,19 +47,19 @@ class Package
     /**
      * @return mixed
      */
-    public function getDelivery()
+    public function getTask()
     {
-        return $this->delivery;
+        return $this->task;
     }
 
     /**
-     * @param mixed $delivery
+     * @param mixed $task
      *
      * @return self
      */
-    public function setDelivery($delivery)
+    public function setTask($task)
     {
-        $this->delivery = $delivery;
+        $this->task = $task;
 
         return $this;
     }

--- a/src/Form/DeliveryType.php
+++ b/src/Form/DeliveryType.php
@@ -7,7 +7,6 @@ use AppBundle\Entity\PackageSet;
 use AppBundle\Entity\Store;
 use AppBundle\Entity\Task;
 use AppBundle\Entity\TimeSlot;
-use AppBundle\Form\Entity\PackageWithQuantity;
 use AppBundle\Service\RoutingInterface;
 use Carbon\Carbon;
 use Symfony\Component\Form\AbstractType;

--- a/src/Form/DeliveryType.php
+++ b/src/Form/DeliveryType.php
@@ -98,6 +98,8 @@ class DeliveryType extends AbstractType
                     'with_time_slot' => $this->getTimeSlot($options, $store),
                     'with_doorstep' => $options['with_dropoff_doorstep'],
                     'with_address_props' => $options['with_address_props'],
+                    'with_package_set' => $this->getPackageSet($options, $store),
+                    'with_packages_required' => null !== $store ? $store->isPackagesRequired() : true,
                 ],
                 'allow_add' => true,
                 'prototype_data' => new Task(),
@@ -135,64 +137,6 @@ class DeliveryType extends AbstractType
 
                 if (null !== $delivery->getId() && null !== $delivery->getWeight()) {
                     $form->get('weight')->setData($delivery->getWeight() / 1000);
-                }
-            }
-        });
-
-        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($options) {
-
-            $form = $event->getForm();
-            $delivery = $event->getData();
-
-            if (!$packageSet = $this->getPackageSet($options, $delivery->getStore())) {
-                return;
-            }
-
-            $data = [];
-
-            if ($delivery->hasPackages()) {
-                foreach ($delivery->getPackages() as $deliveryPackage) {
-                    $pwq = new PackageWithQuantity($deliveryPackage->getPackage());
-                    $pwq->setQuantity($deliveryPackage->getQuantity());
-                    $data[] = $pwq;
-                }
-            }
-
-            $store = $delivery->getStore();
-            $isPackagesRequired = null !== $store ? $store->isPackagesRequired() : true;
-
-            $form->add('packages', CollectionType::class, [
-                'entry_type' => PackageWithQuantityType::class,
-                'entry_options' => [
-                    'label' => false,
-                    'package_set' => $packageSet
-                ],
-                'label' => 'form.delivery.packages.label',
-                'mapped' => false,
-                'allow_add' => true,
-                'allow_delete' => true,
-                'attr' => [
-                    'data-packages-required' => var_export($isPackagesRequired, true),
-                ]
-            ]);
-
-            $form->get('packages')->setData($data);
-        });
-
-        $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) {
-
-            $form = $event->getForm();
-            $delivery = $event->getData();
-
-            if ($form->has('packages')) {
-                $packages = $form->get('packages')->getData();
-                foreach ($packages as $packageWithQuantity) {
-                    if ($packageWithQuantity->getQuantity() > 0) {
-                        $delivery->addPackageWithQuantity(
-                            $packageWithQuantity->getPackage(),
-                            $packageWithQuantity->getQuantity()
-                        );
-                    }
                 }
             }
         });

--- a/src/Form/PackageWithQuantityType.php
+++ b/src/Form/PackageWithQuantityType.php
@@ -3,7 +3,7 @@
 namespace AppBundle\Form;
 
 use AppBundle\Entity\Package;
-use AppBundle\Form\Entity\PackageWithQuantity;
+use AppBundle\Entity\Package\PackageWithQuantity;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;

--- a/src/Form/TaskType.php
+++ b/src/Form/TaskType.php
@@ -152,11 +152,15 @@ class TaskType extends AbstractType
                 $form = $event->getForm();
                 $task = $event->getData();
 
-                if ($task->getType() === Task::TYPE_DROPOFF) {
+                // Because we are using a collection of forms, $task may be NULL
+                // When $task == NULL, it means it's an additional task
+                // In this case, we add the "packages" field anyways,
+                // to avoid the error "This form should not contain extra fields"
+                if (null === $task || $task->getType() === Task::TYPE_DROPOFF) {
 
                     $data = [];
 
-                    if ($task->hasPackages()) {
+                    if ($task && $task->hasPackages()) {
                         foreach ($task->getPackages() as $wrappedPackage) {
                             $pwq = new PackageWithQuantity($wrappedPackage->getPackage());
                             $pwq->setQuantity($wrappedPackage->getQuantity());
@@ -176,7 +180,8 @@ class TaskType extends AbstractType
                         'allow_delete' => true,
                         'attr' => [
                             'data-packages-required' => var_export($options['with_packages_required'], true),
-                        ]
+                        ],
+                        'prototype_name' => '__package__'
                     ]);
 
                     $form->get('packages')->setData($data);

--- a/src/Form/TaskType.php
+++ b/src/Form/TaskType.php
@@ -3,14 +3,17 @@
 namespace AppBundle\Form;
 
 use AppBundle\Entity\Address;
+use AppBundle\Entity\PackageSet;
 use AppBundle\Entity\Task;
 use AppBundle\Entity\TimeSlot;
+use AppBundle\Form\Entity\PackageWithQuantity;
 use AppBundle\Form\Type\TimeSlotChoice;
 use AppBundle\Form\Type\TimeSlotChoiceType;
 use AppBundle\Service\TaskManager;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -142,6 +145,45 @@ class TaskType extends AbstractType
             });
         }
 
+        if (null !== $options['with_package_set']) {
+
+            $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($options) {
+
+                $form = $event->getForm();
+                $task = $event->getData();
+
+                if ($task->getType() === Task::TYPE_DROPOFF) {
+
+                    $data = [];
+
+                    if ($task->hasPackages()) {
+                        foreach ($task->getPackages() as $wrappedPackage) {
+                            $pwq = new PackageWithQuantity($wrappedPackage->getPackage());
+                            $pwq->setQuantity($wrappedPackage->getQuantity());
+                            $data[] = $pwq;
+                        }
+                    }
+
+                    $form->add('packages', CollectionType::class, [
+                        'entry_type' => PackageWithQuantityType::class,
+                        'entry_options' => [
+                            'label' => false,
+                            'package_set' => $options['with_package_set'],
+                        ],
+                        'label' => 'form.delivery.packages.label',
+                        'mapped' => false,
+                        'allow_add' => true,
+                        'allow_delete' => true,
+                        'attr' => [
+                            'data-packages-required' => var_export($options['with_packages_required'], true),
+                        ]
+                    ]);
+
+                    $form->get('packages')->setData($data);
+                }
+            });
+        }
+
         $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) {
 
             $form = $event->getForm();
@@ -151,6 +193,18 @@ class TaskType extends AbstractType
                 $choice = $form->get('timeSlot')->getData();
                 if ($choice) {
                     $choice->applyToTask($task);
+                }
+            }
+
+            if ($form->has('packages')) {
+                $packages = $form->get('packages')->getData();
+                foreach ($packages as $packageWithQuantity) {
+                    if ($packageWithQuantity->getQuantity() > 0) {
+                        $task->addPackageWithQuantity(
+                            $packageWithQuantity->getPackage(),
+                            $packageWithQuantity->getQuantity()
+                        );
+                    }
                 }
             }
         });
@@ -167,9 +221,12 @@ class TaskType extends AbstractType
             'with_remember_address' => false,
             'with_time_slot' => null,
             'with_address_props' => false,
+            'with_package_set' => null,
+            'with_packages_required' => false,
         ));
 
         $resolver->setAllowedTypes('with_time_slot', ['null', TimeSlot::class]);
+        $resolver->setAllowedTypes('with_package_set', ['null', PackageSet::class]);
     }
 
     public function finishView(FormView $view, FormInterface $form, array $options)

--- a/src/Form/TaskType.php
+++ b/src/Form/TaskType.php
@@ -3,10 +3,10 @@
 namespace AppBundle\Form;
 
 use AppBundle\Entity\Address;
+use AppBundle\Entity\Package\PackageWithQuantity;
 use AppBundle\Entity\PackageSet;
 use AppBundle\Entity\Task;
 use AppBundle\Entity\TimeSlot;
-use AppBundle\Form\Entity\PackageWithQuantity;
 use AppBundle\Form\Type\TimeSlotChoice;
 use AppBundle\Form\Type\TimeSlotChoiceType;
 use AppBundle\Service\TaskManager;

--- a/src/Resources/config/doctrine/Delivery.orm.xml
+++ b/src/Resources/config/doctrine/Delivery.orm.xml
@@ -8,11 +8,6 @@
         <join-column name="order_id" referenced-column-name="id"/>
       </join-columns>
     </one-to-one>
-    <one-to-many field="packages" target-entity="AppBundle\Entity\Delivery\Package" mapped-by="delivery">
-      <cascade>
-        <cascade-all/>
-      </cascade>
-    </one-to-many>
     <many-to-one field="store" target-entity="AppBundle\Entity\Store" inversed-by="deliveries">
       <join-columns>
         <join-column name="store_id" referenced-column-name="id"/>

--- a/src/Resources/config/doctrine/Task.Package.orm.xml
+++ b/src/Resources/config/doctrine/Task.Package.orm.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
-  <entity name="AppBundle\Entity\Delivery\Package" table="delivery_package">
+  <entity name="AppBundle\Entity\Task\Package" table="task_package">
     <id name="id" type="integer" column="id">
       <generator strategy="IDENTITY"/>
     </id>
     <field name="quantity" type="integer" column="quantity"/>
-    <many-to-one field="delivery" target-entity="AppBundle\Entity\Delivery" inversed-by="packages">
+    <many-to-one field="task" target-entity="AppBundle\Entity\Task" inversed-by="packages">
       <join-columns>
-        <join-column name="delivery_id" referenced-column-name="id" nullable="false"/>
+        <join-column name="task_id" referenced-column-name="id" nullable="false"/>
       </join-columns>
     </many-to-one>
     <many-to-one field="package" target-entity="AppBundle\Entity\Package">

--- a/src/Resources/config/doctrine/Task.orm.xml
+++ b/src/Resources/config/doctrine/Task.orm.xml
@@ -46,6 +46,11 @@
         <cascade-all/>
       </cascade>
     </one-to-many>
+    <one-to-many field="packages" target-entity="AppBundle\Entity\Task\Package" mapped-by="task">
+      <cascade>
+        <cascade-all/>
+      </cascade>
+    </one-to-many>
     <many-to-one field="delivery" target-entity="AppBundle\Entity\Delivery">
       <join-columns>
         <join-column name="delivery_id" referenced-column-name="id"/>

--- a/src/Serializer/DeliveryNormalizer.php
+++ b/src/Serializer/DeliveryNormalizer.php
@@ -108,6 +108,18 @@ class DeliveryNormalizer implements NormalizerInterface, DenormalizerInterface
         if (isset($data['comments'])) {
             $task->setComments($data['comments']);
         }
+
+        if (isset($data['packages'])) {
+
+            $packageRepository = $this->doctrine->getRepository(Package::class);
+
+            foreach ($data['packages'] as $p) {
+                $package = $packageRepository->findOneByName($p['type']);
+                if ($package) {
+                    $task->addPackageWithQuantity($package, $p['quantity']);
+                }
+            }
+        }
     }
 
     private function denormalizeAddress($data, $format = null)

--- a/src/Serializer/TaskNormalizer.php
+++ b/src/Serializer/TaskNormalizer.php
@@ -6,8 +6,10 @@ use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\Exception\InvalidArgumentException;
 use ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer;
 use AppBundle\Entity\Task;
+use AppBundle\Entity\Package;
 use AppBundle\Service\Geocoder;
 use AppBundle\Service\TagManager;
+use Doctrine\ORM\EntityManagerInterface;
 use Nucleos\UserBundle\Model\UserManagerInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -22,13 +24,15 @@ class TaskNormalizer implements NormalizerInterface, DenormalizerInterface
         IriConverterInterface $iriConverter,
         TagManager $tagManager,
         UserManagerInterface $userManager,
-        Geocoder $geocoder)
+        Geocoder $geocoder,
+        EntityManagerInterface $entityManager)
     {
         $this->normalizer = $normalizer;
         $this->iriConverter = $iriConverter;
         $this->tagManager = $tagManager;
         $this->userManager = $userManager;
         $this->geocoder = $geocoder;
+        $this->entityManager = $entityManager;
     }
 
     public function normalize($object, $format = null, array $context = array())
@@ -155,6 +159,18 @@ class TaskNormalizer implements NormalizerInterface, DenormalizerInterface
 
             $task->setAfter($after);
             $task->setBefore($before);
+        }
+
+        if (isset($data['packages'])) {
+
+            $packageRepository = $this->entityManager->getRepository(Package::class);
+
+            foreach ($data['packages'] as $p) {
+                $package = $packageRepository->findOneByName($p['type']);
+                if ($package) {
+                    $task->addPackageWithQuantity($package, $p['quantity']);
+                }
+            }
         }
 
         return $task;

--- a/templates/form/delivery.html.twig
+++ b/templates/form/delivery.html.twig
@@ -36,6 +36,10 @@ col-md-9
     {{ form_row(form.timeSlot) }}
   {% endif %}
 
+  {% if form.packages is defined %}
+    {{ form_row(form.packages) }}
+  {% endif %}
+
   {{ form_row(form.comments) }}
 
   {% if form.doorstep is defined %}
@@ -83,32 +87,48 @@ col-md-9
   </div>
 {% endblock %}
 
+{% block packages_widget %}
+  <div id="{{ form.vars.id }}" class="delivery__form__packages" data-packages-required="{{ form.vars.attr['data-packages-required'] }}">
+    <div id="{{ form.vars.id }}_list"
+      data-prototype="{{ form_widget(form.vars.prototype)|e }}"
+      data-widget-counter="{{ form.children|length }}"
+      class="delivery__form__packages__list">
+      {% for child in form %}
+        {{ form_widget(child) }}
+      {% endfor %}
+    </div>
+    <div class="text-right">
+      <button type="button" class="btn btn-default" id="{{ form.vars.id }}_add"
+        data-target="#{{ form.vars.id }}_list">{{ 'basics.add'|trans }}</button>
+    </div>
+  </div>
+{% endblock %}
+
 {% block _delivery_packages_widget %}
-<div id="{{ form.vars.id }}" class="delivery__form__packages" data-packages-required="{{ form.vars.attr['data-packages-required'] }}">
-  <div id="{{ form.vars.id }}_list"
-    data-prototype="{{ form_widget(form.vars.prototype)|e }}"
-    data-widget-counter="{{ form.children|length }}"
-    class="delivery__form__packages__list">
-    {% for child in form %}
-      {{ form_widget(child) }}
-    {% endfor %}
+  {{ block('packages_widget') }}
+{% endblock %}
+
+{% block _delivery_tasks_entry_packages_widget %}
+  {{ block('packages_widget') }}
+{% endblock %}
+
+{% block packages_entry_widget %}
+  <div class="delivery__form__packages__list-item" id="{{ form.vars.id }}">
+    {{ form_widget(form.quantity, { attr: { class: 'delivery__form__packages__list-item-quantity' } }) }}
+    <span class="delivery__form__packages__list-item-multiply">×</span>
+    {{ form_widget(form.package, { attr: { class: 'delivery__form__packages__list-item-package' } }) }}
+    <button type="button" class="btn btn-default delivery__form__packages__list-item-delete"
+      data-delete
+      data-target="#{{ form.vars.id }}"><i class="fa fa-trash-o"></i></button>
   </div>
-  <div class="text-right">
-    <button type="button" class="btn btn-default" id="{{ form.vars.id }}_add"
-      data-target="#{{ form.vars.id }}_list">{{ 'basics.add'|trans }}</button>
-  </div>
-</div>
 {% endblock %}
 
 {% block _delivery_packages_entry_widget %}
-<div class="delivery__form__packages__list-item" id="{{ form.vars.id }}">
-  {{ form_widget(form.quantity, { attr: { class: 'delivery__form__packages__list-item-quantity' } }) }}
-  <span class="delivery__form__packages__list-item-multiply">×</span>
-  {{ form_widget(form.package, { attr: { class: 'delivery__form__packages__list-item-package' } }) }}
-  <button type="button" class="btn btn-default delivery__form__packages__list-item-delete"
-    data-delete
-    data-target="#{{ form.vars.id }}"><i class="fa fa-trash-o"></i></button>
-</div>
+  {{ block('packages_entry_widget') }}
+{% endblock %}
+
+{% block _delivery_tasks_entry_packages_entry_widget %}
+  {{ block('packages_entry_widget') }}
 {% endblock %}
 
 {% block _delivery_tasks_entry_row %}

--- a/templates/form/delivery_embed.html.twig
+++ b/templates/form/delivery_embed.html.twig
@@ -23,10 +23,6 @@
     {{ form_row(form.parent.parent.weight) }}
   {% endif %}
 
-  {% if form.vars.data.type == 'PICKUP' and form.parent.parent.packages is defined %}
-    {{ form_row(form.parent.parent.packages) }}
-  {% endif %}
-
   {{ form_row(form.address.newAddress.description) }}
 
   {{ form_widget(form.type) }}

--- a/templates/form/delivery_embed.html.twig
+++ b/templates/form/delivery_embed.html.twig
@@ -15,6 +15,10 @@
     {{ form_row(form.timeSlot) }}
   {% endif %}
 
+  {% if form.packages is defined %}
+    {{ form_row(form.packages) }}
+  {% endif %}
+
   {% if form.vars.data.type == 'PICKUP' and form.parent.parent.weight is defined %}
     {{ form_row(form.parent.parent.weight) }}
   {% endif %}

--- a/tests/AppBundle/Entity/DeliveryTest.php
+++ b/tests/AppBundle/Entity/DeliveryTest.php
@@ -308,4 +308,41 @@ class DeliveryTest extends TestCase
         $this->assertCount(1, $packages);
         $this->assertEquals(2, $delivery->getQuantityForPackage($smallPackage));
     }
+
+    public function testGetPackagesWithMultipleDropoffs()
+    {
+        // Atm, this test can't pass, because we would need to return
+        // an array of Task\Package objects,
+        // which are expecting a reference to a Task object
+        // A possible solution, would be to change the implementation
+        // of the getPackages() method, so that it returns a SplObjectStorage
+        $this->markTestSkipped();
+
+        $delivery = new Delivery();
+
+        $otherDrop = new Task();
+        $otherDrop->setType(Task::TYPE_DROPOFF);
+
+        $delivery->addTask($otherDrop);
+
+        $smallPackage = new Package();
+        $smallPackage->setName('S');
+
+        $i = 0;
+        foreach ($delivery->getTasks() as $task) {
+            if ($task->isDropoff()) {
+                if (0 === $i) {
+                    $task->addPackageWithQuantity($smallPackage, 2);
+                    $this->assertCount(1, $delivery->getPackages());
+                    $this->assertEquals(2, $delivery->getQuantityForPackage($smallPackage));
+                }
+                if (1 === $i) {
+                    $task->addPackageWithQuantity($smallPackage, 1);
+                    $this->assertCount(1, $delivery->getPackages());
+                    $this->assertEquals(3, $delivery->getQuantityForPackage($smallPackage));
+                }
+                $i++;
+            }
+        }
+    }
 }

--- a/tests/AppBundle/Entity/DeliveryTest.php
+++ b/tests/AppBundle/Entity/DeliveryTest.php
@@ -311,13 +311,6 @@ class DeliveryTest extends TestCase
 
     public function testGetPackagesWithMultipleDropoffs()
     {
-        // Atm, this test can't pass, because we would need to return
-        // an array of Task\Package objects,
-        // which are expecting a reference to a Task object
-        // A possible solution, would be to change the implementation
-        // of the getPackages() method, so that it returns a SplObjectStorage
-        $this->markTestSkipped();
-
         $delivery = new Delivery();
 
         $otherDrop = new Task();

--- a/tests/AppBundle/Entity/TaskTest.php
+++ b/tests/AppBundle/Entity/TaskTest.php
@@ -5,6 +5,7 @@ namespace Tests\AppBundle\Entity;
 use AppBundle\Entity\Base\GeoCoordinates;
 use AppBundle\Entity\Address;
 use AppBundle\Entity\Delivery;
+use AppBundle\Entity\Package;
 use AppBundle\Entity\Task;
 use AppBundle\Entity\User;
 use AppBundle\Entity\TaskEvent;
@@ -239,5 +240,25 @@ class TaskTest extends TestCase
 
         $violations = $validator->validate($task);
         $this->assertCount(0, $violations);
+    }
+
+    public function testAddPackageWithQuantity()
+    {
+        $smallPackage = new Package();
+        $smallPackage->setName('S');
+
+        $mediumPackage = new Package();
+        $mediumPackage->setName('M');
+
+        $task = new Task();
+
+        $task->addPackageWithQuantity($smallPackage, 1);
+        $this->assertEquals(1, $task->getQuantityForPackage($smallPackage));
+
+        $task->addPackageWithQuantity($smallPackage, 1);
+        $this->assertEquals(2, $task->getQuantityForPackage($smallPackage));
+
+        $task->addPackageWithQuantity($mediumPackage, 0);
+        $this->assertEquals(0, $task->getQuantityForPackage($mediumPackage));
     }
 }


### PR DESCRIPTION
Now packages will be attached to **dropoff** tasks, instead of delivery. 

**TODO**

- [x] Make it work when adding multiple dropoffs (has error "This form should not contain extra fields.")
- [x] The `Delivery::getPackages()` method should compute an aggregated collection of packages when there are multiple dropoffs. For ex, if a delivery contains 3 tasks, and 2 of them have 1 package of type "XL", `Delivery::getPackages()` should return 2 XL packages. 

---

The `Delivery` class still exposes the same interface, but the implementation will now attach packages to the first dropoff task. 

```php
// Both are equivalent
$delivery->addPackageWithQuantity($small, 1);
$delivery->getDropoff()->addPackageWithQuantity($small, 1);
```

Same for the API, clients can still send `packages` at the delivery level, but they will be attached to the first dropoff task. 

```
POST /api/deliveries
{
  "packages": [
    {"type": "XL", "quantity": 2}
  ]
}
```

```
POST /api/deliveries
{
  "dropoff": {
    "packages": [
      {"type": "XL", "quantity": 2}
    }
  ]
}
```

--- 

![task_package](https://user-images.githubusercontent.com/1162230/146259885-5e338e34-c1eb-4762-84be-40b2d5164e8d.gif)
