### PR TITLE
Improve errors messages for delivery import

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -741,7 +741,9 @@ class AdminController extends AbstractController
 
         $deliveryImportForm->handleRequest($request);
         if ($deliveryImportForm->isSubmitted() && $deliveryImportForm->isValid()) {
-            return $this->handleDeliveryImportForStore($deliveryImportForm, 'admin_deliveries',
+            $store = $deliveryImportForm->get('store')->getData();
+
+            return $this->handleDeliveryImportForStore($store, $deliveryImportForm, 'admin_deliveries',
                 $orderManager, $deliveryManager, $orderFactory);
         } else if ($deliveryImportForm->isSubmitted() && !$deliveryImportForm->isValid()) {
             if (count($deliveryImportForm->getData()) > 0) {

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -741,10 +741,19 @@ class AdminController extends AbstractController
 
         $deliveryImportForm->handleRequest($request);
         if ($deliveryImportForm->isSubmitted() && $deliveryImportForm->isValid()) {
-            $store = $deliveryImportForm->get('store')->getData();
+            return $this->handleDeliveryImportForStore($deliveryImportForm, 'admin_deliveries',
+                $orderManager, $deliveryManager, $orderFactory);
+        } else if ($deliveryImportForm->isSubmitted() && !$deliveryImportForm->isValid()) {
+            if (count($deliveryImportForm->getData()) > 0) {
+                // This is the case when some rows have errors and some others were parsed successfuly and have to be persisted
+                $importedDeliveries = $this->persistImportedDeliveries($deliveryImportForm, $orderManager,
+                    $deliveryManager, $orderFactory);
 
-            return $this->handleDeliveryImportForStore($store, $deliveryImportForm, 'admin_deliveries',
-                $orderManager, $deliveryManager, $orderFactory,);
+                $importedRowsMessage = $this->translator->trans('import.successful.rows', [
+                    '%count%' => count(array_keys($importedDeliveries)),
+                    '%rows%' => implode(", ", array_keys($importedDeliveries))
+                ]);
+            }
         }
 
         $dataExportForm = $this->createForm(DataExportType::class);
@@ -799,6 +808,7 @@ class AdminController extends AbstractController
         return $this->render('admin/deliveries.html.twig', [
             'deliveries' => $deliveries,
             'routes' => $this->getDeliveryRoutes(),
+            'imported_rows_message' => $importedRowsMessage ?? null,
             'stores' => $this->getDoctrine()->getRepository(Store::class)->findBy([], ['name' => 'ASC']),
             'delivery_import_form' => $deliveryImportForm->createView(),
             'delivery_export_form' => $dataExportForm->createView(),

--- a/src/Controller/Utils/StoreTrait.php
+++ b/src/Controller/Utils/StoreTrait.php
@@ -496,6 +496,7 @@ trait StoreTrait
     }
 
     protected function handleDeliveryImportForStore(
+        Store $store,
         FormInterface $deliveryImportForm,
         string $routeTo,
         OrderManager $orderManager,

--- a/src/Exception/DateTimeParseException.php
+++ b/src/Exception/DateTimeParseException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace AppBundle\Exception;
+
+class DateTimeParseException extends \Exception
+{
+}

--- a/src/Form/DeliveryImportType.php
+++ b/src/Form/DeliveryImportType.php
@@ -20,13 +20,16 @@ class DeliveryImportType extends AbstractType
 {
     private $spreadsheetParser;
     private $validator;
+    private $translator;
 
     public function __construct(
         DeliverySpreadsheetParser $spreadsheetParser,
-        ValidatorInterface $validator)
+        ValidatorInterface $validator, 
+        TranslatorInterface $translator)
     {
         $this->spreadsheetParser = $spreadsheetParser;
         $this->validator = $validator;
+        $this->translator = $translator;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -58,12 +61,29 @@ class DeliveryImportType extends AbstractType
 
             try {
 
-                $deliveries = $this->spreadsheetParser->parse($file->getPathname());
+                $result = $this->spreadsheetParser->parse($file->getPathname());
 
-                foreach ($deliveries as $delivery) {
+                $deliveries = array_filter($result->getData(), function($delivery, $rowNumber) use ($result) {
                     $violations = $this->validator->validate($delivery);
                     if (count($violations) > 0) {
-                        throw new \Exception((string) $violations->get(0));
+                        $result->addErrorToRow($rowNumber, (string) $violations->get(0));
+                        return false;
+                    }
+                    return true;
+                }, ARRAY_FILTER_USE_BOTH);
+
+                if ($result->hasErrors()) {
+                    foreach($result->getSortedErrors() as $rowNumber => $failedRow) {
+                        $event->getForm()->addError(new FormError(
+                            $this->translator->trans('import.errors.at.row', [
+                                '%row_number%' => $rowNumber
+                            ])
+                        ));
+                        foreach($failedRow as $errorMessage) {
+                            $event->getForm()->addError(new FormError(
+                                sprintf(' - %s', $errorMessage)
+                            ));
+                        }
                     }
                 }
 

--- a/src/Spreadsheet/AbstractSpreadsheetParser.php
+++ b/src/Spreadsheet/AbstractSpreadsheetParser.php
@@ -102,9 +102,9 @@ abstract class AbstractSpreadsheetParser
     /**
      * @param array $data
      * @param array $options
-     * @return array
+     * @return array|SpreadsheetParseResult
      */
-    abstract public function parseData(array $data, array $options = []): array;
+    abstract public function parseData(array $data, array $options = []): array | SpreadsheetParseResult;
 
     /**
      * @param File|string $file

--- a/src/Spreadsheet/DeliverySpreadsheetParser.php
+++ b/src/Spreadsheet/DeliverySpreadsheetParser.php
@@ -5,10 +5,13 @@ namespace AppBundle\Spreadsheet;
 use AppBundle\Entity\Model\TaggableInterface;
 use AppBundle\Entity\Delivery;
 use AppBundle\Entity\Task;
+use AppBundle\Exception\DateTimeParseException;
 use AppBundle\Service\Geocoder;
 use Cocur\Slugify\SlugifyInterface;
 use Doctrine\ORM\EntityManagerInterface;
+use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumberUtil;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DeliverySpreadsheetParser extends AbstractSpreadsheetParser
 {
@@ -25,51 +28,71 @@ class DeliverySpreadsheetParser extends AbstractSpreadsheetParser
     private $countryCode;
     private $entityManager;
     private $slugify;
+    private $translator;
 
     public function __construct(Geocoder $geocoder, PhoneNumberUtil $phoneNumberUtil, string $countryCode,
-        EntityManagerInterface $entityManager, SlugifyInterface $slugify)
+        EntityManagerInterface $entityManager, SlugifyInterface $slugify, TranslatorInterface $translator)
     {
         $this->geocoder = $geocoder;
         $this->phoneNumberUtil = $phoneNumberUtil;
         $this->countryCode = $countryCode;
         $this->entityManager = $entityManager;
         $this->slugify = $slugify;
+        $this->translator = $translator;
     }
 
     /**
      * @inheritdoc
      */
-    public function parseData(array $data, array $options = []): array
+    public function parseData(array $data, array $options = []): SpreadsheetParseResult
     {
-        $deliveries = [];
+        $parseResult = new SpreadsheetParseResult();
 
-        foreach ($data as $record) {
+        foreach ($data as $index=>$record) {
+            $rowNumber = $index + 1;
 
             if (!$pickupAddress = $this->geocoder->geocode($record['pickup.address'])) {
-                // TODO Translate
-                throw new \Exception(sprintf('Could not geocode %s', $record['pickup.address']));
+                $translatedError = $this->translator->trans('import.address.geocode.error', [
+                    '%failed_address%' => $record['pickup.address']
+                ]);
+                $parseResult->addErrorToRow($rowNumber,
+                    sprintf('pickup.address: %s', $translatedError)
+                );
             }
 
             if (!$dropoffAddress = $this->geocoder->geocode($record['dropoff.address'])) {
-                // TODO Translate
-                throw new \Exception(sprintf('Could not geocode %s', $record['dropoff.address']));
+                $translatedError = $this->translator->trans('import.address.geocode.error', [
+                    '%failed_address%' => $record['dropoff.address']
+                ]);
+                $parseResult->addErrorToRow($rowNumber,
+                    sprintf('dropoff.address: %s', $translatedError)
+                );
             }
-
-            [ $pickupAfter, $pickupBefore ] = $this->parseTimeRange($record['pickup.timeslot']);
-            [ $dropoffAfter, $dropoffBefore ] = $this->parseTimeRange($record['dropoff.timeslot']);
 
             $delivery = new Delivery();
 
             $delivery->getPickup()->setAddress($pickupAddress);
-            $delivery->getPickup()->setDoneAfter($pickupAfter);
-            $delivery->getPickup()->setDoneBefore($pickupBefore);
 
             $delivery->getDropoff()->setAddress($dropoffAddress);
-            $delivery->getDropoff()->setDoneAfter($dropoffAfter);
-            $delivery->getDropoff()->setDoneBefore($dropoffBefore);
 
-            $this->enhanceTask($delivery->getPickup(), 'pickup', $record);
-            $this->enhanceTask($delivery->getDropoff(), 'dropoff', $record);
+            try {
+                [ $pickupAfter, $pickupBefore ] = $this->parseTimeRange($record, 'pickup.timeslot');
+                [ $dropoffAfter, $dropoffBefore ] = $this->parseTimeRange($record, 'dropoff.timeslot');
+
+                $delivery->getPickup()->setDoneAfter($pickupAfter);
+                $delivery->getPickup()->setDoneBefore($pickupBefore);
+                $delivery->getDropoff()->setDoneAfter($dropoffAfter);
+                $delivery->getDropoff()->setDoneBefore($dropoffBefore);
+            } catch(DateTimeParseException $e) {
+                $parseResult->addErrorToRow($rowNumber, $e->getMessage());
+            }
+
+            try {
+                $this->enhanceTask($delivery->getPickup(), 'pickup', $record);
+                $this->enhanceTask($delivery->getDropoff(), 'dropoff', $record);
+            } catch(NumberParseException $e) {
+                $parseResult->addErrorToRow($rowNumber, $e->getMessage());
+            }
 
             if (isset($record['weight']) && is_numeric($record['weight'])) {
                 $delivery->setWeight(floatval($record['weight']) * 1000);
@@ -87,10 +110,12 @@ class DeliverySpreadsheetParser extends AbstractSpreadsheetParser
                 $this->applyTags($delivery->getDropoff(), $record['dropoff.tags']);
             }
 
-            $deliveries[] = $delivery;
-        }
+            if (!$parseResult->rowHasErrors($rowNumber)) {
+                $parseResult->addData($rowNumber, $delivery);
+            }
 
-        return $deliveries;
+        }
+        return $parseResult;
     }
 
     public function validateHeader(array $header)
@@ -107,16 +132,28 @@ class DeliverySpreadsheetParser extends AbstractSpreadsheetParser
         }
     }
 
-    private function parseTimeRange($timeSlotAsText)
+    private function parseTimeRange($data, $key)
     {
+        $timeSlotAsText = $data[$key];
+
         if (false === strpos($timeSlotAsText, '-')) {
-            throw new \Exception(sprintf('Time range "%s" is not valid', $timeSlotAsText));
+            throw new DateTimeParseException(
+                $this->translator->trans('import.time.range.error', [
+                    '%key%' => $key,
+                    '%value%' => $timeSlotAsText
+                ])
+            );
         }
 
         $pattern = sprintf('#^(%s)[^0-9]+(%s)$#', self::TIME_RANGE_PATTERN, self::TIME_RANGE_PATTERN);
 
         if (1 !== preg_match($pattern, $timeSlotAsText, $matches)) {
-            throw new \Exception(sprintf('Time range "%s" is not valid', $timeSlotAsText));
+            throw new DateTimeParseException(
+                $this->translator->trans('import.time.range.error', [
+                    '%key%' => $key,
+                    '%value%' => $timeSlotAsText
+                ])
+            );
         }
 
         $start = new \DateTime();
@@ -159,18 +196,20 @@ class DeliverySpreadsheetParser extends AbstractSpreadsheetParser
         $addressTelephoneColumn    = $this->getColumn($prefix, 'address.telephone');
         $commentsColumn            = $this->getColumn($prefix, 'comments');
 
-        if (isset($record[$addressNameColumn]) && !empty($record[$addressNameColumn])) {
-            $task->getAddress()->setName((string) $record[$addressNameColumn]);
-        }
+        if (null !== $task->getAddress()) {
+            if (isset($record[$addressNameColumn]) && !empty($record[$addressNameColumn])) {
+                $task->getAddress()->setName((string) $record[$addressNameColumn]);
+            }
 
-        if (isset($record[$addressDescriptionColumn]) && !empty($record[$addressDescriptionColumn])) {
-            $task->getAddress()->setDescription($record[$addressDescriptionColumn]);
-        }
+            if (isset($record[$addressDescriptionColumn]) && !empty($record[$addressDescriptionColumn])) {
+                $task->getAddress()->setDescription($record[$addressDescriptionColumn]);
+            }
 
-        if (isset($record[$addressTelephoneColumn]) && !empty($record[$addressTelephoneColumn])) {
-            /* @throws NumberParseException */
-            $phoneNumber = $this->phoneNumberUtil->parse($record[$addressTelephoneColumn], strtoupper($this->countryCode));
-            $task->getAddress()->setTelephone($phoneNumber);
+            if (isset($record[$addressTelephoneColumn]) && !empty($record[$addressTelephoneColumn])) {
+                /* @throws NumberParseException */
+                $phoneNumber = $this->phoneNumberUtil->parse($record[$addressTelephoneColumn], strtoupper($this->countryCode));
+                $task->getAddress()->setTelephone($phoneNumber);
+            }
         }
 
         if (isset($record[$commentsColumn]) && !empty($record[$commentsColumn])) {

--- a/src/Spreadsheet/SpreadsheetParseResult.php
+++ b/src/Spreadsheet/SpreadsheetParseResult.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace AppBundle\Spreadsheet;
+
+/**
+ * A class to keep the relation between a row from a file
+ * and the entity that is created or the errors that occurs
+ * when the import and parse of that fail happens.
+ */
+class SpreadsheetParseResult
+{
+    /**
+     * [
+     *  1 => SomeEntity,
+     *  2 => SomeEntity,
+     *  5 => SomeEntity
+     * ]
+     */
+    private $data;
+
+    /**
+     * [
+     *  3 => ["error 1", "error 2"],
+     *  4 => ["error 1"]
+     * ]
+     */
+    private $errors;
+
+    public function __construct()
+    {
+        $this->data = [];
+        $this->errors = [];
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    public function setData($data)
+    {
+        $this->data = $data;
+    }
+
+    public function addData($rowNumber, $item)
+    {
+        $this->data[$rowNumber] = $item;
+    }
+
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+
+    public function getSortedErrors()
+    {
+        ksort($this->errors);
+        return $this->errors;
+    }
+
+    public function setErrors($errors)
+    {
+        $this->errors = $errors;
+    }
+
+    public function addErrorToRow($rowNumber, $error)
+    {
+        if (array_key_exists($rowNumber, $this->errors)) {
+            array_push($this->errors[$rowNumber], $error);
+        } else {
+            $this->errors[$rowNumber] = [$error];
+        }
+    }
+
+    public function rowHasErrors($rowNumber)
+    {
+        return array_key_exists($rowNumber, $this->errors);
+    }
+
+    public function hasErrors()
+    {
+        return count(array_keys($this->errors)) > 0;
+    }
+}

--- a/templates/admin/deliveries.html.twig
+++ b/templates/admin/deliveries.html.twig
@@ -26,14 +26,34 @@
     </div>
   </div>
 
-  {% if delivery_import_form.vars.submitted and (not delivery_import_form.vars.valid and not delivery_import_form.file.vars.valid) %}
-    <div class="alert alert-danger">
-      <ul class="list-unstyled">
-      {% for error in delivery_import_form.file.vars.errors %}
-        <li>{{ error.message }}</li>
-      {% endfor %}
-      </ul>
+  {% if imported_rows_message is defined and imported_rows_message is not empty %}
+    <div class="alert alert-success">
+      {{ imported_rows_message }}
     </div>
+  {% endif %}
+
+  {% if delivery_import_form.vars.submitted and (not delivery_import_form.vars.valid and not delivery_import_form.file.vars.valid) %}
+    <!-- Delivery errors: i.e. when orders can not be created because errors in price calculation -->
+    {% if delivery_import_form.vars.errors is defined and delivery_import_form.vars.errors is not empty %}
+      <div class="alert alert-danger">
+        <ul class="list-unstyled">
+        {% for error in delivery_import_form.vars.errors %}
+          <li>{{ error.message }}</li>
+        {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
+
+    <!-- Errors at rows level then trying to parse the file -->
+    {% if delivery_import_form.file.vars.errors is defined and delivery_import_form.file.vars.errors is not empty %}
+      <div class="alert alert-danger">
+        <ul class="list-unstyled">
+        {% for error in delivery_import_form.file.vars.errors %}
+          <li>{{ error.message }}</li>
+        {% endfor %}
+        </ul>
+      </div>
+    {% endif %}
   {% endif %}
 
   {% if delivery_export_form.vars.submitted and not delivery_export_form.vars.valid %}

--- a/tests/AppBundle/Spreadsheet/DeliverySpreadsheetParserTest.php
+++ b/tests/AppBundle/Spreadsheet/DeliverySpreadsheetParserTest.php
@@ -12,6 +12,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectRepository;
 use Prophecy\Argument;
 use libphonenumber\PhoneNumberUtil;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class DeliverySpreadsheetParserTest extends TestCase
 {
@@ -20,6 +21,7 @@ class DeliverySpreadsheetParserTest extends TestCase
         $this->geocoder = $this->prophesize(Geocoder::class);
         $this->entityManager = $this->prophesize(EntityManagerInterface::class);
         $this->slugify = $this->prophesize(SlugifyInterface::class);
+        $this->translator = $this->prophesize(TranslatorInterface::class);
 
         $this->geocoder
             ->geocode(Argument::type('string'))
@@ -36,7 +38,8 @@ class DeliverySpreadsheetParserTest extends TestCase
             PhoneNumberUtil::getInstance(),
             'fr',
             $this->entityManager->reveal(),
-            $this->slugify->reveal()
+            $this->slugify->reveal(),
+            $this->translator->reveal()
         );
     }
 }

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1304,3 +1304,4 @@ import.address.geocode.error: Could not geocode address %failed_address%
 import.time.range.error: Time range "%value%" in %key% is not valid
 import.successful.rows: 'Your file was processed and %count% deliveries were created for rows: %rows%'
 import.delivery.price.error.priceCalculation.row: The delivery price could not be calculated for row %row_number%
+import.unsuccessful.rows: "There were errors and deliveries could not be created for rows: %rows%."

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1299,3 +1299,8 @@ profile.dabba.disconnect: Disconnect Dabba
 form.task_export.colisactiv.label: Export using ColivActiv format
 form.task_export.format.label: Export format
 tasks.mark_as_done.has_previous: 'Task #%failed_task% could not be completed because it has a previous task #%previous_task% which must be completed first.'
+import.errors.at.row: Errors at row %row_number%
+import.address.geocode.error: Could not geocode address %failed_address%
+import.time.range.error: Time range "%value%" in %key% is not valid
+import.successful.rows: 'Your file was processed and %count% deliveries were created for rows: %rows%'
+import.delivery.price.error.priceCalculation.row: The delivery price could not be calculated for row %row_number%

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -1290,3 +1290,8 @@ form.integration.productTypes.label: Tipo de productos permitidos
 form.integration.woopitStoreId.label: ID de tienda de Woopit
 integration.created.message: La integración ha sido creada.
 tasks.mark_as_done.has_previous: 'La tarea #%failed_task% no puede finalizarse porque tiene una tarea previa #%previous_task% que debe ser finalizada antes.'
+import.errors.at.row: Errores en fila %row_number%
+import.address.geocode.error: No se pudo geocodificar la dirección %failed_address%
+import.time.range.error: Rango de tiempo "%value%" en %key% no es válido
+import.successful.rows: 'Se procesó el archivo y se crearon %count% entregas correspondientes a las filas: %rows%'
+import.delivery.price.error.priceCalculation.row: El precio de la entrega no pudo ser calculado para la fila %row_number%

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -1295,3 +1295,4 @@ import.address.geocode.error: No se pudo geocodificar la dirección %failed_addr
 import.time.range.error: Rango de tiempo "%value%" en %key% no es válido
 import.successful.rows: 'Se procesó el archivo y se crearon %count% entregas correspondientes a las filas: %rows%'
 import.delivery.price.error.priceCalculation.row: El precio de la entrega no pudo ser calculado para la fila %row_number%
+import.unsuccessful.rows: "Se encontraron errores y no fue posible crear entregas para las filas: %rows%."


### PR DESCRIPTION
Closes #1726 
In order to make the error massages even more helpful when import deliveries: 

- [x] Show the multiple errors that are occurring in the import
- [x] Import only the correctly understood rows and not the erroneous rows
- [x] Inform well to the user which rows have been imported and which not


https://github.com/coopcycle/coopcycle-web/assets/4819244/ed0fe9b3-afa9-4fe2-b519-cfa5e2eceab8

**Explanation of new messages after imports**
![Captura de pantalla de 2023-06-16 14-59-57](https://github.com/coopcycle/coopcycle-web/assets/4819244/c631b73f-b191-404d-adbd-828737be6550)

