### PR TITLE
Improve management of deliveries with multiple dropoffs.

### DIFF
--- a/features/deliveries_multi.feature
+++ b/features/deliveries_multi.feature
@@ -90,3 +90,118 @@ Feature: Multi-step deliveries
         }
       }
       """
+
+  Scenario: Create delivery with pickup & dropoff + packages with OAuth
+    Given the fixtures files are loaded:
+      | sylius_channels.yml |
+      | stores.yml          |
+    Given the setting "latlng" has value "48.856613,2.352222"
+    And the store with name "Acme" has an OAuth client named "Acme"
+    And the OAuth client with name "Acme" has an access token
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the OAuth client "Acme" sends a "POST" request to "/api/deliveries" with body:
+      """
+      {
+        "tasks": [
+          {
+            "type": "pickup",
+            "address": "24, Rue de la Paix",
+            "before": "tomorrow 13:00"
+          },
+          {
+            "type": "dropoff",
+            "address": "48, Rue de Rivoli",
+            "before": "tomorrow 13:30",
+            "weight": 1500,
+            "packages": [
+              {"type": "XL", "quantity": 2}
+            ]
+          },
+          {
+            "type": "dropoff",
+            "address": "52, Rue de Rivoli, Paris France",
+            "before": "tomorrow 14:30",
+            "weight": 1500,
+            "packages": [
+              {"type": "XL", "quantity": 2}
+            ]
+          }
+        ]
+      }
+      """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context":"/api/contexts/Delivery",
+        "@id":"/api/deliveries/1",
+        "@type":"http://schema.org/ParcelDelivery",
+        "id":@integer@,
+        "pickup":{
+          "@id":@string@,
+          "@type":"Task",
+          "id":@integer@,
+          "status":"TODO",
+          "address":{
+            "@id":@string@,
+            "@type":"http://schema.org/Place",
+            "contactName":null,
+            "geo":{
+              "@type":"GeoCoordinates",
+              "latitude":@number@,
+              "longitude":@number@
+            },
+            "streetAddress":@string@,
+            "telephone":null,
+            "name":null
+          },
+          "comments":"4 × XL\n3.00 kg",
+          "weight":3000,
+          "after":"@string@.isDateTime()",
+          "before":"@string@.isDateTime()",
+          "doneAfter":"@string@.isDateTime()",
+          "doneBefore":"@string@.isDateTime()",
+          "packages":[
+            {
+              "type":"XL",
+              "name":"XL",
+              "quantity":4
+            }
+          ]
+        },
+        "dropoff":{
+          "@id":@string@,
+          "@type":"Task",
+          "id":@integer@,
+          "status":"TODO",
+          "address":{
+            "@id":@string@,
+            "@type":"http://schema.org/Place",
+            "contactName":null,
+            "geo":{
+              "@type":"GeoCoordinates",
+              "latitude":@number@,
+              "longitude":@number@
+            },
+            "streetAddress":@string@,
+            "telephone":null,
+            "name":null
+          },
+          "comments":"",
+          "weight":1500,
+          "after":"@string@.isDateTime()",
+          "before":"@string@.isDateTime()",
+          "doneAfter":"@string@.isDateTime()",
+          "doneBefore":"@string@.isDateTime()",
+          "packages":[
+            {
+              "type":"XL",
+              "name":"XL",
+              "quantity":2
+            }
+          ]
+        }
+      }
+      """

--- a/src/Entity/Delivery.php
+++ b/src/Entity/Delivery.php
@@ -298,6 +298,22 @@ class Delivery extends TaskCollection implements TaskCollectionInterface, Packag
         return $delivery;
     }
 
