### PR TITLE
Possibility to change the name of a group

### DIFF
--- a/features/tasks.feature
+++ b/features/tasks.feature
@@ -1560,6 +1560,61 @@ Feature: Tasks
       }
       """
 
+  Scenario: Create and update task group
+    Given the fixtures files are loaded:
+      | dispatch.yml        |
+    And the user "bob" has role "ROLE_ADMIN"
+    And the user "bob" is authenticated
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "POST" request to "/api/task_groups" with body:
+      """
+      {
+        "name": "Fancy group",
+        "tasks": [
+          "/api/tasks/1",
+          "/api/tasks/2"
+        ]
+      }
+      """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context":"/api/contexts/TaskGroup",
+        "@id":"/api/task_groups/1",
+        "@type":"TaskGroup",
+        "name":"Fancy group",
+        "tasks":"@array@.count(2)"
+      }
+      """
+    When the user "bob" is authenticated
+    And I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "PUT" request to "/api/task_groups/1" with body:
+      """
+      {
+        "name": "New name group",
+        "tasks": [
+          "/api/tasks/1",
+          "/api/tasks/2"
+        ]
+      }
+      """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context":"/api/contexts/TaskGroup",
+        "@id":"/api/task_groups/1",
+        "@type":"TaskGroup",
+        "name":"New name group",
+        "tasks":"@array@.count(2)"
+      }
+      """
+
   Scenario: Authorized to retrieve task events
     Given the fixtures files are loaded:
       | sylius_channels.yml |

--- a/js/app/dashboard/components/TaskGroup.js
+++ b/js/app/dashboard/components/TaskGroup.js
@@ -2,15 +2,30 @@ import React from 'react'
 import { withTranslation } from 'react-i18next'
 import Popconfirm from 'antd/lib/popconfirm'
 
+require('gasparesganga-jquery-loading-overlay')
+
 import Task from './Task'
 
 class TaskGroup extends React.Component {
 
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      group: props.group,
+      editName: false,
+      newName: '',
+    }
+
+    this.onEditPressed = this.onEditPressed.bind(this)
+    this.onEditCancelled = this.onEditCancelled.bind(this)
+  }
+
   renderTags() {
-    const { group } = this.props
+    const { group } = this.state
 
     return (
-      <span className="task__tags">
+      <span className="task__tags d-flex mr-2">
         { group.tags.map(tag => (
           <i key={ tag.slug } className="fa fa-circle" style={{ color: tag.color }}></i>
         )) }
@@ -18,8 +33,53 @@ class TaskGroup extends React.Component {
     )
   }
 
+  renderEditNameForm() {
+    return (
+      <form onSubmit={(e) => this.onEditSubmitted(e)} onAbort={e => this.onEditCancelled(e)} className="d-flex flex-grow-1">
+        <input autoFocus type="text" name="group-name" className="mx-2 flex-grow-1 group__editable"
+          value={this.state.newName}
+          onChange={ (e) => this.setState({newName: e.target.value})}
+          onKeyDown={e => e.key === 'Escape' ? this.onEditCancelled(e) : null }>
+        </input>
+        <div className="flex-grow-0">
+          <a role="button" href="#" className="text-reset mr-3"
+            onClick={ e => this.onEditSubmitted(e) }>
+            <i className="fa fa-check"></i>
+          </a>
+          <a role="button" href="#" className="text-reset flex-grow-0"
+            onClick={ e => this.onEditCancelled(e) }>
+            <i className="fa fa-times"></i>
+          </a>
+        </div>
+      </form>
+    )
+  }
+
+  onEditPressed(e, group) {
+    e.preventDefault()
+    this.setState({editName: true, newName: group.name})
+  }
+
+  onEditCancelled(e) {
+    e.preventDefault()
+    this.setState({editName: false})
+  }
+
+  async onEditSubmitted(e) {
+    e.preventDefault()
+    $('.task__draggable').LoadingOverlay('show', {image: false})
+    const group = Object.assign({}, this.state.group, {name: this.state.newName})
+    const updatedGroup = await this.props.onEdit(group)
+    this.setState({
+      group: updatedGroup !== null ? updatedGroup : this.state.group,
+      editName: false
+    }, () => {
+      $('.task__draggable').LoadingOverlay('hide')
+    })
+  }
+
   render() {
-    const { group, tasks } = this.props
+    const { tasks } = this.props
 
     tasks.sort((a, b) => {
       return a.id > b.id ? 1 : -1
@@ -28,26 +88,39 @@ class TaskGroup extends React.Component {
     return (
       <div className="panel panel-default nomargin task__draggable">
         <div className="panel-heading" role="tab">
-          <h4 className="panel-title">
-            <i className="fa fa-folder"></i> <a role="button" data-toggle="collapse" href={ `#task-group-panel-${group.id}` }>
-              { group.name } <span className="badge">{ tasks.length }</span>
-            </a>
-            <Popconfirm
-              placement="left"
-              title={ this.props.t('ADMIN_DASHBOARD_DELETE_GROUP_CONFIRM') }
-              onConfirm={ this.props.onConfirmDelete }
-              okText={ this.props.t('CROPPIE_CONFIRM') }
-              cancelText={ this.props.t('ADMIN_DASHBOARD_CANCEL') }
-              >
-              <a role="button" href="#" className="pull-right"
-                onClick={ e => e.preventDefault() }>
-                <i className="fa fa-trash"></i>
-              </a>
-            </Popconfirm>
-            { this.renderTags() }
+          <h4 className="panel-title d-flex align-items-center">
+            <i className="fa fa-folder flex-grow-0"></i>
+            {
+              !this.state.editName &&
+              <>
+                <a role="button" data-toggle="collapse" href={ `#task-group-panel-${this.state.group.id}` } className="ml-2 flex-grow-1 text-truncate">
+                  { this.state.group.name } <span className="badge">{ tasks.length }</span>
+                </a>
+                { this.renderTags() }
+                <div className="d-flex flex-grow-0">
+                  <a role="button" href="#" className="text-reset mr-2"
+                    onClick={ e => this.onEditPressed(e, this.state.group) }>
+                    <i className="fa fa-pencil"></i>
+                  </a>
+                  <Popconfirm
+                    placement="left"
+                    title={ this.props.t('ADMIN_DASHBOARD_DELETE_GROUP_CONFIRM') }
+                    onConfirm={ this.props.onConfirmDelete }
+                    okText={ this.props.t('CROPPIE_CONFIRM') }
+                    cancelText={ this.props.t('ADMIN_DASHBOARD_CANCEL') }
+                    >
+                    <a role="button" href="#" className="text-reset"
+                      onClick={ e => e.preventDefault() }>
+                      <i className="fa fa-trash"></i>
+                    </a>
+                  </Popconfirm>
+                </div>
+              </>
+            }
+            { this.state.editName && this.renderEditNameForm() }
           </h4>
         </div>
-        <div id={ `task-group-panel-${group.id}` } className="panel-collapse collapse" role="tabpanel">
+        <div id={ `task-group-panel-${this.state.group.id}` } className="panel-collapse collapse" role="tabpanel">
           <ul className="list-group">
             { tasks.map(task => {
               return (

--- a/js/app/dashboard/components/TaskGroup.js
+++ b/js/app/dashboard/components/TaskGroup.js
@@ -24,6 +24,10 @@ class TaskGroup extends React.Component {
   renderTags() {
     const { group } = this.state
 
+    if (!group.tags) {
+      return;
+    }
+
     return (
       <span className="task__tags d-flex mr-2">
         { group.tags.map(tag => (

--- a/js/app/dashboard/components/UnassignedTasks.js
+++ b/js/app/dashboard/components/UnassignedTasks.js
@@ -10,7 +10,7 @@ import Task from './Task'
 import TaskGroup from './TaskGroup'
 import RecurrenceRule from './RecurrenceRule'
 import UnassignedTasksPopoverContent from './UnassignedTasksPopoverContent'
-import { setTaskListGroupMode, openNewTaskModal, toggleSearch, setCurrentRecurrenceRule, openNewRecurrenceRuleModal, deleteGroup, showRecurrenceRules } from '../redux/actions'
+import { setTaskListGroupMode, openNewTaskModal, toggleSearch, setCurrentRecurrenceRule, openNewRecurrenceRuleModal, deleteGroup, editGroup, showRecurrenceRules } from '../redux/actions'
 import { selectGroups, selectStandaloneTasks, selectRecurrenceRules, selectSelectedTasks } from '../redux/selectors'
 
 class StandaloneTasks extends React.Component {
@@ -155,7 +155,8 @@ class UnassignedTasks extends React.Component {
                             key={ group.id }
                             group={ group }
                             tasks={ group.tasks }
-                            onConfirmDelete={ () => this.props.deleteGroup(group) } />
+                            onConfirmDelete={ () => this.props.deleteGroup(group) }
+                            onEdit={ (data) => this.props.editGroup(data) } />
                         </div>
                       )}
                     </Draggable>
@@ -188,6 +189,7 @@ function mapDispatchToProps(dispatch) {
   return {
     setCurrentRecurrenceRule: (recurrenceRule) => dispatch(setCurrentRecurrenceRule(recurrenceRule)),
     deleteGroup: (group) => dispatch(deleteGroup(group)),
+    editGroup: (group) => dispatch(editGroup(group)),
   }
 }
 

--- a/js/app/dashboard/dashboard.scss
+++ b/js/app/dashboard/dashboard.scss
@@ -274,6 +274,11 @@ html, body {
   }
 }
 
+.group__editable {
+  outline: none;
+  border: 0;
+}
+
 .task__highlighted {
   background-color: $yellow!important;
 }

--- a/js/app/dashboard/redux/actions.js
+++ b/js/app/dashboard/redux/actions.js
@@ -158,6 +158,7 @@ export const UPDATE_RECURRENCE_RULE_ERROR = 'UPDATE_RECURRENCE_RULE_ERROR'
 export const SHOW_RECURRENCE_RULES = 'SHOW_RECURRENCE_RULES'
 
 export const DELETE_GROUP_SUCCESS = 'DELETE_GROUP_SUCCESS'
+export const EDIT_GROUP_SUCCESS = 'EDIT_GROUP_SUCCESS'
 
 export const OPEN_CREATE_GROUP_MODAL = 'OPEN_CREATE_GROUP_MODAL'
 export const CLOSE_CREATE_GROUP_MODAL = 'CLOSE_CREATE_GROUP_MODAL'
@@ -1003,6 +1004,42 @@ export function deleteGroup(group) {
       .then(() => dispatch(deleteGroupSuccess(resourceId)))
       // eslint-disable-next-line no-console
       .catch(error => console.log(error))
+  }
+}
+
+export function editGroupSuccess(group) {
+  return { type: EDIT_GROUP_SUCCESS, group }
+}
+
+export function editGroup(group) {
+
+  return function(dispatch, getState) {
+
+    const { jwt } = getState()
+
+    const resourceId = group['@id']
+
+    return createClient(dispatch).request({
+      method: 'put',
+      url: resourceId,
+      headers: {
+        'Authorization': `Bearer ${jwt}`,
+        'Accept': 'application/ld+json',
+        'Content-Type': 'application/ld+json'
+      },
+      data: {
+        name: group.name
+      }
+    })
+      .then((res) => {
+        dispatch(editGroupSuccess())
+        return res.data
+      })
+      .catch(error => {
+        // eslint-disable-next-line no-console
+        console.log(error)
+        return null
+      })
   }
 }
 

--- a/src/Entity/Task/Group.php
+++ b/src/Entity/Task/Group.php
@@ -48,6 +48,11 @@ use Symfony\Component\Validator\Constraints as Assert;
  *       "normalizationContext"={"groups"={"task_group"}},
  *       "security"="is_granted('view', object)"
  *     },
+ *     "put"={
+ *       "method"="PUT",
+ *       "denormalization_context"={"groups"={"task_group"}},
+ *       "security"="is_granted('edit', object)"
+ *     },
  *     "delete"={
  *       "method"="DELETE",
  *       "controller"=DeleteGroupController::class,


### PR DESCRIPTION
This PR adds the possbility to change the name of a group (https://github.com/coopcycle/coopcycle-web/issues/3223)

User can change the name after clicking in the new 'pencil' icon. 
When that icon is pressed, an editable input will be shown where pressing Enter or clicking 'check' icon will submit the action or pressing Escape or clicking 'close' icon will cancel the operation and replace the input with the original group name.

How it works:
https://user-images.githubusercontent.com/4819244/166987819-154fbff4-55d9-4d90-a554-a04c633ca34e.mp4

