### PR TITLE
Allow Guzzle 7 & PHP 8

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -545,11 +545,9 @@ services:
     tags: [ 'api_platform.filter' ]
 
   AppBundle\Api\Filter\TaskFilter:
-    arguments: [ '@doctrine', '@request_stack', '@?logger', { tokenStorage: '@security.token_storage' } ]
     tags: [ 'api_platform.filter' ]
 
   AppBundle\Api\Filter\AssignedFilter:
-    arguments: [ '@doctrine', '@request_stack', '@?logger', { tokenStorage: '@security.token_storage' } ]
     tags: [ 'api_platform.filter' ]
 
   AppBundle\Api\Filter\DeliveryOrderFilter:

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "stripe/stripe-php": "^7.7",
         "vich/uploader-bundle": "^1.13",
         "doctrine/doctrine-migrations-bundle": "^3.0",
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "^7.0",
         "myclabs/php-enum": "^1.8",
         "beberlei/doctrineextensions": "^1.0",
         "sentry/sentry-symfony": "^4.0",
@@ -64,7 +64,6 @@
         "sylius/taxonomy-bundle": "^1.7.5",
         "sonata-project/seo-bundle": "^3.0",
         "sylius/currency-bundle": "^1.7.5",
-        "php-http/guzzle6-adapter": "^2.0",
         "php-http/message": "^1.6",
         "geo6/geocoder-php-addok-provider": "^1.0",
         "geocoder-php/chain-provider": "^4.0",
@@ -100,7 +99,7 @@
         "edamov/pushok": "^0.13",
         "twig/intl-extra": "^3.0",
         "odolbeau/phone-number-bundle": "^3.1",
-        "league/omnipay": "^3",
+        "league/omnipay": "^3.2.1",
         "mercadopago/dx-php": "^2.4.1",
         "egulias/email-validator": "^3.0",
         "twilio/sdk": "^6.10",
@@ -124,7 +123,8 @@
         "symfony/doctrine-messenger": "^5.3",
         "azimolabs/apple-sign-in-php-sdk": "^2.0",
         "google/apiclient": "^2.11",
-        "theofidry/alice-data-fixtures": "1.4.0"
+        "theofidry/alice-data-fixtures": "1.4.0",
+        "php-http/guzzle7-adapter": "^1.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65e88dbc1c80f486c0277731c90a045b",
+    "content-hash": "3b3005335f07c77d9ea893dc4306086d",
     "packages": [
         {
             "name": "api-platform/core",
@@ -219,16 +219,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.209.8",
+            "version": "3.209.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "da83dc5bae8f67a80e53423ad8dac2c0f48b3220"
+                "reference": "9f9591bff3dc0b2bc5400eb81e2e22228f2e4c95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/da83dc5bae8f67a80e53423ad8dac2c0f48b3220",
-                "reference": "da83dc5bae8f67a80e53423ad8dac2c0f48b3220",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/9f9591bff3dc0b2bc5400eb81e2e22228f2e4c95",
+                "reference": "9f9591bff3dc0b2bc5400eb81e2e22228f2e4c95",
                 "shasum": ""
             },
             "require": {
@@ -304,9 +304,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.209.8"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.209.11"
             },
-            "time": "2022-01-19T19:18:46+00:00"
+            "time": "2022-01-24T19:15:49+00:00"
         },
         {
             "name": "azimolabs/apple-sign-in-php-sdk",
@@ -1209,44 +1209,49 @@
         },
         {
             "name": "craue/config-bundle",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/craue/CraueConfigBundle.git",
-                "reference": "d350e161c86fc813cd5f09e4ff00508a3d4c0b92"
+                "reference": "3c6e8d7cfe28376522ce92b6da5548f1a4d4baf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/craue/CraueConfigBundle/zipball/d350e161c86fc813cd5f09e4ff00508a3d4c0b92",
-                "reference": "d350e161c86fc813cd5f09e4ff00508a3d4c0b92",
+                "url": "https://api.github.com/repos/craue/CraueConfigBundle/zipball/3c6e8d7cfe28376522ce92b6da5548f1a4d4baf1",
+                "reference": "3c6e8d7cfe28376522ce92b6da5548f1a4d4baf1",
                 "shasum": ""
             },
             "require": {
-                "doctrine/doctrine-bundle": "^1.5.1|~2.0",
+                "doctrine/doctrine-bundle": "^1.6.12|^2",
                 "php": "^7.3|^8",
-                "psr/simple-cache": "^1.0",
-                "symfony/cache": "~3.4|~4.4|~5.1",
-                "symfony/config": "~3.4|~4.4|~5.1",
-                "symfony/dependency-injection": "~3.4|~4.4|~5.1",
-                "symfony/form": "~3.4|~4.4|~5.1",
-                "symfony/framework-bundle": "~3.4|~4.4|~5.1",
-                "symfony/http-foundation": "~3.4|~4.4|~5.1",
-                "symfony/http-kernel": "~3.4|~4.4|~5.1",
-                "symfony/options-resolver": "~3.4|~4.4|~5.1",
-                "symfony/validator": "~3.4|~4.4|~5.1"
+                "psr/simple-cache": "^1|^2|^3",
+                "symfony/cache": "~4.4|~5.3|^6",
+                "symfony/config": "~4.4|~5.3|^6",
+                "symfony/dependency-injection": "~4.4|~5.3|^6",
+                "symfony/form": "~4.4|~5.3|^6",
+                "symfony/framework-bundle": "~4.4|~5.3|^6",
+                "symfony/http-foundation": "~4.4|~5.3|^6",
+                "symfony/http-kernel": "~4.4|~5.3|^6",
+                "symfony/options-resolver": "~4.4|~5.3|^6",
+                "symfony/validator": "~4.4|~5.3|^6"
             },
             "require-dev": {
                 "craue/translations-tests": "^1.0",
-                "doctrine/instantiator": "^1.0.5",
                 "doctrine/orm": "^2.5.14",
-                "phpunit/phpunit": "^9.4",
-                "symfony/phpunit-bridge": "~5.2",
-                "symfony/symfony": "~3.4.23|~4.4|~5.1"
+                "phpunit/phpunit": "^9.5",
+                "symfony/asset": "~4.4|~5.3|^6",
+                "symfony/browser-kit": "~4.4|~5.3|^6",
+                "symfony/phpunit-bridge": "^6",
+                "symfony/twig-bundle": "~4.4|~5.3|^6",
+                "symfony/web-profiler-bundle": "~4.4|~5.3|^6"
             },
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5.x-dev"
+                    "dev-master": "2.6.x-dev"
+                },
+                "symfony": {
+                    "require": "~4.4|~5.3|^6"
                 }
             },
             "autoload": {
@@ -1279,9 +1284,9 @@
             ],
             "support": {
                 "issues": "https://github.com/craue/CraueConfigBundle/issues",
-                "source": "https://github.com/craue/CraueConfigBundle/tree/2.5.0"
+                "source": "https://github.com/craue/CraueConfigBundle/tree/2.6.0"
             },
