### PR TITLE
Bulk api operations for tasks

### DIFF
--- a/features/dispatch.feature
+++ b/features/dispatch.feature
@@ -579,3 +579,52 @@ Feature: Dispatch
          "updatedAt":"@string@.isDateTime()"
       }
       """
+
+  Scenario: Administrator can assign multiple tasks at once
+    Given the fixtures files are loaded:
+      | sylius_channels.yml |
+      | dispatch.yml        |
+    And the user "bob" has role "ROLE_ADMIN"
+    And the user "bob" is authenticated
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "PUT" request to "/api/tasks/assign" with body:
+      """
+      {
+        "username": "sarah",
+        "tasks": [
+          "/api/tasks/8",
+          "/api/tasks/9"
+        ]
+      }
+      """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context":"/api/contexts/Task",
+        "@id":"/api/tasks",
+        "@type":"hydra:Collection",
+        "hydra:member": [
+          {
+            "@id":"/api/tasks/8",
+            "@type":"Task",
+            "id":8,
+            "isAssigned":true,
+            "assignedTo":"sarah",
+            "@*@":"@*@"
+          },
+          {
+            "@id":"/api/tasks/9",
+            "@type":"Task",
+            "id":9,
+            "isAssigned":true,
+            "assignedTo":"sarah",
+            "@*@":"@*@"
+          }
+        ],
+        "hydra:totalItems": 2,
+        "@*@":"@*@"
+      }
+      """

--- a/features/fixtures/ORM/tasks.yml
+++ b/features/fixtures/ORM/tasks.yml
@@ -81,3 +81,9 @@ AppBundle\Entity\Tour:
     __calls:
       - addTask: [ "@task_1" ]
       - addTask: [ "@task_2" ]
+
+AppBundle\Entity\TaskImage:
+  image_1:
+    imageName: "abcd1234.jpg"
+  image_2:
+    imageName: "efgh5678.jpg"

--- a/features/tasks.feature
+++ b/features/tasks.feature
@@ -2065,3 +2065,56 @@ Feature: Tasks
           "@*@":"@*@"
         }
       """
+
+  Scenario: Assign images to multiple tasks
+    Given the fixtures files are loaded:
+      | sylius_channels.yml |
+      | tasks.yml           |
+    And the courier "bob" is loaded:
+      | email     | bob@coopcycle.org |
+      | password  | 123456            |
+      | telephone | 0033612345678     |
+    And the user "bob" is authenticated
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "PUT" request to "/api/tasks/images" with body:
+      """
+      {
+        "tasks": [
+          "/api/tasks/1",
+          "/api/tasks/2"
+        ],
+        "images": [
+          "/api/task_images/1",
+          "/api/task_images/2"
+        ]
+      }
+      """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should match:
+      """
+        {
+          "@context":"/api/contexts/Task",
+          "@id":"/api/tasks",
+          "@type":"hydra:Collection",
+          "hydra:member": [
+            {
+              "@id":"/api/tasks/1",
+              "@type":"Task",
+              "id":1,
+              "images": "@array@.count(2)",
+              "@*@":"@*@"
+            },
+            {
+              "@id":"/api/tasks/2",
+              "@type":"Task",
+              "id":2,
+              "images": "@array@.count(2)",
+              "@*@":"@*@"
+            }
+          ],
+          "hydra:totalItems": 2,
+          "@*@":"@*@"
+        }
+      """

--- a/features/tasks.feature
+++ b/features/tasks.feature
@@ -2015,3 +2015,53 @@ Feature: Tasks
         "@*@":"@*@"
       }
       """
+
+  Scenario: Mark multiple tasks as done
+    Given the fixtures files are loaded:
+      | sylius_channels.yml |
+      | tasks.yml           |
+    And the courier "bob" is loaded:
+      | email     | bob@coopcycle.org |
+      | password  | 123456            |
+      | telephone | 0033612345678     |
+    And the user "bob" is authenticated
+    And the tasks with comments matching "#bob" are assigned to "bob"
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "PUT" request to "/api/tasks/done" with body:
+      """
+      {
+        "tasks": [
+          "/api/tasks/1",
+          "/api/tasks/2"
+        ]
+      }
+      """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should match:
+      """
+        {
+          "@context":"/api/contexts/Task",
+          "@id":"/api/tasks",
+          "@type":"hydra:Collection",
+          "hydra:member": [
+            {
+              "@id":"/api/tasks/1",
+              "@type":"Task",
+              "id":1,
+              "status": "DONE",
+              "@*@":"@*@"
+            },
+            {
+              "@id":"/api/tasks/2",
+              "@type":"Task",
+              "id":2,
+              "status": "DONE",
+              "@*@":"@*@"
+            }
+          ],
+          "hydra:totalItems": 2,
+          "@*@":"@*@"
+        }
+      """

