### PR TITLE
Editing issues when recurrent task and task address edit

### DIFF
--- a/src/Doctrine/EventSubscriber/TaskSubscriber.php
+++ b/src/Doctrine/EventSubscriber/TaskSubscriber.php
@@ -161,7 +161,7 @@ class TaskSubscriber implements EventSubscriber
 
                     if (isset($entityChangeset['streetAddress'])) {
                         [$oldValue, $newValue] = $entityChangeset['streetAddress'];
-                        if ($oldValue && !empty($oldValue) && $newValue && !empty($newValue) && $oldValue !== $newValue) {
+                        if (!empty($oldValue) && !empty($newValue) && $oldValue !== $newValue) {
                             $taskAddress = $this->geocoder->geocode($newValue, $taskAddress);
 
                             $newAddress = $taskAddress->clone();

--- a/src/Doctrine/EventSubscriber/TaskSubscriber.php
+++ b/src/Doctrine/EventSubscriber/TaskSubscriber.php
@@ -5,11 +5,14 @@ namespace AppBundle\Doctrine\EventSubscriber;
 use AppBundle\Doctrine\EventSubscriber\TaskSubscriber\EntityChangeSetProcessor;
 use AppBundle\Domain\EventStore;
 use AppBundle\Domain\Task\Event\TaskCreated;
+use AppBundle\Entity\Address;
 use AppBundle\Entity\Task;
+use AppBundle\Service\Geocoder;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Events;
+use Doctrine\ORM\UnitOfWork;
 use Psr\Log\LoggerInterface;
 use SimpleBus\Message\Bus\MessageBus;
 use Symfony\Component\Messenger\MessageBusInterface;
@@ -23,17 +26,22 @@ class TaskSubscriber implements EventSubscriber
 
     private $createdTasks = [];
     private $postFlushEvents = [];
+    private $createdAddresses;
 
     public function __construct(
         MessageBus $eventBus,
         EventStore $eventStore,
         EntityChangeSetProcessor $processor,
-        LoggerInterface $logger)
+        LoggerInterface $logger,
+        Geocoder $geocoder)
     {
         $this->eventBus = $eventBus;
         $this->eventStore = $eventStore;
         $this->processor = $processor;
         $this->logger = $logger;
+        $this->geocoder = $geocoder;
+
+        $this->createdAddresses = new \SplObjectStorage();
     }
 
     public function getSubscribedEvents()
@@ -50,6 +58,7 @@ class TaskSubscriber implements EventSubscriber
         $this->createdTasks = [];
         $this->postFlushEvents = [];
         $this->processor->eraseMessages();
+        $this->createdAddresses = new \SplObjectStorage();
 
         $em = $args->getEntityManager();
         $uow = $em->getUnitOfWork();
@@ -74,6 +83,8 @@ class TaskSubscriber implements EventSubscriber
         if (count($tasksToInsert) > 0) {
             $uow->computeChangeSets();
         }
+
+        $this->handleAddressesChangesForTasks($uow, $tasksToUpdate, $this->createdAddresses);
 
         $tasks = array_merge($tasksToInsert, $tasksToUpdate);
 
@@ -102,6 +113,15 @@ class TaskSubscriber implements EventSubscriber
 
     public function postFlush(PostFlushEventArgs $args)
     {
+        $em = $args->getEntityManager();
+        foreach ($this->createdAddresses as $address) {
+            $em->persist($address);
+            $item = $this->createdAddresses[$address];
+            $task = $item['task'];
+            $task->setAddress($address);
+            $em->flush();
+        }
+
         $this->logger->debug(sprintf('There are %d "task:created" events to handle', count($this->createdTasks)));
         foreach ($this->createdTasks as $task) {
             $this->eventBus->handle(new TaskCreated($task));
@@ -116,5 +136,48 @@ class TaskSubscriber implements EventSubscriber
         $this->createdTasks = [];
         $this->postFlushEvents = [];
         $this->processor->eraseMessages();
+    }
+
+    /**
+     * When a task's address is modified, we need to create a new address, instead of updating the existing address.
+     * See https://github.com/coopcycle/coopcycle-web/issues/3306
+     */
+    private function handleAddressesChangesForTasks(UnitOfWork $uow, array $tasksToUpdate, \SplObjectStorage $createdAddresses)
+    {
+        $isAddress = function ($entity) {
+            return $entity instanceof Address;
+        };
+
+        $addressesToUpdate = array_filter($uow->getScheduledEntityUpdates(), $isAddress);
+
+        if (count($tasksToUpdate) > 0 && count($addressesToUpdate) > 0) {
+
+            foreach ($tasksToUpdate as $task) {
+                $index = array_search($task->getAddress(), $addressesToUpdate);
+
+                if ($index) {
+                    $taskAddress = $addressesToUpdate[$index];
+                    $entityChangeset = $uow->getEntityChangeSet($taskAddress);
+
+                    if (isset($entityChangeset['streetAddress'])) {
+                        [$oldValue, $newValue] = $entityChangeset['streetAddress'];
+                        if ($oldValue && !empty($oldValue) && $newValue && !empty($newValue) && $oldValue !== $newValue) {
+                            $taskAddress = $this->geocoder->geocode($newValue, $taskAddress);
+
+                            $newAddress = $taskAddress->clone();
+
+                            $uow->detach($taskAddress); // do not impact updates on previous task
+
+                            $createdAddresses[$newAddress] = [
+                                'task' => $task
+                            ];
+                        }
+                    }
+
+                }
+
+            }
+
+        }
     }
 }

--- a/src/Entity/Address.php
+++ b/src/Entity/Address.php
@@ -152,4 +152,24 @@ class Address extends BaseAddress
 
         return $this;
     }
+
+    public function clone()
+    {
+        $address = new Address();
+
+        $address->setDescription($this->description);
+        $address->setCompany($this->company);
+        $address->setContactName($this->contactName);
+        $address->setGeo($this->getGeo());
+        $address->setStreetAddress($this->streetAddress);
+        $address->setAddressLocality($this->addressLocality);
+        $address->setAddressCountry($this->addressCountry);
+        $address->setAddressRegion($this->addressRegion);
+        $address->setPostOfficeBoxNumber($this->postOfficeBoxNumber);
+        $address->setTelephone($this->telephone);
+        $address->setName($this->getName());
+        $address->setPostalCode($this->postalCode);
+
+        return $address;
+    }
 }