-            "time": "2020-12-17T09:04:32+00:00"
+            "time": "2022-01-24T15:04:40+00:00"
         },
         {
             "name": "defuse/php-encryption",
@@ -1681,16 +1686,16 @@
         },
         {
             "name": "doctrine/data-fixtures",
-            "version": "1.5.1",
+            "version": "1.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/data-fixtures.git",
-                "reference": "f18adf13f6c81c67a88360dca359ad474523f8e3"
+                "reference": "51c1890e8c5467c421c7cab4579f059ebf720278"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/f18adf13f6c81c67a88360dca359ad474523f8e3",
-                "reference": "f18adf13f6c81c67a88360dca359ad474523f8e3",
+                "url": "https://api.github.com/repos/doctrine/data-fixtures/zipball/51c1890e8c5467c421c7cab4579f059ebf720278",
+                "reference": "51c1890e8c5467c421c7cab4579f059ebf720278",
                 "shasum": ""
             },
             "require": {
@@ -1699,15 +1704,20 @@
                 "php": "^7.2 || ^8.0"
             },
             "conflict": {
+                "doctrine/dbal": "<2.13",
                 "doctrine/phpcr-odm": "<1.3.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^9.0",
-                "doctrine/dbal": "^2.5.4 || ^3.0",
+                "doctrine/dbal": "^2.13 || ^3.0",
                 "doctrine/mongodb-odm": "^1.3.0 || ^2.0.0",
                 "doctrine/orm": "^2.7.0",
                 "ext-sqlite3": "*",
-                "phpunit/phpunit": "^8.0"
+                "jangregor/phpstan-prophecy": "^0.8.1",
+                "phpstan/phpstan": "^0.12.99",
+                "phpunit/phpunit": "^8.0",
+                "symfony/cache": "^5.0 || ^6.0",
+                "vimeo/psalm": "^4.10"
             },
             "suggest": {
                 "alcaeus/mongo-php-adapter": "For using MongoDB ODM 1.3 with PHP 7 (deprecated)",
@@ -1732,13 +1742,13 @@
                 }
             ],
             "description": "Data Fixtures for all Doctrine Object Managers",
-            "homepage": "http://www.doctrine-project.org",
+            "homepage": "https://www.doctrine-project.org",
             "keywords": [
                 "database"
             ],
             "support": {
                 "issues": "https://github.com/doctrine/data-fixtures/issues",
-                "source": "https://github.com/doctrine/data-fixtures/tree/1.5.1"
+                "source": "https://github.com/doctrine/data-fixtures/tree/1.5.2"
             },
             "funding": [
                 {
@@ -1754,7 +1764,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-20T21:51:43+00:00"
+            "time": "2022-01-20T17:10:56+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -3010,16 +3020,16 @@
         },
         {
             "name": "fakerphp/faker",
-            "version": "v1.17.0",
+            "version": "v1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FakerPHP/Faker.git",
-                "reference": "b85e9d44eae8c52cca7aa0939483611f7232b669"
+                "reference": "2e77a868f6540695cf5ebf21e5ab472c65f47567"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/b85e9d44eae8c52cca7aa0939483611f7232b669",
-                "reference": "b85e9d44eae8c52cca7aa0939483611f7232b669",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/2e77a868f6540695cf5ebf21e5ab472c65f47567",
+                "reference": "2e77a868f6540695cf5ebf21e5ab472c65f47567",
                 "shasum": ""
             },
             "require": {
@@ -3044,7 +3054,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "v1.17-dev"
+                    "dev-main": "v1.18-dev"
                 }
             },
             "autoload": {
@@ -3069,9 +3079,9 @@
             ],
             "support": {
                 "issues": "https://github.com/FakerPHP/Faker/issues",
-                "source": "https://github.com/FakerPHP/Faker/tree/v1.17.0"
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.18.0"
             },
-            "time": "2021-12-05T17:14:47+00:00"
+            "time": "2022-01-23T17:56:23+00:00"
         },
         {
             "name": "fgrosse/phpasn1",
@@ -4348,7 +4358,7 @@
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.230.0",
+            "version": "v0.231.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
@@ -4386,7 +4396,7 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.230.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.231.0"
             },
             "time": "2021-12-21T12:26:12+00:00"
         },