--- a/src/Action/Task/AddImagesToTasks.php
+++ b/src/Action/Task/AddImagesToTasks.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace AppBundle\Action\Task;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use AppBundle\Entity\TaskImage;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+class AddImagesToTasks
+{
+    private $iriConverter;
+    private $entityManager;
+
+    public function __construct(
+        IriConverterInterface $iriConverter,
+        EntityManagerInterface $entityManager)
+    {
+        $this->iriConverter = $iriConverter;
+        $this->entityManager = $entityManager;
+    }
+
+    public function __invoke(Request $request)
+    {
+        $payload = [];
+
+        $content = $request->getContent();
+        if (!empty($content)) {
+            $payload = json_decode($content, true);
+        }
+
+        if (!isset($payload['tasks']) || !isset($payload['images'])) {
+            throw new BadRequestHttpException('Mandatory parameters are missing');
+        }
+
+        $tasks = $payload["tasks"];
+        $images = $payload["images"];
+
+        $imagesObj = [];
+        foreach($images as $image) {
+            $imagesObj[] = $this->iriConverter->getItemFromIri($image);
+        }
+
+        $tasksResults = [];
+        foreach($tasks as $task) {
+            $taskObj = $this->iriConverter->getItemFromIri($task);
+
+            if (null === $imagesObj[0]->getTask()) {
+                // existing task_images have not a task associated yet
+                $tasksResults[] = $taskObj->addImages($imagesObj);
+            } else {
+                // persist new task_images to relation them with this task
+                $newImages = $this->createAndPersistTaskImages($imagesObj);
+                $tasksResults[] = $taskObj->addImages($newImages);
+            }
+        }
+
+        $this->entityManager->flush();
+
+        return $tasksResults;
+    }
+
+    private function createAndPersistTaskImages($images)
+    {
+        $result = [];
+
+        foreach($images as $image) {
+            $newImage = new TaskImage();
+            $newImage->setImageName($image->getImageName());
+
+            $this->entityManager->persist($newImage);
+            $this->entityManager->flush();
+
+            $result[] = $newImage;
+        }
+
+        return $result;
+    }
+}

--- a/src/Action/Task/Assign.php
+++ b/src/Action/Task/Assign.php
@@ -2,19 +2,14 @@
 
 namespace AppBundle\Action\Task;
 
-use ApiPlatform\Core\Exception\ItemNotFoundException;
-use AppBundle\Api\Exception\BadRequestHttpException;
 use AppBundle\Service\TaskManager;
 use Nucleos\UserBundle\Model\UserManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 class Assign extends Base
 {
     use AssignTrait;
-
-    private $userManager;
 
     public function __construct(
         TokenStorageInterface $tokenStorage,
@@ -37,18 +32,6 @@ class Assign extends Base
             $payload = json_decode($content, true);
         }
 
-        if (isset($payload['username'])) {
-            $user = $this->userManager->findUserByUsername($payload['username']);
-
-            if (!$user) {
-
-                throw new ItemNotFoundException(sprintf('User "%s" does not exist',
-                    $this->getUser()->getUsername()));
-            }
-        } else {
-            $user = $this->getUser();
-        }
-
-        return $this->assign($task, $user);
+        return $this->assign($task, $payload);
     }
 }

--- a/src/Action/Task/AssignTrait.php
+++ b/src/Action/Task/AssignTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace AppBundle\Action\Task;
+
+use AppBundle\Entity\Task;
+use AppBundle\Entity\User;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+trait AssignTrait
+{
+    protected function assign(Task $task, User $user)
+    {
+        if ($task->isAssigned()) {
+            if ($task->isAssignedTo($this->getUser())) {
+
+                return $task; // Do nothing
+            }
+
+            if (!$this->getUser()->hasRole('ROLE_ADMIN')) {
+
+                throw new BadRequestHttpException(sprintf('Task #%d is already assigned to "%s"',
+                    $task->getId(), $this->getUser()->getUsername()));
+            }
+        }
+
+        if ($user) {
+            $task->assignTo($user);
+        }
+
+        return $task;
+    }
+}

