### PR TITLE
Multiple time slots for stores

### DIFF
--- a/app/DoctrineMigrations/Version20220217134929.php
+++ b/app/DoctrineMigrations/Version20220217134929.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220217134929 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('CREATE TABLE store_time_slot (store_id INT NOT NULL, time_slot_id INT NOT NULL, PRIMARY KEY(store_id, time_slot_id))');
+        $this->addSql('CREATE INDEX IDX_5CE54537B092A811 ON store_time_slot (store_id)');
+        $this->addSql('CREATE INDEX IDX_5CE54537D62B0FA ON store_time_slot (time_slot_id)');
+        $this->addSql('ALTER TABLE store_time_slot ADD CONSTRAINT FK_5CE54537B092A811 FOREIGN KEY (store_id) REFERENCES store (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE store_time_slot ADD CONSTRAINT FK_5CE54537D62B0FA FOREIGN KEY (time_slot_id) REFERENCES time_slot (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE store_time_slot');
+    }
+}

--- a/app/DoctrineMigrations/Version20220217134929.php
+++ b/app/DoctrineMigrations/Version20220217134929.php
@@ -24,6 +24,8 @@ final class Version20220217134929 extends AbstractMigration
         $this->addSql('CREATE INDEX IDX_5CE54537D62B0FA ON store_time_slot (time_slot_id)');
         $this->addSql('ALTER TABLE store_time_slot ADD CONSTRAINT FK_5CE54537B092A811 FOREIGN KEY (store_id) REFERENCES store (id) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->addSql('ALTER TABLE store_time_slot ADD CONSTRAINT FK_5CE54537D62B0FA FOREIGN KEY (time_slot_id) REFERENCES time_slot (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        $this->addSql('INSERT INTO store_time_slot (store_id, time_slot_id) SELECT id, time_slot_id FROM store WHERE time_slot_id IS NOT NULL');
     }
 
     public function down(Schema $schema): void

--- a/app/config/services/forms.yml
+++ b/app/config/services/forms.yml
@@ -90,6 +90,8 @@ services:
     tags: [ form.type ]
 
   AppBundle\Form\TaskType:
+    arguments:
+      $locale: '%env(COOPCYCLE_LOCALE)%'
     tags: [ form.type ]
 
   AppBundle\Form\RestaurantType:

--- a/js/app/forms/delivery.js
+++ b/js/app/forms/delivery.js
@@ -171,6 +171,29 @@ function createTagsWidget(name, type, tags) {
   })
 }
 
+function createSwitchTimeSlotWidget(name, taskForm) {
+  const switchTimeSlotEl = document.querySelector(`#${name}_${taskForm}_switchTimeSlot`)
+  const timeSlotEl = document.querySelector(`#${name}_${taskForm}_timeSlot`)
+
+  if (switchTimeSlotEl && timeSlotEl) {
+    switchTimeSlotEl.querySelectorAll('input[type="radio"]').forEach(rad => {
+      rad.addEventListener('change', function(e) {
+
+        const choices = JSON.parse(e.target.dataset.choices)
+        const timeSlotEl = document.querySelector(`#${name}_${taskForm}_timeSlot`)
+
+        timeSlotEl.innerHTML = ''
+        choices.forEach(choice => {
+          const opt = document.createElement('option')
+          opt.value = choice.value
+          opt.innerHTML = choice.label
+          timeSlotEl.appendChild(opt)
+        })
+      })
+    })
+  }
+}
+
 function createPackageForm(name, $list, cb) {
 
   var counter = $list.data('widget-counter') || $list.children().length
@@ -377,6 +400,8 @@ function initSubForm(name, taskEl, preloadedState) {
       createTagsWidget(name, taskForm, tags)
     })
   }
+
+  createSwitchTimeSlotWidget(name, taskForm)
 
   const deleteBtn = taskEl.querySelector('[data-delete="task"]')
 

