### PR TITLE
fix: search returning disabled restaurants products

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -988,8 +988,8 @@ acseo_typesense:
                     type: string
                     entity_attribute: restaurant.name
                     optional: true
-                enabled:
-                    name: enabled
+                shop_enabled:
+                    name: shop_enabled
                     type: bool
                     entity_attribute: restaurant.enabled
                     optional: true

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -988,6 +988,11 @@ acseo_typesense:
                     type: string
                     entity_attribute: restaurant.name
                     optional: true
+                enabled:
+                    name: enabled
+                    type: bool
+                    entity_attribute: restaurant.enabled
+                    optional: true
             default_sorting_field: sortable_id
             finders:
                 products_autocomplete:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -110,6 +110,7 @@ services:
   ACSEO\TypesenseBundle\Manager\CollectionManager: '@typesense.collection_manager'
   ACSEO\TypesenseBundle\Manager\DocumentManager: '@typesense.document_manager'
   ACSEO\TypesenseBundle\Client\CollectionClient: '@typesense.collection_client'
+  ACSEO\TypesenseBundle\Client\TypesenseClient: '@typesense.client'
 
   AppBundle\Routing\FoodtechEnabledAwareLoader:
     arguments:

--- a/features/search.feature
+++ b/features/search.feature
@@ -62,7 +62,8 @@ Feature: Search
             "shop_id":1,
             "shop_name":"Nodaiwa",
             "sortable_id":1,
-            "result_type":"product"
+            "result_type":"product",
+            "shop_enabled": true
           }
         ],
         "hydra:totalItems":1,

--- a/src/Action/Search/ShopsProducts.php
+++ b/src/Action/Search/ShopsProducts.php
@@ -33,7 +33,7 @@ class ShopsProducts
                 ->addParameter('collection', array_search(LocalBusiness::class, $managedClassNames, true)),
             (new TypesenseQuery($q))
                 ->addParameter('query_by', 'name')
-                ->filterBy('enabled:true')
+                ->filterBy('shop_enabled:true')
                 ->addParameter('collection', array_search(Product::class, $managedClassNames, true))
         ];
 

--- a/src/Action/Search/ShopsProducts.php
+++ b/src/Action/Search/ShopsProducts.php
@@ -33,6 +33,7 @@ class ShopsProducts
                 ->addParameter('collection', array_search(LocalBusiness::class, $managedClassNames, true)),
             (new TypesenseQuery($q))
                 ->addParameter('query_by', 'name')
+                ->filterBy('enabled:true')
                 ->addParameter('collection', array_search(Product::class, $managedClassNames, true))
         ];
 

--- a/src/Doctrine/EventSubscriber/ShopsEventsForTypesenseSubscriber.php
+++ b/src/Doctrine/EventSubscriber/ShopsEventsForTypesenseSubscriber.php
@@ -9,7 +9,7 @@ use AppBundle\Entity\Sylius\Product;
 use AppBundle\Enum\FoodEstablishment;
 use Doctrine\ORM\Events;
 use Doctrine\Common\EventSubscriber;
-use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Psr\Log\LoggerInterface;
 use Gedmo\SoftDeleteable\SoftDeleteableListener;
 use Typesense\Exceptions\ObjectNotFound;
