### PR TITLE
Append average preparation + shipping time to last time slot

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -45,6 +45,7 @@ parameters:
         - '#Call to an undefined method Symfony\\Component\\Console\\Helper\\HelperInterface::ask\(\)#'
         - '#Cannot use array destructuring on array<int, mixed>\|Doctrine\\ORM\\PersistentCollection#'
         - '#Call to an undefined method Symfony\\Component\\Security\\Http\\Authenticator\\Passport\\PassportInterface::getAttribute\(\).#'
+        - '#Call to an undefined method DateTimeInterface::modify\(\)#'
     universalObjectCratesClasses:
         - MercadoPago\Item
         - MercadoPago\Preference

--- a/src/Service/TimeRegistry.php
+++ b/src/Service/TimeRegistry.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace AppBundle\Service;
+
+use AppBundle\Entity\LocalBusiness;
+use AppBundle\Sylius\Order\OrderFactory;
+use AppBundle\Utils\OrderTimeHelper;
+use Carbon\CarbonInterval;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
+
+class TimeRegistry
+{
+    public function __construct(
+        EntityManagerInterface $entityManager,
+        CacheInterface $projectCache)
+    {
+        $this->entityManager = $entityManager;
+        $this->projectCache = $projectCache;
+    }
+
+    public function getAveragePreparationTime(): int
+    {
+        $sql = 'SELECT ROUND(AVG(EXTRACT(EPOCH FROM TO_CHAR(t.preparation_time::interval, \'HH24:MI\')::interval) / 60)) FROM sylius_order_timeline t JOIN sylius_order o ON t.order_id = o.id WHERE o.state = \'fulfilled\'';
+
+        $stmt = $this->entityManager->getConnection()->prepare($sql);
+        $result = $stmt->executeQuery()->fetchColumn();
+
+        // TODO Cache
+
+        return (int) $result;
+    }
+
+    public function getAverageShippingTime(): int
+    {
+        $sql = 'SELECT ROUND(AVG(tc.duration)) FROM task_collection tc JOIN delivery d ON tc.id = d.id JOIN sylius_order o ON d.order_id = o.id WHERE tc.type = \'delivery\' and o.state = \'fulfilled\'';
+
+        $stmt = $this->entityManager->getConnection()->prepare($sql);
+        $result = $stmt->executeQuery()->fetchColumn();
+
+        $cascade = CarbonInterval::seconds((int) $result)
+            ->cascade()
+            ->toArray();
+
+        // TODO Cache
+
+        return (int) $cascade['minutes'];
+    }
+}

--- a/src/Utils/OrderTimeHelper.php
+++ b/src/Utils/OrderTimeHelper.php
@@ -7,6 +7,7 @@ use AppBundle\Entity\TimeSlot;
 use AppBundle\Form\Type\AsapChoiceLoader;
 use AppBundle\Form\Type\TimeSlotChoiceLoader;
 use AppBundle\Form\Type\TsRangeChoice;
+use AppBundle\Service\TimeRegistry;
 use AppBundle\Sylius\Order\OrderInterface;
 use AppBundle\Utils\DateUtils;
 use AppBundle\Utils\PreparationTimeCalculator;
@@ -31,6 +32,7 @@ class OrderTimeHelper
         PreparationTimeCalculator $preparationTimeCalculator,
         ShippingTimeCalculator $shippingTimeCalculator,
         Redis $redis,
+        TimeRegistry $timeRegistry,
         string $country,
         LoggerInterface $logger = null)
     {
@@ -38,6 +40,7 @@ class OrderTimeHelper
         $this->preparationTimeCalculator = $preparationTimeCalculator;
         $this->shippingTimeCalculator = $shippingTimeCalculator;
         $this->redis = $redis;
+        $this->timeRegistry = $timeRegistry;
         $this->country = $country;
         $this->logger = $logger ?? new NullLogger();
     }
@@ -97,6 +100,7 @@ class OrderTimeHelper
 
             $choiceLoader = new AsapChoiceLoader(
                 $fulfillmentMethod->getOpeningHours(),
+                $this->timeRegistry,
                 $vendor->getClosingRules(),
                 $this->getOrderingDelayMinutes($fulfillmentMethod->getOrderingDelayMinutes()),
                 $fulfillmentMethod->getOption('range_duration', 10),

--- a/tests/AppBundle/Form/Type/AsapChoiceLoaderTest.php
+++ b/tests/AppBundle/Form/Type/AsapChoiceLoaderTest.php
@@ -721,4 +721,40 @@ class AsapChoiceLoaderTest extends TestCase
             ['2017-10-04T17:50:00+02:00', '2017-10-04T18:00:00+02:00'],
         ], $choices);
     }
