### PR TITLE
feat: add left padding to Group/Tour tasks

### DIFF
--- a/js/app/dashboard/components/TaskGroup.js
+++ b/js/app/dashboard/components/TaskGroup.js
@@ -125,7 +125,7 @@ class TaskGroup extends React.Component {
           </h4>
         </div>
         <div id={ `task-group-panel-${this.state.group.id}` } className="panel-collapse collapse" role="tabpanel">
-          <ul className="list-group">
+          <ul className="list-group list-group-padded">
             { tasks.map(task => {
               return (
                 <Task

--- a/js/app/dashboard/components/Tour.js
+++ b/js/app/dashboard/components/Tour.js
@@ -17,7 +17,7 @@ const Tour = ({ tour, tasks }) => {
         </h4>
       </div>
       <div id={ `${collapseId}` } className="panel-collapse collapse" role="tabpanel">
-        <ul className="list-group">
+        <ul className="list-group list-group-padded">
           { tasks.map(task => {
             return (
               <Task

--- a/js/app/dashboard/dashboard.scss
+++ b/js/app/dashboard/dashboard.scss
@@ -188,6 +188,11 @@ html, body {
   }
 }
 
+.list-group-padded {
+  padding-left: 15px;
+  background-color: #E8E8E8;
+}
+
 :not(.task-package).list-group-item {
 
   font-size: 12px;


### PR DESCRIPTION
Just added a bit of left padding to the Group/Tour container (`ul`):

![Screenshot 2023-03-15 at 17-06-54 CoopCycle](https://user-images.githubusercontent.com/667236/225370462-71d166fd-19e6-4a58-926f-fb2701bb3258.png)