### PR TITLE
New group column in tasks import

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -930,9 +930,7 @@ services:
       arguments: [ '@AppBundle\Api\Swagger\SwaggerDecorator.inner' ]
       autoconfigure: false
 
-  AppBundle\MessageHandler\ImportTasksHandler:
-    arguments:
-      $secret: '%secret%'
+  AppBundle\MessageHandler\ImportTasksHandler: ~
 
   AppBundle\MessageHandler\CalculateRouteHandler:
     arguments:

--- a/src/EventListener/Upload/UploadListener.php
+++ b/src/EventListener/Upload/UploadListener.php
@@ -199,14 +199,7 @@ final class UploadListener
         $date = $request->get('date');
         $hashids = new Hashids($this->secret, 8);
 
-        $taskGroup = new TaskGroup();
-        $taskGroup->setName(sprintf('Import %s', date('d/m H:i')));
-
-        // The TaskGroup will serve as a unique identifier
-        $this->entityManager->persist($taskGroup);
-        $this->entityManager->flush();
-
-        $encoded = $hashids->encode($taskGroup->getId());
+        $encoded = $hashids->encode(mt_rand());
         $this->logger->debug(sprintf('UploadListener | hashid = %s', $encoded));
 
         $filename = sprintf('%s.%s', $encoded, TaskSpreadsheetParser::getFileExtension($mimeType));

--- a/src/MessageHandler/ImportTasksHandler.php
+++ b/src/MessageHandler/ImportTasksHandler.php
@@ -3,17 +3,14 @@
 namespace AppBundle\MessageHandler;
 
 use AppBundle\Entity\Organization;
-use AppBundle\Entity\Task;
 use AppBundle\Entity\Task\Group as TaskGroup;
 use AppBundle\Entity\Task\ImportQueue as TaskImportQueue;
 use AppBundle\Message\ImportTasks;
 use AppBundle\Service\RemotePushNotificationManager;
 use AppBundle\Service\LiveUpdates;
 use AppBundle\Spreadsheet\TaskSpreadsheetParser;
-use Doctrine\DBAL\Driver\PDOException;
 use Doctrine\DBAL\Exception\DriverException;
 use Doctrine\ORM\EntityManagerInterface;
-use Hashids\Hashids;
 use League\Flysystem\Filesystem;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
@@ -26,7 +23,6 @@ class ImportTasksHandler implements MessageHandlerInterface
     private $spreadsheetParser;
     private $validator;
     private $liveUpdates;
-    private $hashids;
     private $logger;
 
     public function __construct(
@@ -35,7 +31,6 @@ class ImportTasksHandler implements MessageHandlerInterface
         TaskSpreadsheetParser $spreadsheetParser,
         ValidatorInterface $validator,
         LiveUpdates $liveUpdates,
-        string $secret,
         LoggerInterface $logger)
     {
         $this->objectManager = $objectManager;
@@ -44,7 +39,6 @@ class ImportTasksHandler implements MessageHandlerInterface
         $this->validator = $validator;
         $this->liveUpdates = $liveUpdates;
         $this->logger = $logger;
-        $this->hashids = new Hashids($secret, 8);
     }
 
     public function __invoke(ImportTasks $message)


### PR DESCRIPTION
Closes #3445 

https://github.com/coopcycle/coopcycle-web/assets/4819244/5f026152-db00-40a4-bc17-0e4c1c9ffd0a
- Tasks with group name in csv file are grouped under that name after the import.
- Tasks without a group name in csv file are grouped under a default group (Import d/m h:s) as was the case before this implementation.

https://github.com/coopcycle/coopcycle-web/assets/4819244/066f3891-68d2-41be-874c-e31ab7229084
- Tasks with a group name equal to an already used one are imported and grouped in a new group but with the same name as the existing one (users should avoid this case).

