### PR TITLE
Csv encoding

### DIFF
--- a/src/EventListener/Upload/UploadListener.php
+++ b/src/EventListener/Upload/UploadListener.php
@@ -177,9 +177,21 @@ final class UploadListener
         if (in_array($mimeType, ['text/csv', 'text/plain'])) {
 
             // Make sure the file is in UTF-8
-            $encoding = mb_detect_encoding($fileSystem->read($file->getPathname()), 'UTF-8', true);
+            $encoding = mb_detect_encoding($fileSystem->read($file->getPathname()), ['UTF-8','Windows-1252'], true);
 
             $this->logger->debug(sprintf('UploadListener | encoding = %s', var_export($encoding, true)));
+
+            if ($encoding == 'Windows-1252') {
+                $converted = mb_convert_encoding($fileSystem->read($file->getPathname()), "Windows-1252", "UTF-8");
+                try {
+                    $fileSystem->delete($file->getPathname());
+                } catch (FilesystemException | UnableToDeleteFile $exception) {
+                    $this->logger->debug(sprintf('UploadListener | Could not replace converted'));
+                }
+                $fileSystem->write($file->getPathname(), $converted);
+                $encoding = "UTF-8";
+            }
+
 
             if ($encoding !== 'UTF-8') {
                 $fileSystem->delete($file->getPathname());

--- a/src/EventListener/Upload/UploadListener.php
+++ b/src/EventListener/Upload/UploadListener.php
@@ -181,13 +181,9 @@ final class UploadListener
 
             $this->logger->debug(sprintf('UploadListener | encoding = %s', var_export($encoding, true)));
 
-            if ($encoding == 'Windows-1252') {
+            if ($encoding === 'Windows-1252') {
                 $converted = mb_convert_encoding($fileSystem->read($file->getPathname()), "Windows-1252", "UTF-8");
-                try {
-                    $fileSystem->delete($file->getPathname());
-                } catch (FilesystemException | UnableToDeleteFile $exception) {
-                    $this->logger->debug(sprintf('UploadListener | Could not replace converted'));
-                }
+                $fileSystem->delete($file->getPathname());
                 $fileSystem->write($file->getPathname(), $converted);
                 $encoding = "UTF-8";
             }


### PR DESCRIPTION
Fixes import problem reported as not having UTF8 encoding, turns out some of our Windows PC on México generate CSV files with  Windows1252 encoding. I validate the encoding and convert those files to UTF8.