### PR TITLE
Return facets property in restaurant list API response

### DIFF
--- a/features/fixtures/ORM/restaurants.yml
+++ b/features/fixtures/ORM/restaurants.yml
@@ -23,6 +23,12 @@ AppBundle\Entity\Address:
     streetAddress: '17, rue Milton 75009 Paris 9ème'
     geo: "@geo_3"
 
+AppBundle\Entity\Cuisine:
+  cuisine_asian:
+    name: 'asian'
+  cuisine_italian:
+    name: 'italian'
+
 AppBundle\Entity\Contract:
   contract_1:
     flatDeliveryPrice: 350
@@ -66,6 +72,10 @@ AppBundle\Entity\LocalBusiness:
     productOptions:
       - '@pizza_topping'
       - '@gluten_intolerance'
+    servesCuisine:
+      - '@cuisine_asian'
+    featured: true
+    exclusive: true
   restaurant_2:
     name: 'Café Barjot'
     address: "@address_2"

--- a/features/restaurants.feature
+++ b/features/restaurants.feature
@@ -19,6 +19,11 @@ Feature: Manage restaurants
       "hydra:member":[
         {
           "@id":"/api/restaurants/1",
+          "facets": {
+            "category":["exclusive","featured"],
+            "cuisine":["Asiatique"],
+            "type":"Restaurant"
+          },
           "@*@": "@*@"
         },
         {

--- a/features/restaurants.feature
+++ b/features/restaurants.feature
@@ -97,7 +97,10 @@ Feature: Manage restaurants
           "specialOpeningHoursSpecification":[],
           "image":@string@,
           "fulfillmentMethods":@array@,
-          "isOpen":true
+          "isOpen":true,
+          "facets": {
+            "@*@": "@*@"
+          }
         }
       ],
       "hydra:totalItems":1,

--- a/features/restaurants.feature
+++ b/features/restaurants.feature
@@ -20,7 +20,7 @@ Feature: Manage restaurants
         {
           "@id":"/api/restaurants/1",
           "facets": {
-            "category":["exclusive","featured"],
+            "category":["Exclusivités","À la une"],
             "cuisine":["Asiatique"],
             "type":"Restaurant"
           },

--- a/src/Entity/LocalBusiness.php
+++ b/src/Entity/LocalBusiness.php
@@ -52,7 +52,7 @@ use Vich\UploaderBundle\Mapping\Annotation as Vich;
  *     "get"={
  *       "method"="GET",
  *       "pagination_enabled"=false,
- *       "normalization_context"={"groups"={"restaurant", "address", "order"}}
+ *       "normalization_context"={"groups"={"restaurant", "address", "order", "restaurant_list"}}
  *     },
  *     "me_restaurants"={
  *       "method"="GET",
@@ -941,5 +941,44 @@ class LocalBusiness extends BaseLocalBusiness implements
         $this->enBoitLePlatEnabled = $enabled;
 
         return $this;
+    }
+
+    /**
+     * @SerializedName("facets")
+     * @Groups("restaurant_list")
+     */
+    public function getFacets()
+    {
+        $facets = [
+            'category' => [],
+            'cuisine'  => [],
+            'type'     => [],
+        ];
+
+        if ($this->isExclusive()) {
+            $facets['category'][] = 'exclusive';
+        }
+
+        if ($this->isFeatured()) {
+            $facets['category'][] = 'featured';
+        }
+
+        if ($this->isZeroWaste()) {
+            $facets['category'][] = 'zero_waste';
+        }
+
+        foreach ($this->getServesCuisine() as $cuisine) {
+            $facets['cuisine'][] = $cuisine->getName();
+        }
+
+        $facets['type'] = $this->getType();
+
+        return $facets;
+    }
+
+
+    public function isZeroWaste()
+    {
+        return $this->isDepositRefundEnabled() || $this->isLoopeatEnabled();
     }
 }

--- a/src/Serializer/RestaurantNormalizer.php
+++ b/src/Serializer/RestaurantNormalizer.php
@@ -16,6 +16,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 use Vich\UploaderBundle\Templating\Helper\UploaderHelper;
 use Carbon\Carbon;
 
@@ -39,6 +40,7 @@ class RestaurantNormalizer implements NormalizerInterface, DenormalizerInterface
         PriceFormatter $priceFormatter,
         SlugifyInterface $slugify,
         FilterService $imagineFilter,
+        TranslatorInterface $translator,
         string $locale)
     {
         $this->normalizer = $normalizer;
@@ -49,6 +51,7 @@ class RestaurantNormalizer implements NormalizerInterface, DenormalizerInterface
         $this->priceFormatter = $priceFormatter;
         $this->slugify = $slugify;
         $this->imagineFilter = $imagineFilter;
+        $this->translator = $translator;
         $this->locale = $locale;
     }
 
@@ -95,6 +98,14 @@ class RestaurantNormalizer implements NormalizerInterface, DenormalizerInterface
         $data['isOpen'] = $isOpen;
         if (!$isOpen) {
             $data['nextOpeningDate'] = $object->getNextOpeningDate();
+        }
+
+        if (isset($data['facets'])) {
+            $cuisines = array_map(fn ($c) => $this->translator->trans($c, [], 'cuisines'), $data['facets']['cuisine']);
+            $data['facets']['cuisine'] = $cuisines;
+
+            $data['facets']['type'] =
+                $this->translator->trans(LocalBusiness::getTransKeyForType($data['facets']['type']));
         }
 
         return $data;

--- a/src/Serializer/RestaurantNormalizer.php
+++ b/src/Serializer/RestaurantNormalizer.php
@@ -101,11 +101,16 @@ class RestaurantNormalizer implements NormalizerInterface, DenormalizerInterface
         }
 
         if (isset($data['facets'])) {
-            $cuisines = array_map(fn ($c) => $this->translator->trans($c, [], 'cuisines'), $data['facets']['cuisine']);
+            $cuisines =
+                array_map(fn ($c) => $this->translator->trans($c, [], 'cuisines'), $data['facets']['cuisine']);
             $data['facets']['cuisine'] = $cuisines;
 
             $data['facets']['type'] =
                 $this->translator->trans(LocalBusiness::getTransKeyForType($data['facets']['type']));
+
+            $categories =
+                array_map(fn ($c) => $this->translator->trans(sprintf('homepage.%s', $c)), $data['facets']['category']);
+            $data['facets']['category'] = $categories;
         }
 
         return $data;


### PR DESCRIPTION
Fist step for #3188, this adds a `facets` property to every restaurant entry, so that search filters can be implemented client-side. To ease client-side usage, it returns translated values out of the box. 

### TODO
- [x] Return translated values for the `category` facet
- [ ] Use the `Accept-Language` HTTP header to resolve the locale