### PR TITLE
Ask consent to existing users

### DIFF
--- a/app/DoctrineMigrations/Version20220307181621.php
+++ b/app/DoctrineMigrations/Version20220307181621.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use AppBundle\Enum\Optin;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220307181623 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE optin_consent ADD accepted BOOLEAN DEFAULT \'false\' NOT NULL');
+        $this->addSql('ALTER TABLE optin_consent ADD asked BOOLEAN DEFAULT \'false\' NOT NULL');
+
+        // select users who are customers of the platform and who does not have any consent added yet
+        $customersUsers = $this->connection->prepare
+        (
+            'SELECT u.id FROM api_user u
+            LEFT JOIN optin_consent oc ON oc.user_id = u.id
+            WHERE oc.user_id IS NULL
+            AND u.roles NOT LIKE \'%ROLE_ADMIN%\'
+            AND u.roles NOT LIKE \'%ROLE_COURIER%\'
+            AND u.roles NOT LIKE \'%ROLE_RESTAURANT%\'
+            AND u.roles NOT LIKE \'%ROLE_STORE%\''
+        );
+        $customersUsers->execute();
+
+        while ($user = $customersUsers->fetch())
+        {
+            foreach(Optin::values() as $optin) {
+                $this->addSql('INSERT INTO optin_consent (user_id, type, created_at) VALUES (:user_id, :type, CURRENT_TIMESTAMP)', [
+                    'user_id' => $user['id'],
+                    'type' => $optin->getKey()
+                ]);
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE optin_consent DROP accepted');
+        $this->addSql('ALTER TABLE optin_consent DROP asked');
+    }
+}

--- a/features/fixtures/ORM/optin_consents.yml
+++ b/features/fixtures/ORM/optin_consents.yml
@@ -1,0 +1,21 @@
+AppBundle\Entity\User:
+  bob:
+    __factory:
+      '@Nucleos\UserBundle\Util\UserManipulator::create':
+        - 'bob'
+        - '123456'
+        - 'bob@demo.coopcycle.org'
+        - true
+        - false
+
+AppBundle\Entity\OptinConsent:
+  optin_1:
+    type: 'NEWSLETTER'
+    accepted: false
+    asked: false
+    user: "@bob"
+  optin_2:
+    type: 'MARKETING'
+    accepted: false
+    asked: false
+    user: "@bob"