@@ -4612,37 +4622,45 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.5",
+            "version": "7.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e"
+                "reference": "ee0a041b1760e6a53d2a39c8c34115adc2af2c79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
-                "reference": "9d4290de1cfd701f38099ef7e183b64b4b7b0c5e",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ee0a041b1760e6a53d2a39c8c34115adc2af2c79",
+                "reference": "ee0a041b1760e6a53d2a39c8c34115adc2af2c79",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^1.0",
-                "guzzlehttp/psr7": "^1.6.1",
-                "php": ">=5.5",
-                "symfony/polyfill-intl-idn": "^1.17.0"
+                "guzzlehttp/promises": "^1.5",
+                "guzzlehttp/psr7": "^1.8.3 || ^2.1",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
-                "psr/log": "^1.1"
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5-dev"
+                    "dev-master": "7.4-dev"
                 }
             },
             "autoload": {
@@ -4659,27 +4677,72 @@
             ],
             "authors": [
                 {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
                     "name": "Michael Dowling",
                     "email": "mtdowling@gmail.com",
                     "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Jeremy Lindblom",
+                    "email": "jeremeamia@gmail.com",
+                    "homepage": "https://github.com/jeremeamia"
+                },
+                {
+                    "name": "George Mponos",
+                    "email": "gmponos@gmail.com",
+                    "homepage": "https://github.com/gmponos"
+                },
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com",
+                    "homepage": "https://github.com/Nyholm"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://github.com/sagikazarmark"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "email": "webmaster@tubo-world.de",
+                    "homepage": "https://github.com/Tobion"
                 }
             ],
             "description": "Guzzle is a PHP HTTP client library",
-            "homepage": "http://guzzlephp.org/",
             "keywords": [
                 "client",
                 "curl",
                 "framework",
                 "http",
                 "http client",
+                "psr-18",
+                "psr-7",
                 "rest",
                 "web service"
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/6.5"
+                "source": "https://github.com/guzzle/guzzle/tree/7.4.1"
             },
-            "time": "2020-06-16T21:01:06+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/guzzlehttp/guzzle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-12-06T18:43:05+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -4767,29 +4830,32 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.8.3",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85"
+                "reference": "089edd38f5b8abba6cb01567c2a8aaa47cec4c72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
-                "reference": "1afdd860a2566ed3c2b0b4a3de6e23434a79ec85",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/089edd38f5b8abba6cb01567c2a8aaa47cec4c72",
+                "reference": "089edd38f5b8abba6cb01567c2a8aaa47cec4c72",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0",
-                "psr/http-message": "~1.0",
-                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0",
+                "ralouphie/getallheaders": "^3.0"
             },
             "provide": {
+                "psr/http-factory-implementation": "1.0",
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
-                "ext-zlib": "*",
-                "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.8 || ^9.3.10"
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "http-interop/http-factory-tests": "^0.9",
+                "phpunit/phpunit": "^8.5.8 || ^9.3.10"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -4797,16 +4863,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "GuzzleHttp\\Psr7\\": "src/"
-                },
-                "files": [
-                    "src/functions_include.php"
-                ]
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -4842,6 +4905,11 @@
                     "name": "Tobias Schultze",
                     "email": "webmaster@tubo-world.de",
                     "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
                 }
             ],
             "description": "PSR-7 message implementation that also provides common utility methods",
@@ -4857,7 +4925,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/1.8.3"
+                "source": "https://github.com/guzzle/psr7/tree/2.1.0"
             },
             "funding": [
                 {
@@ -4873,7 +4941,58 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-05T13:56:00+00:00"
+            "time": "2021-10-06T17:43:30+00:00"
+        },
+        {
+            "name": "hamcrest/hamcrest-php",
+            "version": "v2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/hamcrest/hamcrest-php.git",
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3|^7.0|^8.0"
+            },
+            "replace": {
+                "cordoval/hamcrest-php": "*",
+                "davedevelopment/hamcrest-php": "*",
+                "kodova/hamcrest-php": "*"
+            },
+            "require-dev": {
+                "phpunit/php-file-iterator": "^1.4 || ^2.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "hamcrest"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "This is the PHP port of Hamcrest Matchers",
+            "keywords": [
+                "test"
+            ],
+            "support": {
+                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
+                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+            },
+            "time": "2020-07-09T08:09:16+00:00"
         },
         {
             "name": "hashids/hashids",
@@ -5792,16 +5911,16 @@
         },
         {
             "name": "jmikola/geojson",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jmikola/geojson.git",
-                "reference": "6ec3016cc0215667b7775f6ead7bd0337ad66eee"
+                "reference": "f5b122e15c804fabc5881da214c57d52ea0c5715"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jmikola/geojson/zipball/6ec3016cc0215667b7775f6ead7bd0337ad66eee",
-                "reference": "6ec3016cc0215667b7775f6ead7bd0337ad66eee",
+                "url": "https://api.github.com/repos/jmikola/geojson/zipball/f5b122e15c804fabc5881da214c57d52ea0c5715",
+                "reference": "f5b122e15c804fabc5881da214c57d52ea0c5715",
                 "shasum": ""
             },
             "require": {
@@ -5843,9 +5962,9 @@
             ],
             "support": {
                 "issues": "https://github.com/jmikola/geojson/issues",
-                "source": "https://github.com/jmikola/geojson/tree/master"
+                "source": "https://github.com/jmikola/geojson/tree/1.0.3"
             },
-            "time": "2015-09-27T15:35:21+00:00"
+            "time": "2022-01-21T04:20:33+00:00"
         },
         {
             "name": "jms/metadata",
@@ -6815,16 +6934,16 @@
         },
         {
             "name": "laminas/laminas-stdlib",
-            "version": "3.7.0",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-stdlib.git",
-                "reference": "cba75fad2053bb5dc8d3e7f5e62b61d75eecfaf1"
+                "reference": "bcd869e2fe88d567800057c1434f2380354fe325"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/cba75fad2053bb5dc8d3e7f5e62b61d75eecfaf1",
-                "reference": "cba75fad2053bb5dc8d3e7f5e62b61d75eecfaf1",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/bcd869e2fe88d567800057c1434f2380354fe325",
+                "reference": "bcd869e2fe88d567800057c1434f2380354fe325",
                 "shasum": ""
             },
             "require": {
@@ -6870,7 +6989,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-01-10T11:18:55+00:00"
+            "time": "2022-01-21T15:50:46+00:00"
         },
         {
             "name": "laravolt/avatar",
@@ -7602,30 +7721,31 @@
         },
         {
             "name": "league/omnipay",
-            "version": "v3.0.2",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/omnipay.git",
-                "reference": "9e10d91cbf84744207e13d4483e79de39b133368"
+                "reference": "38f66a0cc043ed51d6edf7956d6439a2f263501f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/omnipay/zipball/9e10d91cbf84744207e13d4483e79de39b133368",
-                "reference": "9e10d91cbf84744207e13d4483e79de39b133368",
+                "url": "https://api.github.com/repos/thephpleague/omnipay/zipball/38f66a0cc043ed51d6edf7956d6439a2f263501f",
+                "reference": "38f66a0cc043ed51d6edf7956d6439a2f263501f",
                 "shasum": ""
             },
             "require": {
-                "omnipay/common": "^3",
-                "php": "^5.6|^7",
-                "php-http/guzzle6-adapter": "^1.1|^2"
+                "omnipay/common": "^3.1",
+                "php": "^7.2|^8.0",
+                "php-http/discovery": "^1.14",
+                "php-http/guzzle7-adapter": "^1"
             },
             "require-dev": {
-                "omnipay/tests": "^3"
+                "omnipay/tests": "^3|^4"
             },
             "type": "metapackage",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -7652,9 +7772,15 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/omnipay/issues",
