### PR TITLE
Autoload previous pages for infinite scroll

### DIFF
--- a/js/app/restaurant/list.js
+++ b/js/app/restaurant/list.js
@@ -71,13 +71,14 @@ const Paginator = ({ page, pages }) => {
 
   const loadPage = (page, onSuccess) => {
     const searchParams = new URLSearchParams(window.location.search)
-    searchParams.set("page", page);
+    searchParams.set("page", page)
+    const url = `${window.location.pathname}?${searchParams.toString()}`
     $.ajax({
-      url : window.location.pathname + '?' + searchParams.toString(),
+      url,
       type: 'GET',
       cache: false,
       success: function(data) {
-        onSuccess(data)
+        onSuccess(url, data)
       }
     })
   }
@@ -88,9 +89,10 @@ const Paginator = ({ page, pages }) => {
 
       if (newPage > currentPage) {
         setLoading(true)
-        loadPage(newPage, (data) => {
+        loadPage(newPage, (path, data) => {
           shopsEl.append($.parseHTML(data.rendered_list))
             setTimeout(() => {
+              window.history.replaceState({path}, '', path)
               setCurrentPage(newPage)
               setLoading(false)
             }, 100)
@@ -110,20 +112,20 @@ const Paginator = ({ page, pages }) => {
       times(page - 1, (num) => {
         // num is an index, from 0 to the previous page number to last page seen
         const newPage = page - (num + 1) // we want to load from the begining 1,2,etc until last page seen
-        loadPage(newPage, (data) => {
+        loadPage(newPage, (_url, data) => {
           shopsEl.prepend($.parseHTML(data.rendered_list))
-            if ((num + 1) === (page - 1)) {
-              // we have loaded all previous pages
-              $("#shops-list").show()
-              // without this timeout the rendering of Paginator behaves weird
-              setTimeout(() => {
-                setCurrentPage(page)
-                setLoadingPrevious(false)
-                setLoading(false)
-                // auto scroll to last scroll position
-                window.scrollTo({ top: localStorage.getItem("shops-lastScrollPos"), behavior: 'smooth' })
-              }, 100)
-            }
+          if ((num + 1) === (page - 1)) {
+            // we have loaded all previous pages
+            $("#shops-list").show()
+            // without this timeout the rendering of Paginator behaves weird
+            setTimeout(() => {
+              setCurrentPage(page)
+              setLoadingPrevious(false)
+              setLoading(false)
+              // auto scroll to last scroll position
+              window.scrollTo({ top: localStorage.getItem("shops-lastScrollPos"), behavior: 'smooth' })
+            }, 100)
+          }
         })
       })
     }

--- a/js/app/restaurant/list.js
+++ b/js/app/restaurant/list.js
@@ -71,15 +71,15 @@ const Paginator = ({ page, pages }) => {
 
   const loadPage = (page, onSuccess) => {
     const searchParams = new URLSearchParams(window.location.search)
-      searchParams.set("page", page);
-      $.ajax({
-        url : window.location.pathname + '?' + searchParams.toString(),
-        type: 'GET',
-        cache: false,
-        success: function(data) {
-          onSuccess(data)
-        }
-      })
+    searchParams.set("page", page);
+    $.ajax({
+      url : window.location.pathname + '?' + searchParams.toString(),
+      type: 'GET',
+      cache: false,
+      success: function(data) {
+        onSuccess(data)
+      }
+    })
   }
 
   const loadMore = () => {


### PR DESCRIPTION
With this PR we are auto loading the pages previously navigated (scrolled) by user when query param `page` is present in the URL and is major than 1 (first page).

After loading all pages we scroll smoothly to the last position where user has been before (at the end of the video you can see this behaviour).

https://user-images.githubusercontent.com/4819244/164297460-51d480d8-9edd-40c0-be74-36a094117ceb.mp4

:warning: Since I don't know if this is the behaviour we want for infinite scroll I added these changes in this new PR different to the infinite scroll ones https://github.com/coopcycle/coopcycle-web/pull/3208

