### PR TITLE
Fix task groups

### DIFF
--- a/features/dispatch.feature
+++ b/features/dispatch.feature
@@ -315,6 +315,7 @@ Feature: Dispatch
         "@context":"/api/contexts/TaskGroup",
         "@id":"/api/task_groups/1",
         "@type":"TaskGroup",
+        "id": 1,
         "name":"Fancy group",
         "tasks":"@array@.count(2)"
       }

--- a/features/tasks.feature
+++ b/features/tasks.feature
@@ -327,6 +327,7 @@ Feature: Tasks
           "@context": "\/api\/contexts\/TaskGroup",
           "@id": "\/api\/task_groups\/1",
           "@type": "TaskGroup",
+          "id": 1,
           "name": "Group #1",
           "tasks":"@array@.count(3)"
       }
@@ -355,6 +356,7 @@ Feature: Tasks
         "@context": "/api/contexts/TaskGroup",
         "@id": "/api/task_groups/1",
         "@type": "TaskGroup",
+        "id": 1,
         "name": "Group #1",
         "tasks": []
       }
@@ -1465,6 +1467,7 @@ Feature: Tasks
         "@context":"/api/contexts/TaskGroup",
         "@id":"/api/task_groups/1",
         "@type":"TaskGroup",
+        "id": 1,
         "name":@string@,
         "tasks":[
           "@string@.matchRegex('#/api/tasks/[0-9]+#')",
@@ -1501,6 +1504,7 @@ Feature: Tasks
         "@context":"/api/contexts/TaskGroup",
         "@id":"/api/task_groups/1",
         "@type":"TaskGroup",
+        "id": 1,
         "name":@string@,
         "tasks":[
           "@string@.matchRegex('#/api/tasks/[0-9]+#')"
@@ -1596,6 +1600,7 @@ Feature: Tasks
         "@context":"/api/contexts/TaskGroup",
         "@id":"/api/task_groups/1",
         "@type":"TaskGroup",
+        "id": 1,
         "name":@string@,
         "tasks":[
           "@string@.matchRegex('#/api/tasks/[0-9]+#')",
@@ -1684,6 +1689,7 @@ Feature: Tasks
         "@context":"/api/contexts/TaskGroup",
         "@id":"/api/task_groups/1",
         "@type":"TaskGroup",
+        "id": 1,
         "name":"Fancy group",
         "tasks":"@array@.count(2)"
       }
@@ -1709,6 +1715,7 @@ Feature: Tasks
         "@context":"/api/contexts/TaskGroup",
         "@id":"/api/task_groups/1",
         "@type":"TaskGroup",
+        "id": 1,
         "name":"New name group",
         "tasks":"@array@.count(2)"
       }
@@ -1739,6 +1746,7 @@ Feature: Tasks
         "@context":"/api/contexts/TaskGroup",
         "@id":"/api/task_groups/1",
         "@type":"TaskGroup",
+        "id": 1,
         "name":"Fancy group",
         "tasks":"@array@.count(2)"
       }
@@ -1764,6 +1772,7 @@ Feature: Tasks
         "@context":"/api/contexts/TaskGroup",
         "@id":"/api/task_groups/1",
         "@type":"TaskGroup",
+        "id": 1,
         "name":"New name group",
         "tasks":"@array@.count(2)"
       }

--- a/js/app/dashboard/components/ContextMenu.js
+++ b/js/app/dashboard/components/ContextMenu.js
@@ -6,7 +6,7 @@ import { Menu, Item } from 'react-contexify'
 
 import moment from 'moment'
 
-import { unassignTasks, cancelTasks, moveToTop, moveToBottom, moveTasksToNextDay, moveTasksToNextWorkingDay, openCreateGroupModal, openAddTaskToGroupModal, removeTaskFromGroup } from '../redux/actions'
+import { unassignTasks, cancelTasks, moveToTop, moveToBottom, moveTasksToNextDay, moveTasksToNextWorkingDay, openCreateGroupModal, openAddTaskToGroupModal, removeTasksFromGroup } from '../redux/actions'
 import { selectNextWorkingDay, selectSelectedTasks } from '../redux/selectors'
 
 const UNASSIGN_SINGLE = 'UNASSIGN_SINGLE'
