### PR TITLE
Allow to delete users in admin

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -607,6 +607,12 @@ class AdminController extends AbstractController
         $user->setEmailCanonical($anonymousEmail);
         $user->setEnabled(false);
 
+        $customer = $user->getCustomer();
+        if (null !== $customer) {
+            $customer->setEmail($anonymousEmail);
+            $customer->setEmailCanonical($anonymousEmail);
+        }
+
         $userManager->updateUser($user, false);
 
         $this->entityManager->flush();

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -611,6 +611,7 @@ class AdminController extends AbstractController
         if (null !== $customer) {
             $customer->setEmail($anonymousEmail);
             $customer->setEmailCanonical($anonymousEmail);
+            $customer->setFullName('');
         }
 
         $userManager->updateUser($user, false);

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -591,7 +591,7 @@ class AdminController extends AbstractController
     }
 
     /**
-     * @Route("/admin/user/{username}/delete", name="admin_user_delete")
+     * @Route("/admin/user/{username}/delete", name="admin_user_delete", methods={"POST"})
      */
     public function userDeleteAction($username, Request $request, UserManagerInterface $userManager)
     {

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -591,6 +591,35 @@ class AdminController extends AbstractController
     }
 
     /**
+     * @Route("/admin/user/{username}/delete", name="admin_user_delete")
+     */
+    public function userDeleteAction($username, Request $request, UserManagerInterface $userManager)
+    {
+        $user = $userManager->findUserByUsername($username);
+
+        if (!$user) {
+            throw $this->createNotFoundException();
+        }
+
+        $anonymousEmail = sprintf('anon%s@coopcycle.org', bin2hex(random_bytes(8)));
+
+        $user->setEmail($anonymousEmail);
+        $user->setEmailCanonical($anonymousEmail);
+        $user->setEnabled(false);
+
+        $userManager->updateUser($user, false);
+
+        $this->entityManager->flush();
+
+        $this->addFlash(
+            'notice',
+            $this->translator->trans('adminDashboard.users.userHasBeenDeleted')
+        );
+
+        return $this->redirectToRoute('admin_users');
+    }
+
+    /**
      * @Route("/admin/user/{username}/tracking", name="admin_user_tracking")
      */
     public function userTrackingAction($username, Request $request, UserManagerInterface $userManager)

--- a/templates/admin/users.html.twig
+++ b/templates/admin/users.html.twig
@@ -125,7 +125,16 @@
       {% if customer.hasUser() %}
       <a class="btn btn-xs btn-success"
         href="{{ path('admin_user_edit', { username: customer.user.username }) }}">
-        <i class="fa fa-pencil" aria-hidden="true"></i>  {% trans from 'messages' %}Edit{%  endtrans %}
+        <i class="fa fa-pencil" aria-hidden="true"></i>  {{ 'basics.edit'|trans }}
+      </a>
+      {% endif %}
+    </td>
+    <td class="text-right">
+      {% if customer.hasUser() %}
+      <a class="btn btn-xs btn-danger"
+        href="{{ path('admin_user_delete', { username: customer.user.username }) }}"
+        onclick="return confirm('{{ 'adminDashboard.users.confirmDeleteUser'|trans({ '%email%': customer.emailCanonical })|escape('js') }}')">
+        <i class="fa fa-trash" aria-hidden="true"></i>  {{ 'basics.delete'|trans }}
       </a>
       {% endif %}
     </td>

--- a/templates/admin/users.html.twig
+++ b/templates/admin/users.html.twig
@@ -131,11 +131,13 @@
     </td>
     <td class="text-right">
       {% if customer.hasUser() %}
-      <a class="btn btn-xs btn-danger"
-        href="{{ path('admin_user_delete', { username: customer.user.username }) }}"
-        onclick="return confirm('{{ 'adminDashboard.users.confirmDeleteUser'|trans({ '%email%': customer.emailCanonical })|escape('js') }}')">
-        <i class="fa fa-trash" aria-hidden="true"></i>  {{ 'basics.delete'|trans }}
-      </a>
+      <form method="post" action="{{ path('admin_user_delete', { username: customer.user.username }) }}">
+        <button type="submit" class="btn btn-xs btn-danger"
+          href="{{ path('admin_user_delete', { username: customer.user.username }) }}"
+          onclick="return confirm('{{ 'adminDashboard.users.confirmDeleteUser'|trans({ '%email%': customer.emailCanonical })|escape('js') }}')">
+          <i class="fa fa-trash" aria-hidden="true"></i>  {{ 'basics.delete'|trans }}
+        </button>
+      </form>
       {% endif %}
     </td>
   </tr>