--- a/src/Service/Geocoder.php
+++ b/src/Service/Geocoder.php
@@ -121,7 +121,7 @@ class Geocoder
     /**
      * @return Address|null
      */
-    public function geocode($value)
+    public function geocode($value, $address = null)
     {
         $query = GeocodeQuery::create($value);
 
@@ -150,7 +150,9 @@ class Geocoder
 
             [ $longitude, $latitude ] = $result->getCoordinates()->toArray();
 
-            $address = new Address();
+            if (!$address) {
+                $address = new Address();
+            }
             $address->setGeo(new GeoCoordinates($latitude, $longitude));
             $address->setStreetAddress($this->formatAddress($result));
             $address->setAddressLocality($result->getLocality());

--- a/tests/AppBundle/Doctrine/EventSubscriber/TaskSubscriberTest.php
+++ b/tests/AppBundle/Doctrine/EventSubscriber/TaskSubscriberTest.php
@@ -12,6 +12,7 @@ use AppBundle\Domain\Task\Event\TaskUnassigned;
 use AppBundle\Entity\User;
 use AppBundle\Entity\Task;
 use AppBundle\Entity\TaskList;
+use AppBundle\Service\Geocoder;
 use Doctrine\Persistence\ObjectRepository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Event\OnFlushEventArgs;
@@ -69,11 +70,14 @@ class TaskSubscriberTest extends TestCase
         $taskListProvider = new TaskListProvider($this->entityManager->reveal());
         $changeSetProcessor = new EntityChangeSetProcessor($taskListProvider);
 
+        $this->geocoder = $this->prophesize(Geocoder::class);
+
         $this->subscriber = new TaskSubscriber(
             $this->eventBus->reveal(),
             $eventStore,
             $changeSetProcessor,
-            new NullLogger()
+            new NullLogger(),
+            $this->geocoder->reveal()
         );
     }
 


### PR DESCRIPTION
Fixes #3306 

- [x] Make sure that address is updated when editing a recurrent rule, using duplication. We need to keep the previous address untouched, and recreated a new address, to avoid losing the database links.

- [x] When editing a task's address, we are actually modifying the address object in database. All other tasks that are linked to this address would have their address modified as well. For most users, when they modify the address of a task, it's not obvious that they will modify all other tasks. So, when a task's address is modified, we need to create a new address, instead of updating the existing address.