-                "source": "https://github.com/thephpleague/omnipay/tree/v3.0.2"
+                "source": "https://github.com/thephpleague/omnipay/tree/v3.2.1"
             },
-            "time": "2019-03-20T14:28:28+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-06-05T11:34:12+00:00"
         },
         {
             "name": "lexik/jwt-authentication-bundle",
@@ -7935,25 +8061,28 @@
         },
         {
             "name": "mailjet/mailjet-apiv3-php",
-            "version": "v1.5.1",
+            "version": "v1.5.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mailjet/mailjet-apiv3-php.git",
-                "reference": "7b94fa629d46fa5ba3826ed4596674942944520d"
+                "reference": "c1c1931c76ebd1adb5cf2a76f60ddcaa61849aa2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mailjet/mailjet-apiv3-php/zipball/7b94fa629d46fa5ba3826ed4596674942944520d",
-                "reference": "7b94fa629d46fa5ba3826ed4596674942944520d",
+                "url": "https://api.github.com/repos/mailjet/mailjet-apiv3-php/zipball/c1c1931c76ebd1adb5cf2a76f60ddcaa61849aa2",
+                "reference": "c1c1931c76ebd1adb5cf2a76f60ddcaa61849aa2",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "~7.0|~6.0|~5.3",
-                "php": ">=5.4.0"
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "~7.0",
+                "mockery/mockery": "^1.4",
+                "php": "^7.2|^8.0",
+                "psr/http-client": "^1.0"
             },
             "require-dev": {
-                "php-coveralls/php-coveralls": "^1.0",
-                "phpunit/phpunit": "^4.8.36|^5.7"
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpunit/phpunit": "^8|^9"
             },
             "type": "library",
             "autoload": {
@@ -7983,9 +8112,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mailjet/mailjet-apiv3-php/issues",
-                "source": "https://github.com/mailjet/mailjet-apiv3-php/tree/v1.5.1"
+                "source": "https://github.com/mailjet/mailjet-apiv3-php/tree/v1.5.5"
             },
-            "time": "2020-12-21T16:30:15+00:00"
+            "time": "2021-09-15T07:26:13+00:00"
         },
         {
             "name": "martin-georgiev/postgresql-for-doctrine",
@@ -8066,16 +8195,16 @@
         },
         {
             "name": "mercadopago/dx-php",
-            "version": "2.4.4",
+            "version": "2.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mercadopago/sdk-php.git",
-                "reference": "678f1e059309c5340f928df909e6b747caed2116"
+                "reference": "f10f278386baf7bf055681c67a95eeafc217d180"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mercadopago/sdk-php/zipball/678f1e059309c5340f928df909e6b747caed2116",
-                "reference": "678f1e059309c5340f928df909e6b747caed2116",
+                "url": "https://api.github.com/repos/mercadopago/sdk-php/zipball/f10f278386baf7bf055681c67a95eeafc217d180",
+                "reference": "f10f278386baf7bf055681c67a95eeafc217d180",
                 "shasum": ""
             },
             "require": {
@@ -8112,9 +8241,9 @@
             "description": "Mercado Pago PHP SDK",
             "homepage": "https://github.com/mercadopago/sdk-php",
             "support": {
-                "source": "https://github.com/mercadopago/sdk-php/tree/2.4.4"
+                "source": "https://github.com/mercadopago/sdk-php/tree/2.4.5"
             },
-            "time": "2021-10-20T18:08:36+00:00"
+            "time": "2022-01-24T18:22:34+00:00"
         },
         {
             "name": "michelf/php-markdown",
@@ -8168,6 +8297,78 @@
                 "source": "https://github.com/michelf/php-markdown/tree/1.9.1"
             },
             "time": "2021-11-24T02:52:38+00:00"