+    public function withTasks(Task ...$tasks)
+    {
+        $this->items->clear();
+
+        $pickup = array_shift($tasks);
+
+        $this->addTask($pickup);
+
+        foreach ($tasks as $dropoff) {
+            $dropoff->setPrevious($pickup);
+            $this->addTask($dropoff);
+        }
+
+        return $this;
+    }
+
     public static function createWithAddress($pickupAddress, $dropoffAddress)
     {
         $delivery = self::createWithDefaults();

--- a/src/Entity/Delivery.php
+++ b/src/Entity/Delivery.php
@@ -266,17 +266,7 @@ class Delivery extends TaskCollection implements TaskCollectionInterface, Packag
 
         if (count($tasks) > 2) {
 
-            $pickup = array_shift($tasks);
-
-            $delivery->addTask($pickup);
-
-            foreach ($tasks as $dropoff) {
-
-                $dropoff->setPrevious($pickup);
-
-                $delivery->addTask($dropoff);
-            }
-
+            $delivery = $delivery->withTasks(...$tasks);
 
         } else {
 
@@ -303,6 +293,9 @@ class Delivery extends TaskCollection implements TaskCollectionInterface, Packag
         $this->items->clear();
 
         $pickup = array_shift($tasks);
+
+        // Make sure the first task is a pickup
+        $pickup->setType(Task::TYPE_PICKUP);
 
         $this->addTask($pickup);
 

--- a/src/Serializer/DeliveryNormalizer.php
+++ b/src/Serializer/DeliveryNormalizer.php
@@ -46,6 +46,10 @@ class DeliveryNormalizer implements NormalizerInterface, DenormalizerInterface
 
     private function denormalizeTask($data, Task $task, $format = null)
     {
+        if (isset($data['type'])) {
+            $task->setType(strtoupper($data['type']));
+        }
+
         if (isset($data['timeSlot'])) {
 
             // TODO Validate time slot
@@ -150,9 +154,19 @@ class DeliveryNormalizer implements NormalizerInterface, DenormalizerInterface
         $pickup = $delivery->getPickup();
         $dropoff = $delivery->getDropoff();
 
-        if (isset($data['tasks']) && is_array($data['tasks']) && count($data['tasks']) === 2) {
-            $this->denormalizeTask($data['tasks'][0], $pickup, $format);
-            $this->denormalizeTask($data['tasks'][1], $dropoff, $format);
+        if (isset($data['tasks']) && is_array($data['tasks'])) {
+            if (count($data['tasks']) === 2) {
+                $this->denormalizeTask($data['tasks'][0], $pickup, $format);
+                $this->denormalizeTask($data['tasks'][1], $dropoff, $format);
+            } else {
+                $tasks = array_map(function ($item) use ($format) {
+                    $task = new Task();
+                    $this->denormalizeTask($item, $task, $format);
+                    return $task;
+                }, $data['tasks']);
+
+                $delivery = $delivery->withTasks(...$tasks);
+            }
         } else {
             if (isset($data['dropoff'])) {
                 $this->denormalizeTask($data['dropoff'], $dropoff, $format);

--- a/tests/AppBundle/Entity/DeliveryTest.php
+++ b/tests/AppBundle/Entity/DeliveryTest.php
@@ -344,7 +344,9 @@ class DeliveryTest extends TestCase
         $delivery = new Delivery();
 
         $pickup = new Task();
-        $pickup->setType(Task::TYPE_PICKUP);
+        // Even if the first task is not a pickup,
+        // it will be considered as a pickup
+        // $pickup->setType(Task::TYPE_PICKUP);
 
         $dropoff1 = new Task();
         $dropoff1->setType(Task::TYPE_DROPOFF);

--- a/tests/AppBundle/Entity/DeliveryTest.php
+++ b/tests/AppBundle/Entity/DeliveryTest.php
@@ -338,4 +338,22 @@ class DeliveryTest extends TestCase
             }
         }
     }
+
+    public function testWithTasks()
+    {
+        $delivery = new Delivery();
+
+        $pickup = new Task();
+        $pickup->setType(Task::TYPE_PICKUP);
+
+        $dropoff1 = new Task();
+        $dropoff1->setType(Task::TYPE_DROPOFF);
+
+        $dropoff2 = new Task();
+        $dropoff2->setType(Task::TYPE_DROPOFF);
+
+        $delivery = $delivery->withTasks(...[ $pickup, $dropoff1, $dropoff2 ]);
+
+        $this->assertNotNull($delivery->getPickup());
+    }
 }


### PR DESCRIPTION
Following #3112, I realised that we didn't have a functional test that checks that the pickup task contains an aggregation of the packages and weight of the subsequent dropoffs. 

This pull request adds a test for that, and also allows to send a payload with multiple dropoffs. 