@@ -120,8 +120,8 @@ class ShopsEventsForTypesenseSubscriber implements EventSubscriber
         $entity = $args->getEntity();
 
         if ($entity instanceof LocalBusiness) {
-            $em = $args->getEntityManager();
-            $uow = $em->getUnitOfWork();
+            $om = $args->getObjectManager();
+            $uow = $om->getUnitOfWork();
             $uow->computeChangeSets();
             $changeset = $uow->getEntityChangeSet($entity);
             

--- a/src/Doctrine/EventSubscriber/ShopsEventsForTypesenseSubscriber.php
+++ b/src/Doctrine/EventSubscriber/ShopsEventsForTypesenseSubscriber.php
@@ -92,7 +92,7 @@ class ShopsEventsForTypesenseSubscriber implements EventSubscriber
 
         foreach ($sResults['hits'] as $sResult) {
             $product = $sResult['document'];
-            $product['enabled'] = $enabled;
+            $product['shop_enabled'] = $enabled;
             $productsToUpsert[] = $product;
         }
 

--- a/src/Doctrine/EventSubscriber/ShopsEventsForTypesenseSubscriber.php
+++ b/src/Doctrine/EventSubscriber/ShopsEventsForTypesenseSubscriber.php
@@ -5,6 +5,7 @@ namespace AppBundle\Doctrine\EventSubscriber;
 use ACSEO\TypesenseBundle\Manager\CollectionManager;
 use ACSEO\TypesenseBundle\Manager\DocumentManager;
 use AppBundle\Entity\LocalBusiness;
+use AppBundle\Entity\Sylius\Product;
 use AppBundle\Enum\FoodEstablishment;
 use Doctrine\ORM\Events;
 use Doctrine\Common\EventSubscriber;
@@ -12,24 +13,35 @@ use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Psr\Log\LoggerInterface;
 use Gedmo\SoftDeleteable\SoftDeleteableListener;
 use Typesense\Exceptions\ObjectNotFound;
+use ACSEO\TypesenseBundle\Client\TypesenseClient;
+
 
 class ShopsEventsForTypesenseSubscriber implements EventSubscriber
 {
+    private $typesenseClient;
+    private $productsCollection;
+    private $maxPosts = 250;
+
     public function __construct(
         CollectionManager $collectionManager,
         DocumentManager $documentManager,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        TypesenseClient $typeClient
     )
     {
         $this->logger = $logger;
         $this->collectionManager = $collectionManager;
         $this->documentManager = $documentManager;
+        $this->typesenseClient = $typeClient;
+
+        $this->productsCollection = array_search(Product::class, $this->collectionManager->getManagedClassNames(), true);
     }
 
     public function getSubscribedEvents()
     {
         return array(
             SoftDeleteableListener::POST_SOFT_DELETE,
+            Events::postUpdate,
         );
     }
 
@@ -53,6 +65,75 @@ class ShopsEventsForTypesenseSubscriber implements EventSubscriber
                         $this->logger->error($e->getMessage());
                     }
                 }
+            }
+        }
+    }
+
+    private function updateSearchProductsEnabledStatus($search, $enabled, $page = 1, )
+    {
+        $searchParameters = [
+            'q'         => '*',
+            'query_by'  => 'name', // TypeSense can't search for non string fields...
+            'filter_by' => 'shop_id:=' . $search, //... so we need to filter
+            'per_page' => $this->maxPosts, // max! 
+            'page' => $page,
+        ];
+
+        $sResults = $this->typesenseClient
+            ->collections[$this->productsCollection]
+            ->documents->search($searchParameters);
+
+        // PAGINATION:
+        // `$sResults['found']` is the total count of products found.
+        // `$sResults['hits']` are the products returned (by the query) limited by `per_page`
+        // `$sResults['page']` is the current results page
+        
+        $productsToUpsert = [];
+
+        foreach ($sResults['hits'] as $sResult) {
+            $product = $sResult['document'];
+            $product['enabled'] = $enabled;
+            $productsToUpsert[] = $product;
+        }
+
+        try {
+            $this->typesenseClient
+                ->collections[$this->productsCollection]
+                ->documents
+                ->import($productsToUpsert, ['action' => 'upsert']);
+        } catch (\Exception $e) {
+            $this->logger->error($e->getMessage());
+            
+            // bail early if there was an error, as next request will probably fail
+            return;
+        }
+
+        // If there are more items than the already processed ones
+        // call this method again with updated params
+        if ($sResults['found'] > ($sResults['page'] * $this->maxPosts)) {
+            $this->updateSearchProductsEnabledStatus($search, $enabled, $sResults['page'] + 1);
+        }
+    }
+
+    public function postUpdate(LifecycleEventArgs $args)
+    {
+        $entity = $args->getEntity();
+
+        if ($entity instanceof LocalBusiness) {
+            $em = $args->getEntityManager();
+            $uow = $em->getUnitOfWork();
+            $uow->computeChangeSets();
+            $changeset = $uow->getEntityChangeSet($entity);
+            
+            // LocalBusiness `enabled` status changed, so update it's products
+            // enabled status on the search server.
+            if (isset($changeset['enabled'])) {
+                // the second value of the changeset is the new/current value
+                $isShopEnabled = $changeset['enabled'][1];
+
+                // recursive function that paginates and updates all shop's
+                // products
+                $this->updateSearchProductsEnabledStatus($entity->getId(), $isShopEnabled, 1);
             }
         }
     }


### PR DESCRIPTION
This is done in three steps:

- Add a new `enabled` field to products search index
- Disable/enable products in the search index based on restaurants enabled status. Done in a postUpdate listener *manually* using TypesenseClient.
- Filter products by enabled status.