### PR TITLE
Allow admins to select a date in the past when creating a delivery

### DIFF
--- a/js/app/forms/delivery.js
+++ b/js/app/forms/delivery.js
@@ -124,8 +124,7 @@ function getTaskType(name, type) {
   return document.querySelector(`#${name}_${type}_type`).value.toUpperCase()
 }
 
-function createDatePickerWidget(name, type) {
-
+function createDatePickerWidget(name, type, userAdmin) {
   const datePickerEl = document.querySelector(`#${name}_${type}_doneBefore`)
   const timeSlotEl = document.querySelector(`#${name}_${type}_timeSlot`)
 
@@ -156,7 +155,8 @@ function createDatePickerWidget(name, type) {
         taskIndex: getTaskIndex(type),
         value: date.format()
       })
-    }
+    },
+    allowPastDates: userAdmin, // admins are allowed to select a free date range
   })
 }
 
@@ -369,7 +369,7 @@ function createElementFromHTML(htmlString) {
   return div.firstChild;
 }
 
-function initSubForm(name, taskEl, preloadedState) {
+function initSubForm(name, taskEl, preloadedState, userAdmin) {
   const taskForm = taskEl.getAttribute('id').replace(name + '_', '')
   const taskIndex = getTaskIndex(taskForm)
 
@@ -397,7 +397,7 @@ function initSubForm(name, taskEl, preloadedState) {
       }
     }
   })
-  createDatePickerWidget(name, taskForm)
+  createDatePickerWidget(name, taskForm, userAdmin)
 
   const tagsEl = document.querySelector(`#${name}_${taskForm}_tagsAsString`)
   if (tagsEl) {
@@ -480,7 +480,7 @@ export default function(name, options) {
 
     // tasks_0, tasks_1...
     const taskForms = Array.from(el.querySelectorAll('[data-form="task"]'))
-    taskForms.forEach((taskEl) => initSubForm(name, taskEl, preloadedState))
+    taskForms.forEach((taskEl) => initSubForm(name, taskEl, preloadedState, !!el.dataset.userAdmin))
 
     store = createStore(
       reducer, preloadedState,
@@ -543,7 +543,7 @@ export default function(name, options) {
 
         collectionHolder.appendChild(item)
 
-        initSubForm(name, item)
+        initSubForm(name, item, null, !!el.dataset.userAdmin)
 
         collectionHolder.dataset.index++
       })

--- a/js/app/widgets/DateRangePicker.js
+++ b/js/app/widgets/DateRangePicker.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import { render } from 'react-dom'
+import moment from 'moment'
+import { ConfigProvider, DatePicker } from 'antd';
+
+import { timePickerProps } from '../utils/antd'
+
+import 'antd/es/input/style/index.css'
+
+import { antdLocale } from '../i18n'
+
+class DateRangePicker extends React.Component {
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      after: this.props.defaultValue.after,
+      before: this.props.defaultValue.before,
+    }
+
+    this.onChange = this.onChange.bind(this)
+  }
+
+  onChange(value) {
+    // When the input has been cleared
+    if (!value) {
+      return
+    }
+
+    const values = {
+      after: value[0],
+      before: value[1],
+    }
+
+    this.setState(values)
+
+    this.props.onChange(values)
+  }
+
+  render() {
+
+    return (
+      <DatePicker.RangePicker
+        style={{ width: '100%' }}
+        showTime={{
+          ...timePickerProps,
+          hideDisabledOptions: true,
+        }}
+        format="LLL"
+        defaultValue={[ moment(this.state.after), moment(this.state.before) ]}
+        onChange={(value) => this.onChange(value)} />
+    )
+  }
+}
+
+export default function(el, options) {
+
+  const defaultProps = {
+    getDatePickerContainer: null,
+    getTimePickerContainer: null,
+    onChange: () => {}
+  }
+
+  const props = { ...defaultProps, ...options }
+
+  render(
+    <ConfigProvider locale={ antdLocale }>
+      <DateRangePicker { ...props } />
+    </ConfigProvider>, el)
+}