--- a/features/optins.feature
+++ b/features/optins.feature
@@ -1,0 +1,154 @@
+Feature: Optin Consents
+
+  Scenario: Retrieve user consents
+    Given the fixtures files are loaded:
+      | optin_consents.yml |
+    And the user "bob" is loaded:
+      | email      | bob@coopcycle.org |
+      | password   | 123456            |
+    And the user "bob" is authenticated
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "GET" request to "/api/me/optin-consents"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context": "/api/contexts/OptinConsent",
+        "@id": "/api/me/optin-consents",
+        "@type": "hydra:Collection",
+        "hydra:member": [
+            {
+                "@id": "/api/optin_consents/1",
+                "@type": "OptinConsent",
+                "id": @integer@,
+                "user": "@string@.startsWith('/api/users')",
+                "type": "NEWSLETTER",
+                "createdAt": "@string@.isDateTime()",
+                "withdrawedAt": null,
+                "accepted": false,
+                "asked": false
+            },
+            {
+                "@id": "/api/optin_consents/2",
+                "@type": "OptinConsent",
+                "id": @integer@,
+                "user": "@string@.startsWith('/api/users')",
+                "type": "MARKETING",
+                "createdAt": "@string@.isDateTime()",
+                "withdrawedAt": null,
+                "accepted": false,
+                "asked": false
+            }
+        ],
+        "hydra:totalItems": 2
+      }
+      """
+
+
+  Scenario: User accepts the consent to receive the Newsletter
+    Given the fixtures files are loaded:
+      | optin_consents.yml |
+    And the user "bob" is loaded:
+      | email      | bob@coopcycle.org |
+      | password   | 123456            |
+    And the user "bob" is authenticated
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "PUT" request to "/api/me/optin-consents" with body:
+      """
+      {
+        "type": "NEWSLETTER",
+        "accepted": true,
+        "asked": true
+      }
+      """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context": "/api/contexts/OptinConsent",
+        "@id": "/api/me/optin-consents",
+        "@type": "hydra:Collection",
+        "hydra:member": [
+            {
+                "@id": "/api/optin_consents/1",
+                "@type": "OptinConsent",
+                "id": @integer@,
+                "user": "@string@.startsWith('/api/users')",
+                "type": "NEWSLETTER",
+                "createdAt": "@string@.isDateTime()",
+                "withdrawedAt": null,
+                "accepted": true,
+                "asked": true
+            },
+            {
+                "@id": "/api/optin_consents/2",
+                "@type": "OptinConsent",
+                "id": @integer@,
+                "user": "@string@.startsWith('/api/users')",
+                "type": "MARKETING",
+                "createdAt": "@string@.isDateTime()",
+                "withdrawedAt": null,
+                "accepted": false,
+                "asked": false
+            }
+        ],
+        "hydra:totalItems": 2
+      }
+      """
+
+  Scenario: User rejects consent for Marketing
+    Given the fixtures files are loaded:
+      | optin_consents.yml |
+    And the user "bob" is loaded:
+      | email      | bob@coopcycle.org |
+      | password   | 123456            |
+    And the user "bob" is authenticated
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "PUT" request to "/api/me/optin-consents" with body:
+      """
+      {
+        "type": "MARKETING",
+        "accepted": false,
+        "asked": true
+      }
+      """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context": "/api/contexts/OptinConsent",
+        "@id": "/api/me/optin-consents",
+        "@type": "hydra:Collection",
+        "hydra:member": [
+            {
+                "@id": "/api/optin_consents/1",
+                "@type": "OptinConsent",
+                "id": @integer@,
+                "user": "@string@.startsWith('/api/users')",
+                "type": "NEWSLETTER",
+                "createdAt": "@string@.isDateTime()",
+                "withdrawedAt": null,
+                "accepted": false,
+                "asked": false
+            },
+            {
+                "@id": "/api/optin_consents/2",
+                "@type": "OptinConsent",
+                "id": @integer@,
+                "user": "@string@.startsWith('/api/users')",
+                "type": "MARKETING",
+                "createdAt": "@string@.isDateTime()",
+                "withdrawedAt": null,
+                "accepted": false,
+                "asked": true
+            }
+        ],
+        "hydra:totalItems": 2
+      }
+      """

--- a/js/app/i18n/locales/en.json
+++ b/js/app/i18n/locales/en.json
@@ -254,6 +254,10 @@
         "ADMIN_DASHBOARD_GROUP_NAME_LABEL": "Group name",
         "RULE_PICKER_LINE_VOLUME_UNITS": "Volume units",
         "RULE_PICKER_LINE_PICKUP_TIME_RANGE_LENGTH_HOURS": "Pickup time range length (hours)",
-        "RULE_PICKER_LINE_DROPOFF_TIME_RANGE_LENGTH_HOURS": "Dropoff time range length (hours)"
+        "RULE_PICKER_LINE_DROPOFF_TIME_RANGE_LENGTH_HOURS": "Dropoff time range length (hours)",
+        "OPTIN_CONSENT_NEWSLETTER_LABEL": "I agree to receive the {{brand}} newsletter.",
+        "OPTIN_CONSENT_MARKETING_LABEL": "I agree to receive occasional promotions.",
+        "SELECT_OPTIN_CONSENTS": "Do you agree to receive the following information?",
+        "DONE": "Done"
     }
 }

--- a/js/app/i18n/locales/es.json
+++ b/js/app/i18n/locales/es.json
@@ -253,6 +253,10 @@
             "weekday": "dia de la semana",
             "day": "dia"
         },
-        "TIME_RANGE_FROM": "desde {{start}}"
+        "TIME_RANGE_FROM": "desde {{start}}",
+        "OPTIN_CONSENT_NEWSLETTER_LABEL": "Estoy de acuerdo en recibir las últimas novedades de {{brand}}.",
+        "OPTIN_CONSENT_MARKETING_LABEL": "Estoy de acuerdo en recibir promociones.",
+        "SELECT_OPTIN_CONSENTS": "¿Está de acuerdo en recibir la siguiente información?",
+        "DONE": "Hecho"
     }
 }

--- a/js/app/optins/AskForOptinsModal.js
+++ b/js/app/optins/AskForOptinsModal.js
@@ -1,0 +1,105 @@
+import React, { Component } from 'react'
+import { withTranslation } from 'react-i18next'
+import Modal from 'react-modal'
+
+class AskForOptinsModal extends Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {
+        isOpen: false,
+        user: null,
+        optins: [],
+        optinsToAsk: [],
+    }
+
+    this._onCheckboxChange = this._onCheckboxChange.bind(this);
+    this._onClickSubmit = this._onClickSubmit.bind(this);
+  }
+
+  async componentDidMount() {
+    if (this.props.httpClient) {
+      await this._loadUser()
+    }
+  }
+
+  _loadUser() {
+    return this.props.httpClient.get('/api/me')
+      .then((result) => {
+        this.setState({user: result.data}, () => this._loadUserOptins())
+      })
+  }
+
+  _loadUserOptins() {
+    if (this.state.user && this.state.user.roles.length && this.state.user.roles.includes('ROLE_USER')) {
+      return this.props.httpClient.get('/api/me/optin-consents')
+        .then((result) => {
+          this.setState({optins: result.data['hydra:member']}, () => this._handleUserOptins())
+        })
+    }
+  }
+
+  _handleUserOptins() {
+    if (this.state.optins.length) {
+      const optinsToAsk = this.state.optins.filter((optin) => !optin.asked);
+      this.setState({optinsToAsk, isOpen: !!optinsToAsk.length})
+    }
+  }
+
+  _onCheckboxChange(optin) {
+    this.setState({optinsToAsk: this.state.optinsToAsk.map((opt) => {
+      if (opt.id === optin.id) opt.accepted = !opt.accepted
+      return opt
+    })})
+  }
+
+  _onClickSubmit() {
+    const optinsToSubmit = this.state.optinsToAsk.map((opt) => {
+      opt.asked = true
+      return this.props.httpClient.put('/api/me/optin-consents', opt)
+    })
+    return Promise.all(optinsToSubmit)
+      .then(() => this.setState({isOpen: false}))
+      .catch((err) => {
+        console.error(`Can not update optin consents - err: ${err}`)
+        this.setState({isOpen: false})
+      })
+
+  }
+
+  render() {
+
+    return (
+      <Modal
+        isOpen={ this.state.isOpen }
+        shouldCloseOnOverlayClick={ false }
+        contentLabel={ this.props.t('SELECT_OPTIN_CONSENTS') }
+        className="ReactModal__Content">
+        <form name="optins">
+          <h4 className="text-center">{ this.props.t('SELECT_OPTIN_CONSENTS') }</h4>
+          {this.state.optinsToAsk.length && this.state.optinsToAsk.map((optin) => {
+              return (
+                <div className="checkbox" key={optin.id}>
+                  <label>
+                    <input type="checkbox" onChange={() => this._onCheckboxChange(optin)}/>
+                      { this.props.t(`OPTIN_CONSENT_${optin.type}_LABEL`, {brand: this.props.brandName}) }
+                  </label>
+                </div>
+              )
+          })}
+          <div className="row" >
+            <div className="col-sm-4 col-xs-12"></div>
+            <div className="col-sm-4 col-xs-12">
+              <button type="button" className="btn btn-block btn-default" onClick={ () => this._onClickSubmit() }>
+                {this.props.t('DONE')}
+              </button>
+            </div>
+            <div className="col-sm-4 col-xs-12"></div>
+          </div>
+        </form>
+      </Modal>
+    )
+  }
+}
+
+export default withTranslation()(AskForOptinsModal)

--- a/js/app/optins/index.js
+++ b/js/app/optins/index.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { render } from 'react-dom'
+import { I18nextProvider } from 'react-i18next'
+import Modal from 'react-modal'
+
+import i18n from '../i18n'
+
+import AskForOptinsModal from "./AskForOptinsModal"
+import createHttpClient from "../client"
+
+const init = async () => {
+    const container = document.getElementById('optins')
+
+    if (!container) {
+        return
+    }
+
+    Modal.setAppElement(container)
+
+    const fetchToken = window.Routing.generate('profile_jwt')
+
+    let result = null;
+    let httpClient = null;
+
+    try {
+      result = await $.getJSON(fetchToken)
+    } catch (err) {
+      // when user is not logged in the request fails
+    }
+
+    if (result && result.jwt) {
+      httpClient = createHttpClient(
+        result.jwt,
+        () => new Promise((resolve) => {
+          $.getJSON(fetchToken).then(result => resolve(result.jwt))
+        })
+      )
+    }
+
+    render(
+        <I18nextProvider i18n={ i18n }>
+          <AskForOptinsModal httpClient={httpClient} brandName={container.dataset.brandName} />
+        </I18nextProvider>,
+        container
+      )
+}
+
+init()

--- a/src/Action/MyOptinConsents.php
+++ b/src/Action/MyOptinConsents.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AppBundle\Action;
+
+use AppBundle\Action\Utils\TokenStorageTrait;
+use AppBundle\Entity\OptinConsent;
+use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class MyOptinConsents
+{
+    use TokenStorageTrait;
+
+    protected $doctrine;
+
+    public function __construct(TokenStorageInterface $tokenStorage, ManagerRegistry $doctrine)
+    {
+        $this->tokenStorage = $tokenStorage;
+        $this->doctrine = $doctrine;
+    }
+
+    public function __invoke()
+    {
+        return $this->doctrine
+            ->getRepository(OptinConsent::class)
+            ->findByUser($this->getUser());
+    }
+}

--- a/src/Action/UpdateOptinConsent.php
+++ b/src/Action/UpdateOptinConsent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace AppBundle\Action;
+
+use AppBundle\Action\Utils\TokenStorageTrait;
+use AppBundle\Entity\OptinConsent;
+use Doctrine\Persistence\ManagerRegistry;
+use Nucleos\UserBundle\Model\UserManagerInterface;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Psr\Log\LoggerInterface;
+
+class UpdateOptinConsent
+{
+    use TokenStorageTrait;
+
+    public function __construct(TokenStorageInterface $tokenStorage, UserManagerInterface $userManager, LoggerInterface $logger)
+    {
+        $this->tokenStorage = $tokenStorage;
+        $this->userManager = $userManager;
+        $this->logger = $logger;
+    }
+
+    public function __invoke($data)
+    {
+        $user = $this->getUser();
+
+        foreach($user->getOptinConsents() as $userOptinConsent) {
+            if ($userOptinConsent->getType() === $data->getType()) {
+                $userOptinConsent->setAccepted($data->getAccepted());
+                $userOptinConsent->setAsked($data->getAsked());
+            }
+        }
+
+        $this->userManager->updateUser($user);
+
+        return $user->getOptinConsents();
+    }
+}

--- a/src/Action/UpdateOptinConsent.php
+++ b/src/Action/UpdateOptinConsent.php
@@ -8,17 +8,15 @@ use Doctrine\Persistence\ManagerRegistry;
 use Nucleos\UserBundle\Model\UserManagerInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
-use Psr\Log\LoggerInterface;
 
 class UpdateOptinConsent
 {
     use TokenStorageTrait;
 
-    public function __construct(TokenStorageInterface $tokenStorage, UserManagerInterface $userManager, LoggerInterface $logger)
+    public function __construct(TokenStorageInterface $tokenStorage, UserManagerInterface $userManager)
     {
         $this->tokenStorage = $tokenStorage;
         $this->userManager = $userManager;
-        $this->logger = $logger;
     }
 
     public function __invoke($data)

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -470,7 +470,7 @@ class AdminController extends AbstractController
                     ->createQueryBuilder('u')
                     ->select('u.username, u.email')
                     ->innerJoin('u.optinConsents', 'oc')
-                    ->where('oc.type = :optin')
+                    ->where('oc.type = :optin and oc.accepted = true')
                     ->setParameter('optin', $optinSelected);
 
                 $optinsResult = $optinsQB->getQuery()->getResult();

--- a/src/Entity/OptinConsent.php
+++ b/src/Entity/OptinConsent.php
@@ -2,8 +2,27 @@
 
 namespace AppBundle\Entity;
 
+use AppBundle\Action\MyOptinConsents;
+use AppBundle\Action\UpdateOptinConsent;
+use ApiPlatform\Core\Annotation\ApiResource;
+
 /**
  * @see https://law.stackexchange.com/questions/29190/gdpr-where-to-store-users-consent
+ *
+ * @ApiResource(
+ *   collectionOperations={
+ *     "me_optin_consents"={
+ *       "method"="GET",
+ *       "path"="/me/optin-consents",
+ *       "controller"=MyOptinConsents::class
+ *     },
+ *     "update_optin_consents"={
+ *       "method"="PUT",
+ *       "path"="/me/optin-consents",
+ *       "controller"=UpdateOptinConsent::class
+ *     }
+ *   }
+ * )
  */
 class OptinConsent
 {

--- a/src/Entity/OptinConsent.php
+++ b/src/Entity/OptinConsent.php
@@ -12,6 +12,8 @@ class OptinConsent
     private $type;
     private $createdAt;
     private $withdrawedAt;
+    private $accepted;
+    private $asked;
 
     /**
      * @return mixed
@@ -97,6 +99,46 @@ class OptinConsent
     public function setWithdrawedAt($withdrawedAt)
     {
         $this->withdrawedAt = $withdrawedAt;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAccepted()
+    {
+        return $this->accepted;
+    }
+
+    /**
+     * @param mixed $accepted
+     *
+     * @return self
+     */
+    public function setAccepted($accepted)
+    {
+        $this->accepted = $accepted;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAsked()
+    {
+        return $this->asked;
+    }
+
+    /**
+     * @param mixed $asked
+     *
+     * @return self
+     */
+    public function setAsked($asked)
+    {
+        $this->asked = $asked;
 
         return $this;
     }

--- a/src/EventListener/RegistrationListener.php
+++ b/src/EventListener/RegistrationListener.php
@@ -48,9 +48,12 @@ class RegistrationListener implements EventSubscriberInterface
         }
 
         foreach(Optin::values() as $optin) {
-            if ($form->has($optin->getValue()) && $form->get($optin->getValue())->getData()) {
+            if ($form->has($optin->getValue())) {
                 $consent = new OptinConsent();
+
                 $consent->setType($optin->getKey());
+                $consent->setAsked(true);
+                $consent->setAccepted($form->get($optin->getValue())->getData());
 
                 $user->addOptinConsent($consent);
             }

--- a/src/Resources/config/doctrine/OptinConsent.orm.xml
+++ b/src/Resources/config/doctrine/OptinConsent.orm.xml
@@ -9,6 +9,16 @@
       <gedmo:timestampable on="create"/>
     </field>
     <field name="withdrawedAt" type="datetime" column="withdrawed_at" nullable="true"/>
+    <field name="accepted" type="boolean" column="accepted" nullable="false">
+      <options>
+        <option name="default">0</option>
+      </options>
+    </field>
+    <field name="asked" type="boolean" column="asked" nullable="false">
+      <options>
+        <option name="default">0</option>
+      </options>
+    </field>
     <many-to-one field="user" target-entity="AppBundle\Entity\User" inversed-by="optinConsents">
       <join-columns>
         <join-column name="user_id" referenced-column-name="id"/>

--- a/templates/index/index.html.twig
+++ b/templates/index/index.html.twig
@@ -88,6 +88,9 @@
   {% endfor %}
 {% endif %}
 
+<div id="optins" data-brand-name={{coopcycle_setting('brand_name')}}>
+</div>
+
 {% endblock %}
 
 {% block styles %}
@@ -99,4 +102,5 @@
   {{ encore_entry_script_tags('search-address') }}
   {{ encore_entry_script_tags('restaurant-list') }}
   {{ encore_entry_script_tags('delivery-homepage') }}
+  {{ encore_entry_script_tags('optins') }}
 {% endblock %}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,7 @@ Encore
   .addEntry('metrics', './js/app/metrics/index.js')
   .addEntry('metrics-admin', './js/app/metrics/admin.js')
   .addEntry('metrics-loopeat', './js/app/metrics/loopeat.js')
+  .addEntry('optins', './js/app/optins/index.js')
   .addEntry('order', './js/app/order/index.js')
   .addEntry('product-form', './js/app/product/form.js')
   .addEntry('product-list', './js/app/product/list.js')


### PR DESCRIPTION
- [x] Add migration to insert Marketing and Newsletter optins to all existing users (except for admin, courier, store, and restaurant users)
- [x] Add new fields `asked` and `accepted` to `OptinConsent`
- [x] Allow GET and PUT operations for OptinConsents at `/api/me`
- [x] Add React component to handle OptinConsents
- [x] New React component should check if there is any OptinConsent to ask for
- [x] New React component should update the OptinConsent after user accepts or rejects it
- [x] Export feature should export only users who have accepted the Optin
- [x] `RegistrationListener` should save always the Optin and set the correct value for new field `accepted` (`asked` has to be always setted to `true` after a registration)

With this PR now we are able to ask for optin consents to existing users:
https://user-images.githubusercontent.com/4819244/157557840-2ae862a8-9e39-495f-9ea6-3bd2ad69233b.mp4