### PR TITLE
Avoid duplicated tasks in export

### DIFF
--- a/src/Form/TaskExportType.php
+++ b/src/Form/TaskExportType.php
@@ -63,7 +63,6 @@ class TaskExportType extends AbstractType
                     'order' => [
                         ["TasksExportUnified.orderId","asc"],
                         ["TasksExportUnified.taskType","desc"],
-                        ["TasksExportUnified.taskPosition","asc"],
                     ],
                     'filters' => [
                       [
@@ -118,7 +117,7 @@ class TaskExportType extends AbstractType
             $csv->insertOne([
                 '#',
                 '# order',
-                'orderNumber',
+                'orderCode',
                 'type',
                 'address.name',
                 'address.streetAddress',


### PR DESCRIPTION
Some tasks have more than one `task_collection_item` associated. 
Now we are avoiding duplication of tasks sorting by `task.id` and `task_collection_item.position` and then for each task duplicated we keep the first one (the one with minimum position value in the collection).