@@ -32,7 +32,7 @@ function _unassign(tasksToUnassign, unassignTasks) {
 const DynamicMenu = ({
   unassignedTasks, selectedTasks, nextWorkingDay,
   unassignTasks, cancelTasks, moveToTop, moveToBottom, moveTasksToNextDay, moveTasksToNextWorkingDay,
-  openCreateGroupModal, openAddTaskToGroupModal, removeTaskFromGroup
+  openCreateGroupModal, openAddTaskToGroupModal, removeTasksFromGroup
 }) => {
 
   const { t } = useTranslation()
@@ -159,7 +159,7 @@ const DynamicMenu = ({
       </Item>
       <Item
         hidden={ !actions.includes(REMOVE_FROM_GROUP) }
-        onClick={ () => removeTaskFromGroup(selectedTasks) }
+        onClick={ () => removeTasksFromGroup(selectedTasks) }
       >
         { t('ADMIN_DASHBOARD_REMOVE_FROM_GROUP') }
       </Item>
@@ -191,7 +191,7 @@ function mapDispatchToProps(dispatch) {
     moveTasksToNextWorkingDay: tasks => dispatch(moveTasksToNextWorkingDay(tasks)),
     openCreateGroupModal: () => dispatch(openCreateGroupModal()),
     openAddTaskToGroupModal: tasks => dispatch(openAddTaskToGroupModal(tasks)),
-    removeTaskFromGroup: tasks => dispatch(removeTaskFromGroup(tasks)),
+    removeTasksFromGroup: tasks => dispatch(removeTasksFromGroup(tasks)),
   }
 }
 

--- a/js/app/dashboard/redux/actions.js
+++ b/js/app/dashboard/redux/actions.js
@@ -166,8 +166,10 @@ export const CLOSE_CREATE_GROUP_MODAL = 'CLOSE_CREATE_GROUP_MODAL'
 export const OPEN_ADD_TASK_TO_GROUP_MODAL = 'OPEN_ADD_TASK_TO_GROUP_MODAL'
 export const CLOSE_ADD_TASK_TO_GROUP_MODAL = 'CLOSE_ADD_TASK_TO_GROUP_MODAL'
 export const ADD_TASK_TO_GROUP_REQUEST = 'ADD_TASK_TO_GROUP_REQUEST'
+export const ADD_TASKS_TO_GROUP_SUCCESS = 'ADD_TASKS_TO_GROUP_SUCCESS'
 
 export const REMOVE_TASK_FROM_GROUP_REQUEST = 'REMOVE_TASK_FROM_GROUP_REQUEST'
+export const REMOVE_TASKS_FROM_GROUP_SUCCESS = 'REMOVE_TASKS_FROM_GROUP_SUCCESS'
 
 export const CREATE_GROUP_REQUEST = 'CREATE_GROUP_REQUEST'
 export const CREATE_GROUP_SUCCESS = 'CREATE_GROUP_SUCCESS'
@@ -1219,6 +1221,10 @@ export function addTaskToGroupRequest() {
   return { type: ADD_TASK_TO_GROUP_REQUEST }
 }
 
+export function addTasksToGroupSuccess(tasks, taskGroup) {
+  return { type: ADD_TASKS_TO_GROUP_SUCCESS, tasks, taskGroup }
+}
+
 export function openAddTaskToGroupModal() {
   return { type: OPEN_ADD_TASK_TO_GROUP_MODAL }
 }
@@ -1249,13 +1255,7 @@ export function addTasksToGroup(tasks, taskGroup) {
     })
       .then(() => {
         dispatch(closeAddTaskToGroupModal())
-        tasks.forEach((task) => {
-          const taskWithGroup = {
-            ...task,
-            group: taskGroup
-          }
-          dispatch(_updateTask(taskWithGroup))
-        })
+        dispatch(addTasksToGroupSuccess(tasks, taskGroup))
         dispatch(clearSelectedTasks())
       })
       // eslint-disable-next-line no-console
@@ -1263,17 +1263,21 @@ export function addTasksToGroup(tasks, taskGroup) {
   }
 }
 
-export function removeTaskFromGroupRequest() {
+export function removeTasksFromGroupRequest() {
   return { type: REMOVE_TASK_FROM_GROUP_REQUEST }
 }
 
-export function removeTaskFromGroup(tasks) {
+export function removeTasksFromGroupSuccess(tasks) {
+  return { type: REMOVE_TASKS_FROM_GROUP_SUCCESS, tasks }
+}
+
+export function removeTasksFromGroup(tasks) {
 
   return function(dispatch, getState) {
 
     const { jwt } = getState()
 
-    dispatch(removeTaskFromGroupRequest())
+    dispatch(removeTasksFromGroupRequest())
 
     const requests = tasks.map((task) => {
       return createClient(dispatch).request({
@@ -1289,13 +1293,7 @@ export function removeTaskFromGroup(tasks) {
 
     Promise.all(requests)
       .then(() => {
-        tasks.forEach((task) => {
-          const taskWithoutGroup = {
-            ...task,
-            group: null
-          }
-          dispatch(_updateTask(taskWithoutGroup))
-        })
+        dispatch(removeTasksFromGroupSuccess(tasks))
       })
       // eslint-disable-next-line no-console
       .catch(error => console.log(error))

--- a/js/app/dashboard/redux/taskEntityReducers.js
+++ b/js/app/dashboard/redux/taskEntityReducers.js
@@ -6,6 +6,8 @@ import {
   DELETE_GROUP_SUCCESS,
   REMOVE_TASK,
   CREATE_GROUP_SUCCESS,
+  REMOVE_TASKS_FROM_GROUP_SUCCESS,
+  ADD_TASKS_TO_GROUP_SUCCESS,
 } from './actions'
 import { taskAdapter } from '../../coopcycle-frontend-js/logistics/redux'
 
@@ -54,6 +56,23 @@ export default (state = initialState, action) => {
       }
 
       return taskAdapter.upsertMany(state, tasksMatchingCreatedGroup.map(t => ({
+        ...t,
+        group: _.pickBy({
+          ...action.taskGroup,
+          tags: [],
+        }, (value, key) => key !== 'tasks')
+      })))
+
+    case REMOVE_TASKS_FROM_GROUP_SUCCESS:
+
+      return taskAdapter.upsertMany(state, action.tasks.map(t => ({
+        ...t,
+        group: null
+      })))
+
+    case ADD_TASKS_TO_GROUP_SUCCESS:
+
+      return taskAdapter.upsertMany(state, action.tasks.map(t => ({
         ...t,
         group: _.pickBy({
           ...action.taskGroup,

--- a/src/Entity/Task/Group.php
+++ b/src/Entity/Task/Group.php
@@ -76,7 +76,7 @@ class Group implements TaggableInterface
     use TaggableTrait;
 
     /**
-     * @Groups({"task"})
+     * @Groups({"task", "task_group"})
      */
     protected $id;
 


### PR DESCRIPTION
Closes #3251 

Now new groups are visible.
Rendering of TaskGroup wasn't working because after creating a group we weren't sending its ID and we use it as the key to loop all the groups.

https://user-images.githubusercontent.com/4819244/171052049-1ca21820-6876-44d4-bc70-7e900575a30c.mp4