--- a/templates/admin/users.html.twig
+++ b/templates/admin/users.html.twig
@@ -87,6 +87,7 @@
   <th class="text-right">{% trans %}adminDashboard.users.roles{% endtrans  %}</th>
   <th>{% trans %}profile.username{% endtrans  %}</th>
   <th></th>
+  <th></th>
 </thead>
 <tbody>
 {% for customer in customers %}
@@ -130,7 +131,8 @@
       {% endif %}
     </td>
     <td class="text-right">
-      {% if customer.hasUser() and customer.user.enabled %}
+      {# Show delete button only for "normal" users, without any special role #}
+      {% if customer.hasUser() and customer.user.enabled and customer.user.hasRole('ROLE_USER') and customer.user.roles|length == 1 %}
       <form method="post" action="{{ path('admin_user_delete', { username: customer.user.username }) }}">
         <button type="submit" class="btn btn-xs btn-danger"
           href="{{ path('admin_user_delete', { username: customer.user.username }) }}"

--- a/templates/admin/users.html.twig
+++ b/templates/admin/users.html.twig
@@ -90,7 +90,7 @@
 </thead>
 <tbody>
 {% for customer in customers %}
-  <tr>
+  <tr class="{{ customer.hasUser() and not customer.user.enabled ? 'danger' : '' }}">
     <td>
       <span class="text-monospace">{% if is_demo %}✴✴✴{% else %}{{ customer.emailCanonical }}{% endif %}</span>
     </td>
@@ -130,7 +130,7 @@
       {% endif %}
     </td>
     <td class="text-right">
-      {% if customer.hasUser() %}
+      {% if customer.hasUser() and customer.user.enabled %}
       <form method="post" action="{{ path('admin_user_delete', { username: customer.user.username }) }}">
         <button type="submit" class="btn btn-xs btn-danger"
           href="{{ path('admin_user_delete', { username: customer.user.username }) }}"

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -64,6 +64,8 @@ adminDashboard.restaurants.exclusive: Exclusive
 adminDashboard.users.title: Users
 adminDashboard.users.roles: Roles
 adminDashboard.users.editUser: Edit user
+adminDashboard.users.confirmDeleteUser: Are you sure you want to delete user with email %email%?
+adminDashboard.users.userHasBeenDeleted: User has been deleted.
 adminDashboard.users.edit.addStore: Add a store
 adminDashboard.users.edit.addRestaurant: Add a restaurant
 adminDashboard.users.createNew: Add user

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -43,6 +43,8 @@ adminDashboard.shops.title: Tiendas
 adminDashboard.users.title: Usuarios
 adminDashboard.users.roles: Roles
 adminDashboard.users.editUser: Editar usuario
+adminDashboard.users.confirmDeleteUser: ¿Estás seguro de eliminar al usuario con email %email%?
+adminDashboard.users.userHasBeenDeleted: El usuario ha sido eliminado.
 adminDashboard.users.edit.addStore: Añadir tienda
 adminDashboard.users.edit.addRestaurant: Añadir restaurante
 adminDashboard.users.createNew: Añadir usuario

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -1202,3 +1202,5 @@ restaurant.closedNowWarning: Ce restaurant est fermé actuellement.
 restaurant.form.section.en_boite_le_plat: En Boîte Le Plat
 restaurant.form.en_boite_le_plat_enabled.label: Activer le système de consigne En Boîte Le Plat
 form.checkout_address.reusable_packaging_en_boite_le_plat_enabled.label: 'Je veux des contenants consignés <a href="https://enboiteleplat.fr/rennes/" target="_blank">En Boîte Le Plat</a>.'
+adminDashboard.users.confirmDeleteUser: Voulez-vous vraiment supprimer l'utilisateur avec l'email %email% ?
+adminDashboard.users.userHasBeenDeleted: L'utilisateur a été supprimé.


### PR DESCRIPTION
Closes #453 

This change doesn't delete the user from database. Instead, it changes the user's email to an anonymized one and sets user as disabled.
I don't know if it's a problem but the users list is showing enabled and disabled users, so when "delete" the user it still remains in the list but with the new anonymized email.

![Peek 26-01-2022 14-45](https://user-images.githubusercontent.com/4819244/151218856-3612f561-f529-4882-b652-6d4286fe3330.gif)