+        },
+        {
+            "name": "mockery/mockery",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mockery/mockery.git",
+                "reference": "c10a5f6e06fc2470ab1822fa13fa2a7380f8fbac"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/c10a5f6e06fc2470ab1822fa13fa2a7380f8fbac",
+                "reference": "c10a5f6e06fc2470ab1822fa13fa2a7380f8fbac",
+                "shasum": ""
+            },
+            "require": {
+                "hamcrest/hamcrest-php": "^2.0.1",
+                "lib-pcre": ">=7.0",
+                "php": "^7.3 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5 || ^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mockery": "library/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Pádraic Brady",
+                    "email": "padraic.brady@gmail.com",
+                    "homepage": "http://blog.astrumfutura.com"
+                },
+                {
+                    "name": "Dave Marshall",
+                    "email": "dave.marshall@atstsolutions.co.uk",
+                    "homepage": "http://davedevelopment.co.uk"
+                }
+            ],
+            "description": "Mockery is a simple yet flexible PHP mock object framework",
+            "homepage": "https://github.com/mockery/mockery",
+            "keywords": [
+                "BDD",
+                "TDD",
+                "library",
+                "mock",
+                "mock objects",
+                "mockery",
+                "stub",
+                "test",
+                "test double",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/mockery/mockery/issues",
+                "source": "https://github.com/mockery/mockery/tree/1.5.0"
+            },
+            "time": "2022-01-20T13:18:17+00:00"
         },
         {
             "name": "moneyphp/money",
@@ -8753,16 +8954,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "2.55.2",
+            "version": "2.56.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/briannesbitt/Carbon.git",
-                "reference": "8c2a18ce3e67c34efc1b29f64fe61304368259a2"
+                "reference": "626ec8cbb724cd3c3400c3ed8f730545b744e3f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/8c2a18ce3e67c34efc1b29f64fe61304368259a2",
-                "reference": "8c2a18ce3e67c34efc1b29f64fe61304368259a2",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/626ec8cbb724cd3c3400c3ed8f730545b744e3f4",
+                "reference": "626ec8cbb724cd3c3400c3ed8f730545b744e3f4",
                 "shasum": ""
             },
             "require": {
@@ -8779,7 +8980,7 @@
                 "kylekatarnls/multi-tester": "^2.0",
                 "phpmd/phpmd": "^2.9",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^0.12.54",
+                "phpstan/phpstan": "^0.12.54 || ^1.0",
                 "phpunit/phpunit": "^7.5.20 || ^8.5.14",
                 "squizlabs/php_codesniffer": "^3.4"
             },
@@ -8845,7 +9046,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-12-03T14:59:52+00:00"
+            "time": "2022-01-21T17:08:38+00:00"
         },
         {
             "name": "notfloran/mjml-bundle",
@@ -9917,22 +10118,22 @@
             "time": "2021-09-18T07:57:46+00:00"
         },
         {
-            "name": "php-http/guzzle6-adapter",
-            "version": "v2.0.2",
+            "name": "php-http/guzzle7-adapter",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-http/guzzle6-adapter.git",
-                "reference": "9d1a45eb1c59f12574552e81fb295e9e53430a56"
+                "url": "https://github.com/php-http/guzzle7-adapter.git",
+                "reference": "fb075a71dbfa4847cf0c2938c4e5a9c478ef8b01"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/guzzle6-adapter/zipball/9d1a45eb1c59f12574552e81fb295e9e53430a56",
-                "reference": "9d1a45eb1c59f12574552e81fb295e9e53430a56",
+                "url": "https://api.github.com/repos/php-http/guzzle7-adapter/zipball/fb075a71dbfa4847cf0c2938c4e5a9c478ef8b01",
+                "reference": "fb075a71dbfa4847cf0c2938c4e5a9c478ef8b01",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": "^6.0",
-                "php": "^7.1 || ^8.0",
+                "guzzlehttp/guzzle": "^7.0",
+                "php": "^7.2 | ^8.0",
                 "php-http/httplug": "^2.0",
                 "psr/http-client": "^1.0"
             },
@@ -9942,19 +10143,18 @@
                 "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
-                "ext-curl": "*",
-                "php-http/client-integration-tests": "^2.0 || ^3.0",
-                "phpunit/phpunit": "^7.4 || ^8.4"
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.0|^9.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "0.2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Http\\Adapter\\Guzzle6\\": "src/"
+                    "Http\\Adapter\\Guzzle7\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -9963,25 +10163,21 @@
             ],
             "authors": [
                 {
-                    "name": "David de Boer",
-                    "email": "david@ddeboer.nl"
-                },
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com"
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
                 }
             ],
-            "description": "Guzzle 6 HTTP Adapter",
+            "description": "Guzzle 7 HTTP Adapter",
             "homepage": "http://httplug.io",
             "keywords": [
                 "Guzzle",
                 "http"
             ],
             "support": {
-                "issues": "https://github.com/php-http/guzzle6-adapter/issues",
-                "source": "https://github.com/php-http/guzzle6-adapter/tree/v2.0.2"
+                "issues": "https://github.com/php-http/guzzle7-adapter/issues",
+                "source": "https://github.com/php-http/guzzle7-adapter/tree/1.0.0"
             },