--- a/js/app/widgets/DateTimePicker.js
+++ b/js/app/widgets/DateTimePicker.js
@@ -73,7 +73,7 @@ class DateTimePicker extends React.Component {
   }
 
   disabledDate(date) {
-    if (date) {
+    if (date && !this.props.allowPastDates) {
       return date.isBefore(today)
     }
   }
@@ -107,7 +107,7 @@ class DateTimePicker extends React.Component {
       <div>
         <Form.Item {...formItemProps}>
           <DatePicker
-            disabledDate={this.disabledDate}
+            disabledDate={this.disabledDate.bind(this)}
             onChange={this.onDateChange.bind(this)}
             format={dateFormat}
             placeholder="Date"

--- a/src/Form/DeliveryType.php
+++ b/src/Form/DeliveryType.php
@@ -84,7 +84,15 @@ class DeliveryType extends AbstractType
                 $dropoffBefore = clone $pickupBefore;
                 $dropoffBefore->modify('+1 hour');
 
+                $pickupAfter = clone $pickupBefore;
+                $pickupBefore->modify('-15 minute');
+
+                $dropoffAfter = clone $dropoffBefore;
+                $dropoffAfter->modify('-15 minute');
+
                 $delivery->getPickup()->setDoneBefore($pickupBefore);
+                $delivery->getPickup()->setDoneAfter($pickupAfter);
+                $delivery->getDropoff()->setDoneAfter($dropoffAfter);
                 $delivery->getDropoff()->setDoneBefore($dropoffBefore);
             }
 

--- a/src/Form/DeliveryType.php
+++ b/src/Form/DeliveryType.php
@@ -175,6 +175,12 @@ class DeliveryType extends AbstractType
      */
     private function getTimeSlot(array $options, ?Store $store = null): ?TimeSlot
     {
+        // See https://github.com/coopcycle/coopcycle-web/issues/3465
+        // For admin users we do not show timeslots dropdown, now we show a date picker so they can select a free range
+        if ($this->authorizationChecker->isGranted('ROLE_ADMIN')) { //check if user is administrator
+            return null;
+        }
+
         if (null !== $options['with_time_slot']) {
 
             return $options['with_time_slot'];
@@ -193,6 +199,12 @@ class DeliveryType extends AbstractType
      */
     private function getTimeSlots(array $options, ?Store $store = null)
     {
+        // See https://github.com/coopcycle/coopcycle-web/issues/3465
+        // For admin users we do not show timeslots dropdown, now we show a date picker so they can select a free range
+        if ($this->authorizationChecker->isGranted('ROLE_ADMIN')) { //check if user is administrator
+            return null;
+        }
+
         if (null !== $options['with_time_slots']) {
 
             return $options['with_time_slots'];

--- a/templates/delivery/form.html.twig
+++ b/templates/delivery/form.html.twig
@@ -25,7 +25,7 @@
 {% set delivery = form.vars.value %}
 {% set is_new = delivery.id is null %}
 
-{{ form_start(form, { attr: { 'data-store': delivery.store is not empty ? delivery.store|get_iri_from_item : null } }) }}
+{{ form_start(form, { attr: { 'data-store': delivery.store is not empty ? delivery.store|get_iri_from_item : null, 'data-user-admin': is_granted('ROLE_ADMIN') } }) }}
 
   {% if is_granted('ROLE_ADMIN') and not is_new and delivery.order is not empty %}
     {% include '_partials/delivery/order_alert.html.twig' with { order: delivery.order } %}


### PR DESCRIPTION
Closes #3465 

**Store with timeslot configured. Admin user is able to select a free range**
![Storewithtimeslotconfigured Adminuserisabletoselectafreerange](https://user-images.githubusercontent.com/4819244/202214502-9609327e-8226-4faa-aee4-3247dfe819b9.png)


**Store with timeslot configured. Store user is only able to select a timeslot, not a free range**
![not_admin_timeslot_now_allowed_free_range](https://user-images.githubusercontent.com/4819244/200919364-22e6ed35-9381-4598-8b50-331002519614.png)

**Store without a timeslot configured. Admin user is able to select a free range**
![Storewithoutatimeslotconfigured Adminuserisabletoselectarange](https://user-images.githubusercontent.com/4819244/202214607-ea01a682-01dd-4ea6-bc5d-408816d75bcc.png)


**Store without a timeslot configured. Store user is able to select a range only in the future**
![not_admin_not_allowed_past_dates](https://user-images.githubusercontent.com/4819244/200919380-3647ed0b-cefd-4a58-95ae-9fdf52746cc6.png)