+
+    public function testSameDayWithPreparationAndShippingOffset()
+    {
+        $this->timeRegistry->getAveragePreparationTime()->willReturn(15);
+        $this->timeRegistry->getAverageShippingTime()->willReturn(15);
+
+        // 2017-10-04 is a Wednesday
+        Carbon::setTestNow(Carbon::parse('2017-10-04T17:30:00+02:00'));
+
+        $choiceLoader = new AsapChoiceLoader(["Mo-Sa 10:00-19:00"], $this->timeRegistry->reveal());
+
+        $choiceList = $choiceLoader->loadChoiceList();
+        $choices = $choiceList->getChoices();
+
+        $this->assertContainsTimeRanges([
+            [ '2017-10-04T17:30:00+02:00', '2017-10-04T17:40:00+02:00' ],
+            [ '2017-10-04T18:00:00+02:00', '2017-10-04T18:10:00+02:00' ],
+            [ '2017-10-04T18:40:00+02:00', '2017-10-04T18:50:00+02:00' ],
+            [ '2017-10-04T18:50:00+02:00', '2017-10-04T19:00:00+02:00' ],
+            [ '2017-10-04T19:00:00+02:00', '2017-10-04T19:10:00+02:00' ],
+            [ '2017-10-04T19:10:00+02:00', '2017-10-04T19:20:00+02:00' ],
+            [ '2017-10-04T19:20:00+02:00', '2017-10-04T19:30:00+02:00' ],
+            [ '2017-10-05T10:00:00+02:00', '2017-10-05T10:10:00+02:00' ],
+        ], $choices);
+
+        $this->assertContainsDays([
+            "2017-10-04",
+            "2017-10-05",
+            "2017-10-06",
+            "2017-10-07",
+            // Sunday
+            "2017-10-09",
+            "2017-10-10",
+            "2017-10-11",
+        ], $choices);
+    }
 }

--- a/tests/AppBundle/Utils/OrderTimeHelperTest.php
+++ b/tests/AppBundle/Utils/OrderTimeHelperTest.php
@@ -7,6 +7,7 @@ use AppBundle\Entity\LocalBusiness\FulfillmentMethod;
 use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\Vendor;
 use AppBundle\Sylius\Order\OrderInterface;
+use AppBundle\Service\TimeRegistry;
 use AppBundle\Utils\OrderTimeHelper;
 use AppBundle\Utils\PreparationTimeCalculator;
 use AppBundle\Utils\ShippingDateFilter;
@@ -32,11 +33,16 @@ class OrderTimeHelperTest extends TestCase
         $this->shippingTimeCalculator = $this->prophesize(ShippingTimeCalculator::class);
         $this->redis = $this->prophesize(Redis::class);
 
+        $this->timeRegistry = $this->prophesize(TimeRegistry::class);
+        $this->timeRegistry->getAveragePreparationTime()->willReturn(0);
+        $this->timeRegistry->getAverageShippingTime()->willReturn(0);
+
         $this->helper = new OrderTimeHelper(
             $this->shippingDateFilter->reveal(),
             $this->preparationTimeCalculator->reveal(),
             $this->shippingTimeCalculator->reveal(),
             $this->redis->reveal(),
+            $this->timeRegistry->reveal(),
             'fr'
         );
     }


### PR DESCRIPTION
Fixes #3009

As a result, (with a average preparation + shipping of 20 minutes in the example below) for a shop that closes at 6:30PM, the last slot ends at 6:50PM


<img width="448" alt="Capture d’écran 2022-05-16 à 17 37 23" src="https://user-images.githubusercontent.com/1162230/168630862-d7c4b507-e0ca-4fee-9903-efba09abb0bf.png">

---

<img width="835" alt="Capture d’écran 2022-05-16 à 17 37 44" src="https://user-images.githubusercontent.com/1162230/168630893-f5f6735e-88a7-4426-baf2-82f73ab2b9e3.png">