-            "time": "2021-03-02T10:52:33+00:00"
+            "time": "2021-03-09T07:35:15+00:00"
         },
         {
             "name": "php-http/httplug",
@@ -13654,16 +13850,16 @@
         },
         {
             "name": "stripe/stripe-php",
-            "version": "v7.110.0",
+            "version": "v7.111.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stripe/stripe-php.git",
-                "reference": "a463289e4f025b49378b9ebec6457d149036c0c7"
+                "reference": "374647b1079203ed7278ad4b58afc0fae3faaab9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/a463289e4f025b49378b9ebec6457d149036c0c7",
-                "reference": "a463289e4f025b49378b9ebec6457d149036c0c7",
+                "url": "https://api.github.com/repos/stripe/stripe-php/zipball/374647b1079203ed7278ad4b58afc0fae3faaab9",
+                "reference": "374647b1079203ed7278ad4b58afc0fae3faaab9",
                 "shasum": ""
             },
             "require": {
@@ -13673,7 +13869,7 @@
                 "php": ">=5.6.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "3.4.0",
+                "friendsofphp/php-cs-fixer": "3.5.0",
                 "phpstan/phpstan": "^1.2",
                 "phpunit/phpunit": "^5.7 || ^9.0",
                 "squizlabs/php_codesniffer": "^3.3"
@@ -13708,9 +13904,9 @@
             ],
             "support": {
                 "issues": "https://github.com/stripe/stripe-php/issues",
-                "source": "https://github.com/stripe/stripe-php/tree/v7.110.0"
+                "source": "https://github.com/stripe/stripe-php/tree/v7.111.0"
             },