--- a/src/Action/Task/AssignTrait.php
+++ b/src/Action/Task/AssignTrait.php
@@ -2,14 +2,29 @@
 
 namespace AppBundle\Action\Task;
 
+use ApiPlatform\Core\Exception\ItemNotFoundException;
 use AppBundle\Entity\Task;
 use AppBundle\Entity\User;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 trait AssignTrait
 {
-    protected function assign(Task $task, User $user)
+    protected $userManager;
+
+    protected function assign(Task $task, $payload)
     {
+        if (isset($payload['username'])) {
+            $user = $this->userManager->findUserByUsername($payload['username']);
+
+            if (!$user) {
+
+                throw new ItemNotFoundException(sprintf('User "%s" does not exist',
+                    $this->getUser()->getUsername()));
+            }
+        } else {
+            $user = $this->getUser();
+        }
+
         if ($task->isAssigned()) {
             if ($task->isAssignedTo($this->getUser())) {
 

--- a/src/Action/Task/BulkAssign.php
+++ b/src/Action/Task/BulkAssign.php
@@ -3,8 +3,6 @@
 namespace AppBundle\Action\Task;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
-use ApiPlatform\Core\Exception\ItemNotFoundException;
-use AppBundle\Api\Exception\BadRequestHttpException;
 use AppBundle\Service\TaskManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Nucleos\UserBundle\Model\UserManagerInterface;
@@ -15,7 +13,6 @@ class BulkAssign extends Base
 {
     use AssignTrait;
 
-    private $userManager;
     private $iriConverter;
     private $entityManager;
 
@@ -42,29 +39,13 @@ class BulkAssign extends Base
             $payload = json_decode($content, true);
         }
 
-        if (isset($payload['username'])) {
-            $user = $this->userManager->findUserByUsername($payload['username']);
-
-            if (!$user) {
-
-                throw new ItemNotFoundException(sprintf('User "%s" does not exist',
-                    $this->getUser()->getUsername()));
-            }
-        } else {
-            $user = $this->getUser();
-        }
-
-        if (!isset($payload["tasks"])) {
-            throw new BadRequestHttpException('Mandatory parameters are missing');
-        }
-
         $tasks = $payload["tasks"];
 
         $tasksResults= [];
 
         foreach($tasks as $task) {
             $taskObj = $this->iriConverter->getItemFromIri($task);
-            $tasksResults[] = $this->assign($taskObj, $user);
+            $tasksResults[] = $this->assign($taskObj, $payload);
         }
 
         $this->entityManager->flush();

--- a/src/Action/Task/BulkMarkAsDone.php
+++ b/src/Action/Task/BulkMarkAsDone.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace AppBundle\Action\Task;
+
+use ApiPlatform\Core\Api\IriConverterInterface;
+use AppBundle\Service\TaskManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class BulkMarkAsDone extends Base
+{
+    use DoneTrait;
+
+    private $iriConverter;
+    private $entityManager;
+
+    public function __construct(
+        TokenStorageInterface $tokenStorage,
+        TaskManager $taskManager,
+        IriConverterInterface $iriConverter,
+        EntityManagerInterface $entityManager)
+    {
+        parent::__construct($tokenStorage, $taskManager);
+
+        $this->iriConverter = $iriConverter;
+        $this->entityManager = $entityManager;
+    }
+
+    public function __invoke(Request $request)
+    {
+        $payload = [];
+
+        $content = $request->getContent();
+        if (!empty($content)) {
+            $payload = json_decode($content, true);
+        }
+
+        $tasks = $payload["tasks"];
+
+        $tasksResults= [];
+
+        foreach($tasks as $task) {
+            $taskObj = $this->iriConverter->getItemFromIri($task);
+            $tasksResults[] = $this->done($taskObj, $request);
+        }
+
+        $this->entityManager->flush();
+
+        return $tasksResults;
+    }
+}

--- a/src/Action/Task/Done.php
+++ b/src/Action/Task/Done.php
@@ -2,29 +2,16 @@
 
 namespace AppBundle\Action\Task;
 
-use AppBundle\Exception\PreviousTaskNotCompletedException;
-use AppBundle\Exception\TaskAlreadyCompletedException;
-use AppBundle\Exception\TaskCancelledException;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
-use Symfony\Component\Routing\Annotation\Route;
 
 class Done extends Base
 {
+    use DoneTrait;
+
     public function __invoke($data, Request $request)
     {
         $task = $data;
 
-        try {
-            $this->taskManager->markAsDone($task, $this->getNotes($request), $this->getContactName($request));
-        } catch (PreviousTaskNotCompletedException $e) {
-            throw new BadRequestHttpException($e->getMessage());
-        } catch (TaskAlreadyCompletedException $e) {
-            throw new BadRequestHttpException($e->getMessage());
-        } catch (TaskCancelledException $e) {
-            throw new BadRequestHttpException($e->getMessage());
-        }
-
-        return $task;
+        return $this->done($task, $request);
     }
 }

--- a/src/Action/Task/DoneTrait.php
+++ b/src/Action/Task/DoneTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AppBundle\Action\Task;
+
+use AppBundle\Entity\Task;
+use AppBundle\Exception\PreviousTaskNotCompletedException;
+use AppBundle\Exception\TaskAlreadyCompletedException;
+use AppBundle\Exception\TaskCancelledException;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+
+trait DoneTrait
+{
+    protected function done(Task $task, Request $request)
+    {
+        try {
+            $this->taskManager->markAsDone($task, $this->getNotes($request), $this->getContactName($request));
+        } catch (PreviousTaskNotCompletedException $e) {
+            throw new BadRequestHttpException($e->getMessage());
+        } catch (TaskAlreadyCompletedException $e) {
+            throw new BadRequestHttpException($e->getMessage());
+        } catch (TaskCancelledException $e) {
+            throw new BadRequestHttpException($e->getMessage());
+        }
+
+        return $task;
+    }
+}

--- a/src/Entity/Task.php
+++ b/src/Entity/Task.php
@@ -4,6 +4,7 @@ namespace AppBundle\Entity;
 
 use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Annotation\ApiResource;
+use AppBundle\Action\Task\AddImagesToTasks;
 use AppBundle\Action\Task\Assign as TaskAssign;
 use AppBundle\Action\Task\BulkAssign as TaskBulkAssign;
 use AppBundle\Action\Task\Cancel as TaskCancel;
@@ -89,6 +90,24 @@ use Symfony\Component\Validator\Constraints as Assert;
  *             "in"="body",
  *             "name"="N/A",
  *             "schema"={"type"="object", "properties"={"tasks"={"type"="array"}}},
+ *             "style"="form"
+ *           }
+ *         }
+ *       }
+ *     },
+ *     "tasks_images"={
+ *       "method"="PUT",
+ *       "path"="/tasks/images",
+ *       "denormalization_context"={"groups"={"tasks_images"}},
+ *       "controller"=AddImagesToTasks::class,
+ *       "access_control"="is_granted('ROLE_ADMIN') or is_granted('ROLE_COURIER')",
+ *       "openapi_context"={
+ *         "summary"="",
+ *         "parameters"={
+ *           {
+ *             "in"="body",
+ *             "name"="N/A",
+ *             "schema"={"type"="object", "properties"={"tasks"={"type"="array"}, "images"={"type"="array"}}},
  *             "style"="form"
  *           }
  *         }
@@ -698,6 +717,18 @@ class Task implements TaggableInterface, OrganizationAwareInterface, PackagesAwa
     public function addImage($image)
     {
         $this->images->add($image);
+        $this->imageCount = count($this->images);
+
+        return $this;
+    }
+
+    public function addImages($images)
+    {
+        foreach ($images as $image) {
+            $this->addImage($image);
+            $image->setTask($this);
+        }
+
         $this->imageCount = count($this->images);
 
         return $this;

--- a/src/Entity/Task.php
+++ b/src/Entity/Task.php
@@ -15,6 +15,7 @@ use AppBundle\Action\Task\Duplicate as TaskDuplicate;
 use AppBundle\Action\Task\Restore as TaskRestore;
 use AppBundle\Action\Task\Start as TaskStart;
 use AppBundle\Action\Task\RemoveFromGroup;
+use AppBundle\Action\Task\BulkMarkAsDone as TaskBulkMarkAsDone;
 use AppBundle\Api\Dto\BioDeliverInput;
 use AppBundle\Api\Filter\AssignedFilter;
 use AppBundle\Api\Filter\TaskDateFilter;
@@ -71,6 +72,23 @@ use Symfony\Component\Validator\Constraints as Assert;
  *             "in"="body",
  *             "name"="N/A",
  *             "schema"={"type"="object", "properties"={"username"={"type"="string"}, "tasks"={"type"="array"}}},
+ *             "style"="form"
+ *           }
+ *         }
+ *       }
+ *     },
+ *     "tasks_done"={
+ *       "method"="PUT",
+ *       "path"="/tasks/done",
+ *       "controller"=TaskBulkMarkAsDone::class,
+ *       "access_control"="is_granted('ROLE_ADMIN') or is_granted('ROLE_COURIER')",
+ *       "openapi_context"={
+ *         "summary"="Mark multiple Tasks as done at once",
+ *         "parameters"={
+ *           {
+ *             "in"="body",
+ *             "name"="N/A",
+ *             "schema"={"type"="object", "properties"={"tasks"={"type"="array"}}},
  *             "style"="form"
  *           }
  *         }

--- a/src/Entity/Task.php
+++ b/src/Entity/Task.php
@@ -5,6 +5,7 @@ namespace AppBundle\Entity;
 use ApiPlatform\Core\Annotation\ApiFilter;
 use ApiPlatform\Core\Annotation\ApiResource;
 use AppBundle\Action\Task\Assign as TaskAssign;
+use AppBundle\Action\Task\BulkAssign as TaskBulkAssign;
 use AppBundle\Action\Task\Cancel as TaskCancel;
 use AppBundle\Action\Task\Done as TaskDone;
 use AppBundle\Action\Task\Events as TaskEvents;
@@ -57,7 +58,24 @@ use Symfony\Component\Validator\Constraints as Assert;
  *       "access_control"="is_granted('ROLE_ADMIN')",
  *       "denormalization_context"={"groups"={"task_create"}},
  *       "validation_groups"={"Default"}
- *     }
+ *     },
+ *     "tasks_assign"={
+ *       "method"="PUT",
+ *       "path"="/tasks/assign",
+ *       "controller"=TaskBulkAssign::class,
+ *       "access_control"="is_granted('ROLE_ADMIN') or is_granted('ROLE_COURIER')",
+ *       "openapi_context"={
+ *         "summary"="Assigns multiple Tasks at once to a messenger",
+ *         "parameters"={
+ *           {
+ *             "in"="body",
+ *             "name"="N/A",
+ *             "schema"={"type"="object", "properties"={"username"={"type"="string"}, "tasks"={"type"="array"}}},
+ *             "style"="form"
+ *           }
+ *         }
+ *       }
+ *     },
  *   },
  *   itemOperations={
  *     "get"={

--- a/src/Serializer/TaskImageNormalizer.php
+++ b/src/Serializer/TaskImageNormalizer.php
@@ -4,6 +4,7 @@ namespace AppBundle\Serializer;
 
 use ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer;
 use AppBundle\Entity\TaskImage;
+use Liip\ImagineBundle\Exception\Binary\Loader\NotLoadableException;
 use Liip\ImagineBundle\Service\FilterService;
 use Symfony\Component\Serializer\Exception\LogicException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
@@ -30,8 +31,12 @@ class TaskImageNormalizer implements NormalizerInterface, DenormalizerInterface
     {
         $data =  $this->normalizer->normalize($object, $format, $context);
 
-        $imagePath = $this->uploaderHelper->asset($object, 'file');
-        $data['thumbnail'] = $this->imagineFilter->getUrlOfFilteredImage($imagePath, 'task_image_thumbnail');
+        try {
+            $imagePath = $this->uploaderHelper->asset($object, 'file');
+            $data['thumbnail'] = $this->imagineFilter->getUrlOfFilteredImage($imagePath, 'task_image_thumbnail');
+        } catch (NotLoadableException $e) {
+            return $data;
+        }
 
         return $data;
     }


### PR DESCRIPTION
New API endpoints that allow:
- Assign multiple tasks to a courier at once
- Mark multiple tasks as done at once
- Assign images (photos or signatures) to multiple tasks

Related to https://github.com/coopcycle/coopcycle-app/issues/1476.

A courier can select multiple tasks to complete and attach same images/signatures to all of them. In admin panel you can see the same images for all the tasks:

https://user-images.githubusercontent.com/4819244/224723657-ba4ca709-70fa-40b2-b262-2958114e844a.mp4




