### PR TITLE
Creación de nuevo campo 'ShowOnHomePage' en DeliveryForm

### DIFF
--- a/bin/demo
+++ b/bin/demo
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 
+php bin/console typesense:create "$@"
 php bin/console coopcycle:setup "$@"
 php bin/console coopcycle:demo:init "$@"
 php bin/console coopcycle:setup "$@"

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -1349,10 +1349,20 @@ class AdminController extends AbstractController
     {
         $this->denyAccessUnlessGranted('ROLE_ADMIN');
         $deliveryForm = new DeliveryForm();
+        
         $form = $this->createForm(EmbedSettingsType::class, $deliveryForm);
-
+        
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
+            
+            // Disable "Show on Home Page" on all forms ONLY if this new form is setted true
+            if($deliveryForm->getShowHomepage()){
+                $forms = $this->getDoctrine()->getRepository(DeliveryForm::class)->findAll();
+                foreach ($forms as $formTemp) {
+                    $formTemp->setShowHomepage(false);
+                }
+            }
+
             $this->getDoctrine()
                 ->getManagerForClass(DeliveryForm::class)
                 ->persist($deliveryForm);
@@ -1380,6 +1390,17 @@ class AdminController extends AbstractController
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
+            
+            // Disable "Show on Home Page" on all forms except current form if setted true
+            if($deliveryForm->getShowHomepage()){
+                $forms = $this->getDoctrine()->getRepository(DeliveryForm::class)->findAll();
+                foreach ($forms as $formTemp) {
+                    if($deliveryForm->getId() != $formTemp->getId()){ //except current form
+                        $formTemp->setShowHomepage(false);
+                    }
+                }
+            }
+
             $this->getDoctrine()
                 ->getManagerForClass(DeliveryForm::class)
                 ->flush();

--- a/src/Form/EmbedSettingsType.php
+++ b/src/Form/EmbedSettingsType.php
@@ -59,6 +59,10 @@ class EmbedSettingsType extends AbstractType
             ->add('withWeight', CheckboxType::class, [
                 'label' => 'form.embed_settings.with_weight.label',
                 'required' => false
+            ])
+            ->add('showHomePage', CheckboxType::class, [
+                'label' => 'form.embed_settings.show_home_page.label',
+                'required' => false
             ]);
     }
 

--- a/templates/admin/forms.html.twig
+++ b/templates/admin/forms.html.twig
@@ -15,6 +15,7 @@
 <table class="table">
   <thead>
     <th>#</th>
+    <th>{{ 'form.embed_settings.show_home_page.label'|trans }}</th>
     <th>{{ 'form.store_type.pricing_rule_set.label'|trans }}</th>
     <th>{{ 'form.store_type.time_slot.label'|trans }}</th>
     <th>{{ 'form.store_type.package_set.label'|trans }}</th>
@@ -28,6 +29,11 @@
         <a href="{{ path('admin_form', { id: form.id }) }}">
           <span class="text-monospace">{{ form|hashid(12) }}</span>
         </a>
+      </td>
+      <td class="text-center">
+        <span>
+          <i class="fa fa-{{ form.showHomePage ? 'check' : '' }}"></i>
+        </span>
       </td>
       <td>
         {{ form.pricingRuleSet.name }}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -731,6 +731,7 @@ form.credit_note.restaurant.help: The promotion will only be usable when orderin
 form.resend_confirmation_email.submit.label: Send email again
 form.embed_settings.with_vehicle.label: Add vehicle choice
 form.embed_settings.with_weight.label: Ask for weight of goods
+form.embed_settings.show_home_page.label: Show on Home Page
 form.time_slot.name.label: Name
 form.time_slot.interval.label: Interval
 form.time_slot.working_days_only.label: Allow selecting only working days

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -936,6 +936,7 @@ form.checkout_address.takeaway.contact: Si tiene algún problema, contacte con e
 form.checkout_payment.method.label: Elija un método de pago
 form.checkout_address.reusable_packaging.loopeat.learn_more: Saber más sobre LoopEat
 form.embed_settings.with_weight.label: Consultar peso de bienes
+form.embed_settings.show_home_page.label: Mostrar en Inicio
 form.time_slot.working_days_only.label: Permitir seleccionar sólo días laborales
 form.reusable_packaging.price.label: Precio
 form.reusable_packaging.on_hand.label: Cantidad


### PR DESCRIPTION
Creación de nuevo campo 'ShowOnHomePage' en DeliveryForm para configurar si un formulario se muestra o no en la página principal. Con validación para que sólo un formulario esté activo a la vez