-            "time": "2022-01-13T15:28:18+00:00"
+            "time": "2022-01-20T17:30:55+00:00"
         },
         {
             "name": "sylius-labs/polyfill-symfony-framework-bundle",
@@ -18118,16 +18314,16 @@
         },
         {
             "name": "voku/portable-ascii",
-            "version": "1.5.6",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "80953678b19901e5165c56752d087fc11526017c"
+                "reference": "87337c91b9dfacee02452244ee14ab3c43bc485a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/80953678b19901e5165c56752d087fc11526017c",
-                "reference": "80953678b19901e5165c56752d087fc11526017c",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/87337c91b9dfacee02452244ee14ab3c43bc485a",
+                "reference": "87337c91b9dfacee02452244ee14ab3c43bc485a",
                 "shasum": ""
             },
             "require": {
@@ -18164,7 +18360,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/1.5.6"
+                "source": "https://github.com/voku/portable-ascii/tree/1.6.1"
             },
             "funding": [
                 {
@@ -18188,7 +18384,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-12T00:07:28+00:00"
+            "time": "2022-01-24T18:55:24+00:00"
         },
         {
             "name": "web-token/jwt-core",
@@ -20021,16 +20217,16 @@
         },
         {
             "name": "phpstan/phpstan-doctrine",
-            "version": "1.1.1",
+            "version": "1.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-doctrine.git",
-                "reference": "830789b82e7e0fadbeca9ad55e7fb62c43fb69d1"
+                "reference": "7c11cd7125e033e9576f7cfa52bb57c16f44e03a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/830789b82e7e0fadbeca9ad55e7fb62c43fb69d1",
-                "reference": "830789b82e7e0fadbeca9ad55e7fb62c43fb69d1",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/7c11cd7125e033e9576f7cfa52bb57c16f44e03a",
+                "reference": "7c11cd7125e033e9576f7cfa52bb57c16f44e03a",
                 "shasum": ""
             },
             "require": {
@@ -20048,11 +20244,11 @@
                 "doctrine/annotations": "^1.11.0",
                 "doctrine/collections": "^1.6",
                 "doctrine/common": "^2.7 || ^3.0",
-                "doctrine/dbal": "^2.13.7",
+                "doctrine/dbal": "^2.13.7 || ^3.0",
                 "doctrine/lexer": "^1.2.1",
                 "doctrine/mongodb-odm": "^1.3 || ^2.1",
                 "doctrine/orm": "^2.11.0",
-                "doctrine/persistence": "^1.1 || ^2.0",
+                "doctrine/persistence": "^1.3.8 || ^2.2.1",
                 "nesbot/carbon": "^2.49",
                 "nikic/php-parser": "^4.13.2",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -20065,7 +20261,7 @@
             "type": "phpstan-extension",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-master": "1.2-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -20086,9 +20282,9 @@
             "description": "Doctrine extensions for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
-                "source": "https://github.com/phpstan/phpstan-doctrine/tree/1.1.1"
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/1.2.6"
             },
-            "time": "2022-01-19T07:18:34+00:00"
+            "time": "2022-01-24T14:52:58+00:00"
         },
         {
             "name": "phpstan/phpstan-symfony",
@@ -20535,16 +20731,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.11",
+            "version": "9.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2406855036db1102126125537adb1406f7242fdd"
+                "reference": "597cb647654ede35e43b137926dfdfef0fb11743"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2406855036db1102126125537adb1406f7242fdd",
-                "reference": "2406855036db1102126125537adb1406f7242fdd",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/597cb647654ede35e43b137926dfdfef0fb11743",
+                "reference": "597cb647654ede35e43b137926dfdfef0fb11743",
                 "shasum": ""
             },
             "require": {
@@ -20622,7 +20818,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.11"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.13"
             },
             "funding": [
                 {
@@ -20634,7 +20830,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-12-25T07:07:57+00:00"
+            "time": "2022-01-24T07:33:35+00:00"
         },
         {
             "name": "rector/rector",

--- a/src/Api/Filter/AssignedFilter.php
+++ b/src/Api/Filter/AssignedFilter.php
@@ -17,10 +17,10 @@ final class AssignedFilter extends AbstractContextAwareFilter
 
     public function __construct(
         ManagerRegistry $managerRegistry,
+        TokenStorageInterface $tokenStorage,
         $requestStack = null,
         LoggerInterface $logger = null,
-        array $properties = null,
-        TokenStorageInterface $tokenStorage)
+        array $properties = null)
     {
         parent::__construct($managerRegistry, $requestStack, $logger, $properties);
 

--- a/src/Api/Filter/TaskFilter.php
+++ b/src/Api/Filter/TaskFilter.php
@@ -17,10 +17,10 @@ final class TaskFilter extends AbstractContextAwareFilter
 
     public function __construct(
         ManagerRegistry $managerRegistry,
+        TokenStorageInterface $tokenStorage,
         $requestStack = null,
         LoggerInterface $logger = null,
-        array $properties = null,
-        TokenStorageInterface $tokenStorage)
+        array $properties = null)
     {
         parent::__construct($managerRegistry, $requestStack, $logger, $properties);
 

--- a/src/Command/CreateTasksCommand.php
+++ b/src/Command/CreateTasksCommand.php
@@ -14,7 +14,7 @@ use Geocoder\Provider\Photon\Photon as PhotonProvider;
 use Geocoder\StatefulGeocoder;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\HandlerStack;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use League\Geotools\Coordinate\Coordinate;
 use Spatie\GuzzleRateLimiterMiddleware\RateLimiterMiddleware;
 use Symfony\Component\Console\Command\Command;

--- a/src/Command/InitDemoCommand.php
+++ b/src/Command/InitDemoCommand.php
@@ -22,7 +22,7 @@ use Geocoder\Provider\Photon\Photon as PhotonProvider;
 use Geocoder\StatefulGeocoder;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\HandlerStack;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use libphonenumber\PhoneNumberUtil;
 use League\Geotools\Coordinate\Coordinate;
 use Redis;

--- a/src/Edenred/Authentication.php
+++ b/src/Edenred/Authentication.php
@@ -5,13 +5,13 @@ namespace AppBundle\Edenred;
 use ApiPlatform\Core\Api\IriConverterInterface;
 use AppBundle\Sylius\Customer\CustomerInterface;
 use AppBundle\Sylius\Order\OrderInterface;
-use GuzzleHttp\Client as BaseClient;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\HandlerStack;
 use Lexik\Bundle\JWTAuthenticationBundle\Encoder\JWTEncoderInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class Authentication extends BaseClient
+class Authentication
 {
     public function __construct(
         array $config = [],
@@ -29,7 +29,7 @@ class Authentication extends BaseClient
 
         $config['handler'] = $stack;
 
-        parent::__construct($config);
+        $this->client = new GuzzleClient($config);
 
         $this->baseUrl = $config['base_uri'];
         $this->clientId = $clientId;
@@ -126,7 +126,7 @@ class Authentication extends BaseClient
 
     public function userInfo(CustomerInterface $customer)
     {
-        $response = $this->request('GET', '/connect/userinfo', [
+        $response = $this->client->request('GET', '/connect/userinfo', [
             'headers' => [
                 'Authorization' => sprintf('Bearer %s', $customer->getEdenredCredentials()->getAccessToken()),
             ],

--- a/src/Edenred/Authentication.php
+++ b/src/Edenred/Authentication.php
@@ -14,14 +14,14 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 class Authentication
 {
     public function __construct(
-        array $config = [],
         string $clientId,
         string $clientSecret,
         RefreshTokenHandler $refreshTokenHandler,
         UrlGeneratorInterface $urlGenerator,
         JWTEncoderInterface $jwtEncoder,
         IriConverterInterface $iriConverter,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        array $config = []
     )
     {
         $stack = HandlerStack::create();

--- a/src/Edenred/Client.php
+++ b/src/Edenred/Client.php
@@ -6,7 +6,7 @@ use AppBundle\Entity\Sylius\Customer;
 use AppBundle\Sylius\Customer\CustomerInterface;
 use AppBundle\Sylius\Order\AdjustmentInterface;
 use AppBundle\Sylius\Order\OrderInterface;
-use GuzzleHttp\Client as BaseClient;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
@@ -15,7 +15,7 @@ use Psr\Log\NullLogger;
 use Sylius\Component\Payment\Model\PaymentInterface;
 use Webmozart\Assert\Assert;
 
-class Client extends BaseClient
+class Client
 {
     private $logger;
 
@@ -37,7 +37,7 @@ class Client extends BaseClient
 
         $stack->push($refreshTokenHandler);
 
-        parent::__construct($config);
+        $this->client = new GuzzleClient($config);
 
         $this->paymentClientId = $paymentClientId;
         $this->paymentClientSecret = $paymentClientSecret;
@@ -55,7 +55,7 @@ class Client extends BaseClient
             $credentials = $customer->getEdenredCredentials();
 
             // https://documenter.getpostman.com/view/10405248/TVewaQQX#82e953fc-9110-4246-8a78-aba888b70b31
-            $response = $this->request('GET', sprintf('/v1/users/%s', $userInfo['username']), [
+            $response = $this->client->request('GET', sprintf('/v1/users/%s', $userInfo['username']), [
                 'headers' => [
                     'Authorization' => sprintf('Bearer %s', $credentials->getAccessToken()),
                     'X-Client-Id' => $this->paymentClientId,
@@ -111,7 +111,7 @@ class Client extends BaseClient
 
         // https://documenter.getpostman.com/view/10405248/TVewaQQX#42a5e69d-898b-41b9-b37e-9d28c23135c8
         try {
-            $response = $this->request('POST', '/v1/transactions', [
+            $response = $this->client->request('POST', '/v1/transactions', [
                 'headers' => [
                     'Authorization' => sprintf('Bearer %s', $credentials->getAccessToken()),
                     'X-Client-Id' => $this->paymentClientId,
@@ -153,7 +153,7 @@ class Client extends BaseClient
 
         // https://documenter.getpostman.com/view/10405248/TVewaQQX#93c0ef51-7526-46a2-9c48-967692f51d7f
         try {
-            $response = $this->request('POST', sprintf('/v1/transactions/%s/actions/capture', $payment->getEdenredAuthorizationId()), [
+            $response = $this->client->request('POST', sprintf('/v1/transactions/%s/actions/capture', $payment->getEdenredAuthorizationId()), [
                 'headers' => [
                     'Authorization' => sprintf('Bearer %s', $credentials->getAccessToken()),
                     'X-Client-Id' => $this->paymentClientId,
@@ -220,7 +220,7 @@ class Client extends BaseClient
 
         // https://documenter.getpostman.com/view/10405248/TVewaQQX#daa3d033-f7d9-4c0b-a0c4-db3614596895
         try {
-            $response = $this->request('POST', sprintf('/v1/transactions/%s/actions/cancel', $payment->getEdenredAuthorizationId()), [
+            $response = $this->client->request('POST', sprintf('/v1/transactions/%s/actions/cancel', $payment->getEdenredAuthorizationId()), [
                 'headers' => [
                     'Authorization' => sprintf('Bearer %s', $credentials->getAccessToken()),
                     'X-Client-Id' => $this->paymentClientId,
@@ -259,7 +259,7 @@ class Client extends BaseClient
         // https://documenter.getpostman.com/view/2761627/TVejiB3m#bf335b3c-d9fc-4249-93fe-1bbdedc1a9cd
         try {
 
-            $response = $this->request('POST', sprintf('/v1/transactions/%s/actions/refund', $payment->getEdenredAuthorizationId()), [
+            $response = $this->client->request('POST', sprintf('/v1/transactions/%s/actions/refund', $payment->getEdenredAuthorizationId()), [
                 'headers' => [
                     'Authorization' => sprintf('Bearer %s', $credentials->getAccessToken()),
                     'X-Client-Id' => $this->paymentClientId,

--- a/src/Edenred/Client.php
+++ b/src/Edenred/Client.php
@@ -20,11 +20,11 @@ class Client
     private $logger;
 
     public function __construct(
-        array $config = [],
         string $paymentClientId,
         string $paymentClientSecret,
         RefreshTokenHandler $refreshTokenHandler,
         Authentication $authentication,
+        array $config = [],
         LoggerInterface $logger = null
     )
     {

--- a/src/Edenred/RefreshTokenHandler.php
+++ b/src/Edenred/RefreshTokenHandler.php
@@ -5,7 +5,7 @@ namespace AppBundle\Edenred;
 use Doctrine\ORM\EntityManagerInterface;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -75,7 +75,7 @@ class RefreshTokenHandler
 
                                 $this->entityManager->flush();
 
-                                $request = Psr7\modify_request($request, [
+                                $request = Utils::modifyRequest($request, [
                                     'set_headers' => [
                                         'Authorization' => sprintf('Bearer %s', $data['access_token'])
                                     ]

--- a/src/LoopEat/Client.php
+++ b/src/LoopEat/Client.php
@@ -29,12 +29,12 @@ class Client
     private $logger;
 
     public function __construct(
-        array $config = [],
         EntityManagerInterface $objectManager,
         JWTEncoderInterface $jwtEncoder,
         IriConverterInterface $iriConverter,
         UrlGeneratorInterface $urlGenerator,
-        LoggerInterface $logger)
+        LoggerInterface $logger,
+        array $config = [])
     {
         $stack = HandlerStack::create();
         $stack->push($this->refreshToken());

--- a/src/Service/Geocoder.php
+++ b/src/Service/Geocoder.php
@@ -18,7 +18,7 @@ use Geocoder\Query\ReverseQuery;
 use Geocoder\StatefulGeocoder;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\HandlerStack;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Spatie\GuzzleRateLimiterMiddleware\RateLimiterMiddleware;
 use Spatie\GuzzleRateLimiterMiddleware\Store as RateLimiterStore;
 use Webmozart\Assert\Assert;

--- a/src/Utils/RestaurantStats.php
+++ b/src/Utils/RestaurantStats.php
@@ -408,7 +408,7 @@ class RestaurantStats implements \Countable
         return $bypass ? $amount : $this->numberFormatter->format($amount / 100);
     }
 
-    public function count()
+    public function count(): int
     {
         return count($this->result);
     }

--- a/src/Utils/SortableRestaurantIterator.php
+++ b/src/Utils/SortableRestaurantIterator.php
@@ -8,7 +8,7 @@ use Carbon\Carbon;
 
 class SortableRestaurantIterator extends \ArrayIterator
 {
-    public function __construct($array = [], TimingRegistry $timingRegistry)
+    public function __construct($array, TimingRegistry $timingRegistry)
     {
         $this->timingRegistry = $timingRegistry;
 

--- a/tests/AppBundle/Edenred/ClientTest.php
+++ b/tests/AppBundle/Edenred/ClientTest.php
@@ -43,11 +43,11 @@ class ClientTest extends TestCase
         $handlerStack = HandlerStack::create($this->mockHandler);
 
         $this->client = new EdenredClient(
-            ['handler' => $handlerStack],
             'key_123',
             'secret_456',
             $this->refreshTokenHandler,
-            $this->edenredAuth->reveal()
+            $this->edenredAuth->reveal(),
+            ['handler' => $handlerStack]
         );
     }
 


### PR DESCRIPTION
At least now the project dependencies can be installed under PHP 8.x, and PHPStan returns no errors.

- [x] Fix errors for PHP 8.x
- [x] Stop extending final class `GuzzleHttp\Client`