--- a/js/app/forms/delivery.js
+++ b/js/app/forms/delivery.js
@@ -180,7 +180,6 @@ function createSwitchTimeSlotWidget(name, taskForm) {
       rad.addEventListener('change', function(e) {
 
         const choices = JSON.parse(e.target.dataset.choices)
-        const timeSlotEl = document.querySelector(`#${name}_${taskForm}_timeSlot`)
 
         timeSlotEl.innerHTML = ''
         choices.forEach(choice => {

--- a/js/app/store/form.js
+++ b/js/app/store/form.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { render } from 'react-dom'
 import TagsSelect from '../components/TagsSelect'
 import { addressMapper } from '../widgets/addressForm'
-import _ from 'lodash'
 
 var tagsEl = document.querySelector('#store_tags');
 
@@ -74,15 +73,62 @@ const timeSlotsEl = document.querySelector('#store_timeSlots')
 const timeSlotEl = document.querySelector('#store_timeSlot')
 
 if (timeSlotsEl && timeSlotEl) {
+
+  const defaultValue = timeSlotEl.value
+
   timeSlotsEl.querySelectorAll('input[type="checkbox"]').forEach(chk => {
-    chk.addEventListener('change', () => {
 
-      const checked = timeSlotsEl.querySelectorAll('input[type="checkbox"]:checked')
-      const values = Array.from(checked).map(el => el.value)
+    if (chk.value === defaultValue) {
+      document.querySelector(chk.dataset.defaultControl).checked = true
+    }
 
-      if (!_.includes(values, timeSlotEl.value)) {
-        timeSlotEl.value = values[0]
+    document.querySelector(chk.dataset.defaultControl).addEventListener('change', e => {
+      if (e.target.checked) {
+        timeSlotEl.value = e.target.value
+      }
+    })
+
+    chk.addEventListener('change', (e) => {
+
+      const defaultControl = document.querySelector(e.target.dataset.defaultControl)
+      const checkedCheckboxes = Array.from(timeSlotsEl.querySelectorAll('input[type="checkbox"]:checked'))
+      const checkedRadios = Array.from(timeSlotsEl.querySelectorAll('input[type="radio"]:checked'))
+
+      if (!e.target.checked) {
+
+        if (defaultControl.checked) {
+          if (checkedCheckboxes.length > 0) {
+            const firstChecked = checkedCheckboxes[0]
+            document.querySelector(firstChecked.dataset.defaultControl).checked = true
+          }
+        }
+
+        defaultControl.setAttribute('disabled', true)
+        defaultControl
+          .closest('.radio')
+          .classList.add('disabled')
+        defaultControl.checked = false
+
+      } else {
+
+        defaultControl.removeAttribute('disabled')
+        defaultControl
+          .closest('.radio')
+          .classList.remove('disabled')
+
+        if (checkedRadios.length === 0) {
+          defaultControl.checked = true
+        }
+      }
+
+      const checkedRadio = timeSlotsEl.querySelector('input[type="radio"]:checked')
+      if (checkedRadio) {
+        timeSlotEl.value = checkedRadio.value
+      } else {
+        timeSlotEl.value = ''
       }
     })
   })
+
+  document.querySelector('#store_timeSlot').closest('.form-group').classList.add('d-none')
 }

--- a/js/app/store/form.js
+++ b/js/app/store/form.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { render } from 'react-dom'
 import TagsSelect from '../components/TagsSelect'
 import { addressMapper } from '../widgets/addressForm'
+import _ from 'lodash'
 
 var tagsEl = document.querySelector('#store_tags');
 
@@ -67,4 +68,21 @@ $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
 
 if (window.location.hash !== '') {
   $(`a[aria-controls="${window.location.hash.substring(1)}"]`).tab('show')
+}
+
+const timeSlotsEl = document.querySelector('#store_timeSlots')
+const timeSlotEl = document.querySelector('#store_timeSlot')
+
+if (timeSlotsEl && timeSlotEl) {
+  timeSlotsEl.querySelectorAll('input[type="checkbox"]').forEach(chk => {
+    chk.addEventListener('change', () => {
+
+      const checked = timeSlotsEl.querySelectorAll('input[type="checkbox"]:checked')
+      const values = Array.from(checked).map(el => el.value)
+
+      if (!_.includes(values, timeSlotEl.value)) {
+        timeSlotEl.value = values[0]
+      }
+    })
+  })
 }

--- a/src/Entity/Store.php
+++ b/src/Entity/Store.php
@@ -153,10 +153,13 @@ class Store extends LocalBusiness implements TaggableInterface, OrganizationAwar
      */
     private $multiDropEnabled = false;
 
+    private $timeSlots;
+
     public function __construct() {
         $this->deliveries = new ArrayCollection();
         $this->owners = new ArrayCollection();
         $this->addresses = new ArrayCollection();
+        $this->timeSlots = new ArrayCollection();
     }
 
     /**
@@ -476,5 +479,15 @@ class Store extends LocalBusiness implements TaggableInterface, OrganizationAwar
         $this->multiDropEnabled = $multiDropEnabled;
 
         return $this;
+    }
+
+    public function getTimeSlots()
+    {
+        return $this->timeSlots;
+    }
+
+    public function addTimeSlot(TimeSlot $timeSlot)
+    {
+        $this->timeSlots->add($timeSlot);
     }
 }

--- a/src/Form/DeliveryType.php
+++ b/src/Form/DeliveryType.php
@@ -98,6 +98,7 @@ class DeliveryType extends AbstractType
                     'with_addresses' => null !== $store ? $store->getAddresses() : [],
                     'with_remember_address' => $options['with_remember_address'],
                     'with_time_slot' => $this->getTimeSlot($options, $store),
+                    'with_time_slots' => $this->getTimeSlots($options, $store),
                     'with_doorstep' => $options['with_dropoff_doorstep'],
                     'with_address_props' => $options['with_address_props'],
                     'with_package_set' => $this->getPackageSet($options, $store),
@@ -190,6 +191,24 @@ class DeliveryType extends AbstractType
     }
 
     /**
+     * @return TimeSlot[]|null
+     */
+    private function getTimeSlots(array $options, ?Store $store = null)
+    {
+        if (null !== $options['with_time_slots']) {
+
+            return $options['with_time_slots'];
+        }
+
+        if ($store) {
+
+            return $store->getTimeSlots();
+        }
+
+        return null;
+    }
+
+    /**
      * @return PackageSet|null
      */
     private function getPackageSet(array $options, ?Store $store = null): ?PackageSet
@@ -216,6 +235,7 @@ class DeliveryType extends AbstractType
             'with_tags' => $this->authorizationChecker->isGranted('ROLE_ADMIN'),
             'with_dropoff_doorstep' => false,
             'with_time_slot' => null,
+            'with_time_slots' => null,
             'with_package_set' => null,
             'with_remember_address' => false,
             'with_address_props' => false,

--- a/src/Form/StoreType.php
+++ b/src/Form/StoreType.php
@@ -68,6 +68,15 @@ class StoreType extends LocalBusinessType
                     'required' => false,
                     'query_builder' => new OrderByNameQueryBuilder(),
                 ])
+                ->add('timeSlots', EntityType::class, [
+                    'label' => 'form.store_type.time_slots.label',
+                    'class' => TimeSlot::class,
+                    'choice_label' => 'name',
+                    'required' => false,
+                    'expanded' => true,
+                    'multiple' => true,
+                    'query_builder' => new OrderByNameQueryBuilder(),
+                ])
                 ->add('tags', TagsType::class, [
                     'mapped' => false,
                 ]);

--- a/src/Resources/config/doctrine/Store.orm.xml
+++ b/src/Resources/config/doctrine/Store.orm.xml
@@ -62,6 +62,19 @@
         <join-column name="time_slot_id" referenced-column-name="id"/>
       </join-columns>
     </many-to-one>
+    <many-to-many field="timeSlots" target-entity="AppBundle\Entity\TimeSlot">
+      <cascade>
+        <cascade-persist/>
+      </cascade>
+      <join-table name="store_time_slot">
+        <join-columns>
+          <join-column name="store_id" referenced-column-name="id" on-delete="CASCADE"/>
+        </join-columns>
+        <inverse-join-columns>
+          <join-column name="time_slot_id" referenced-column-name="id"/>
+        </inverse-join-columns>
+      </join-table>
+    </many-to-many>
     <many-to-one field="packageSet" target-entity="AppBundle\Entity\PackageSet">
       <join-columns>
         <join-column name="package_set_id" referenced-column-name="id"/>

--- a/templates/form/delivery.html.twig
+++ b/templates/form/delivery.html.twig
@@ -36,7 +36,7 @@ col-md-9
     {{ form_row(form.timeSlot) }}
   {% endif %}
 
-  {% if form.switchTimeSlot is defined %}
+  {% if form.switchTimeSlot is defined and not form.switchTimeSlot.rendered %}
     {{ form_row(form.switchTimeSlot) }}
   {% endif %}
 
@@ -120,7 +120,6 @@ col-md-9
   {{ block('weight_widget') }}
 {% endblock %}
 
-
 {% block packages_entry_widget %}
   <div class="delivery__form__packages__list-item" id="{{ form.vars.id }}">
     {{ form_widget(form.quantity, { attr: { class: 'delivery__form__packages__list-item-quantity' } }) }}
@@ -173,4 +172,11 @@ col-md-9
     }) }}
   </div>
 {% endif %}
+{% endblock %}
+
+{% block _delivery_tasks_entry_timeSlot_widget %}
+  {{ form_widget(form) }}
+  {% if form.parent.switchTimeSlot is defined %}
+    {{ form_widget(form.parent.switchTimeSlot) }}
+  {% endif %}
 {% endblock %}

--- a/templates/form/delivery.html.twig
+++ b/templates/form/delivery.html.twig
@@ -36,6 +36,10 @@ col-md-9
     {{ form_row(form.timeSlot) }}
   {% endif %}
 
+  {% if form.switchTimeSlot is defined %}
+    {{ form_row(form.switchTimeSlot) }}
+  {% endif %}
+
   {% if form.packages is defined %}
     {{ form_row(form.packages) }}
   {% endif %}

--- a/templates/form/store.html.twig
+++ b/templates/form/store.html.twig
@@ -18,3 +18,17 @@
   {{ form_row(form.delete) }}
   {% endif %}
 {% endblock %}
+
+{% block _store_timeSlots_entry_widget %}
+  {% set default_control_id = (form.vars.id ~ '_default') %}
+  <div class="d-flex align-items-center justify-content-between"
+    style="margin-bottom: -10px;">
+    {{ form_widget(form, { attr: { 'data-default-control': ('#' ~ default_control_id) } }) }}
+    <div class="radio text-right {% if not form.vars.checked %}disabled{% endif %}">
+      <label>
+        <input type="radio" name="store_timeSlots_default" value="{{ form.vars.value }}" id="{{ default_control_id }}" {% if not form.vars.checked %}disabled{% endif %}>
+        {{ 'form.store_type.time_slots.set_as_default'|trans }}
+      </label>
+    </div>
+  </div>
+{% endblock %}

--- a/templates/store/form/_partials/settings.html.twig
+++ b/templates/store/form/_partials/settings.html.twig
@@ -33,7 +33,10 @@
   <hr>
 {% endif %}
 
-{% if form.timeSlot is defined or form.packageSet is defined %}
+{% if form.timeSlot is defined or form.timeSlots is defined or form.packageSet is defined %}
+  {% if form.timeSlots is defined %}
+    {{ form_row(form.timeSlots) }}
+  {% endif %}
   {% if form.timeSlot is defined %}
     {{ form_row(form.timeSlot) }}
   {% endif %}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1232,3 +1232,4 @@ order.cart.donation.disclaimer: We offer you to donate %percentage% of the reven
 form.checkout_address.nonprofit.placeholder: Choose your favorite nonprofit
 form.delivery.arbitrary_price.label: Define the price manually
 form.store_type.time_slots.label: Time slots
+form.store_type.time_slots.set_as_default: Set as default time slot

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1231,3 +1231,4 @@ adminDashboard.nonprofits.confirm_delete: Are you sure you want to delete this n
 order.cart.donation.disclaimer: We offer you to donate %percentage% of the revenue from your order to one of our partner associations. You will not pay more.
 form.checkout_address.nonprofit.placeholder: Choose your favorite nonprofit
 form.delivery.arbitrary_price.label: Define the price manually
+form.store_type.time_slots.label: Time slots

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -1211,3 +1211,4 @@ adminDashboard.users.userHasBeenDeleted: L'utilisateur a été supprimé.
 order.cart.donation.disclaimer: Nous vous proposons de consacrer %percentage% des revenus tirés de votre commmande à l'une de nos associations partenaires. Vous ne paierez pas plus cher.
 form.checkout_address.nonprofit.placeholder: Choisissez votre association préférée
 form.delivery.arbitrary_price.label: Definir le prix manuellement
+form.store_type.time_slots.label: Tranches horaires

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -1212,3 +1212,4 @@ order.cart.donation.disclaimer: Nous vous proposons de consacrer %percentage% de
 form.checkout_address.nonprofit.placeholder: Choisissez votre association préférée
 form.delivery.arbitrary_price.label: Definir le prix manuellement
 form.store_type.time_slots.label: Tranches horaires
+form.store_type.time_slots.set_as_default: Définir comme tranche horaire par défaut


### PR DESCRIPTION
Fixes #3135 

It's now possible to attach multiple time slots to a store. It's still necessary to set a default time slot for retro-compatibility. 

<img width="1226" alt="Capture d’écran 2022-02-17 à 23 15 54" src="https://user-images.githubusercontent.com/1162230/154580194-4c2431f1-6b0f-436b-be27-28be9bae7869.png">

---

When multiple slots are configured, it's possible to switch in the delivery form.

![multi_slot](https://user-images.githubusercontent.com/1162230/154580346-f2b289a4-c853-4719-a1cd-c7661d06221c.gif)


