### PR TITLE
Migration to MercacdoPago SDK V2 and implementation of Bricks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,8 +27,7 @@ module.exports = {
     io: true,
     CoopCycle: true,
     Stripe: true,
-    google: true,
-    Mercadopago: true
+    google: true
   },
   settings: {
     react: {

--- a/js/app/i18n/locales/en.json
+++ b/js/app/i18n/locales/en.json
@@ -328,6 +328,10 @@
           "LIMIT": "A maximum of {{command}} orders every {{time}}"
         },
         "COPY": "Copy",
-        "COPIED": "Copied"
+        "COPIED": "Copied",
+        "PM_CREDIT_OR_DEBIT_CARD": "Credit or debit card",
+        "PM_CASH": "Cash",
+        "PM_EDENRED": "Edenred",
+        "PM_GIROPAY": "Giropay"
     }
 }

--- a/js/app/i18n/locales/es.json
+++ b/js/app/i18n/locales/es.json
@@ -312,6 +312,10 @@
           "TIME_UNIT": "minuto(s)",
           "NO_LIMIT": "Sin límite de pedidos",
           "LIMIT": "Un máximo de {{command}} pedidos cada {{time}}"
-        }
+        },
+        "PM_CREDIT_OR_DEBIT_CARD": "Tarjeta de crédito o débito",
+        "PM_CASH": "Efectivo",
+        "PM_EDENRED": "Edenred",
+        "PM_GIROPAY": "Giropay"
     }
 }

--- a/js/app/payment/mercadopago.js
+++ b/js/app/payment/mercadopago.js
@@ -1,165 +1,79 @@
-import React, { useState } from 'react'
-import { render, unmountComponentAtNode } from 'react-dom'
-import { PaymentInputsWrapper, usePaymentInputs } from 'react-payment-inputs'
-import images from 'react-payment-inputs/images'
-import _ from 'lodash'
-import { useTranslation } from 'react-i18next'
+import React from 'react'
+import { render } from 'react-dom'
 
-// @see https://www.mercadopago.com.mx/developers/es/guides/payments/api/receiving-payment-by-card/
-
-function getInstallments(cardNumber, amount, setPaymentMethod, setInstallments) {
-
-  const cardNumberClean = cardNumber.replace(/\s/g,'')
-
-  if (cardNumberClean.length >= 6) {
-      let bin = cardNumberClean.substring(0, 6)
-      // Obtener método de pago de la tarjeta
-      Mercadopago.getPaymentMethod({
-        "bin": bin
-      }, (status, response) => {
-        if (status === 200) {
-          setPaymentMethod(response[0].id)
-          // Obtener cantidad de cuotas
-          Mercadopago.getInstallments({
-            "payment_method_id": response[0].id,
-            "amount": (amount / 100),
-          }, (status, response) => {
-            if (status === 200) {
-              setInstallments(response[0].payer_costs)
-            } else {
-                alert(`installments method info error: ${response}`);
-            }
-          })
-        } else {
-          // TODO Show error message
-        }
-      })
-  }
-}
-
-const paymentMethodRef = React.createRef()
-const installmentsRef = React.createRef()
-
-const MercadoPagoForm = ({ amount, onChange }) => {
-
-  const { t } = useTranslation()
-
-  const [ cardNumber, setCardNumber ] = useState('')
-  const [ expiryDate, setExpiryDate ] = useState('')
-  const [ paymentMethod, setPaymentMethod ] = useState('')
-  const [ installments, setInstallments ] = useState([])
-
-  const {
-    wrapperProps,
-    getCardImageProps,
-    getCardNumberProps,
-    getExpiryDateProps,
-    getCVCProps,
-  } = usePaymentInputs()
-  const { error: formError } = wrapperProps
-  const [ expiryDateMonth, expiryDateYear ] = expiryDate.split('/').map(i => i.trim())
-
-  const cardNumberProps = getCardNumberProps({
-    onChange: e => {
-      // Obtener método de pago de la tarjeta
-      // Obtener cantidad de cuotas
-      getInstallments(e.target.value, amount, setPaymentMethod, setInstallments)
-      setCardNumber(e.target.value)
-    }
-  })
-
-  const expiryDateProps = getExpiryDateProps({
-    onChange: e => setExpiryDate(e.target.value)
-  })
-
-  const cvcProps = getCVCProps()
-
-  React.useEffect(() => {
-    onChange(formError === undefined)
-  }, [formError])
-
-  return (
-    <React.Fragment>
-      <div className="form-group">
-        <label className="control-label required">
-          { t('PAYMENT_FORM_CARDHOLDER_NAME') }
-        </label>
-        <input type="text"
-          required="required"
-          data-checkout="cardholderName"
-          className="form-control" />
-      </div>
-      <div className="form-group">
-        <PaymentInputsWrapper { ...wrapperProps }>
-          <input type="hidden" data-checkout="cardNumber" value={ cardNumber } />
-          { /* Mercado Pago expects separate fields for month & year */ }
-          <input type="hidden" data-checkout="cardExpirationMonth" value={ expiryDateMonth || '' } />
-          <input type="hidden" data-checkout="cardExpirationYear" value={ expiryDateYear || '' } />
-
-          <svg { ...getCardImageProps({ images }) } />
-          { /* We need to remove the "name" attributes from the managed fields, for security */ }
-          { /* @see https://github.com/medipass/react-payment-inputs/issues/47 */ }
-          <input { ..._.omit(cardNumberProps, ['name']) } />
-          <input { ..._.omit(expiryDateProps, ['name']) } />
-          <input { ..._.omit(cvcProps, ['name']) } data-checkout="securityCode" />
-          { /* The value of the fields below will be copied to the "real" form fields before creating a token */ }
-          { installments.length > 0 && (
-            <select ref={ installmentsRef }>
-              { installments.map((installment, i) => (
-                <option key={ `installment-${i}` }
-                  value={ installment.installments }>{ installment.recommended_message }</option>
-              )) }
-            </select>
-          ) }
-          <input type="hidden" ref={ paymentMethodRef } value={ paymentMethod || '' } />
-        </PaymentInputsWrapper>
-      </div>
-    </React.Fragment>
-  );
-}
-
-export default ({ onChange }) => ({
-  init(form) {
-    this.form = form
-    const { country, publishableKey } = this.config.gatewayConfig
+/**
+ * see https://www.mercadopago.com.ar/developers/en/docs/checkout-bricks/card-payment-brick/introduction
+ */
+export default {
+  async init() {
+    const { publishableKey } = this.config.gatewayConfig
 
     if (!publishableKey) {
       throw new Error('You need a Public Key for Mercadopago')
     }
 
-    Mercadopago.setPublishableKey(publishableKey)
-
-    if (country !== 'mx') {
-      Mercadopago.getIdentificationTypes()
-    }
+    this.mpInstance = new window.MercadoPago(publishableKey);
   },
-  mount(el) {
-    this.el = el
+  async mount(el) {
     return new Promise((resolve) => {
-      render(<MercadoPagoForm
-        amount={ this.config.amount }
-        onChange={onChange} />, el, resolve)
-    })
-  },
-  unmount() {
-    unmountComponentAtNode(this.el)
-  },
-  createToken() {
-
-    // FIXME There must be a better way
-    document.getElementById('checkout_payment_paymentMethod').value = paymentMethodRef.current.value
-    document.getElementById('checkout_payment_installments').value = installmentsRef.current.value
-
-    return new Promise((resolve, reject) => {
-      Mercadopago.createToken(this.form, function(status, response) {
-        if (status !== 200 && status !== 201) {
-          // TODO Show error
-          console.error(response)
-          reject(new Error('The payment data is not valid'))
-        } else {
-          resolve(response.id)
-        }
+      render(<div id="cardPaymentBrick_container"></div>, el, async () => {
+        await this.createBrickContainer()
+        resolve()
       })
     })
+  },
+  async createBrickContainer() {
+    const bricksBuilder = this.mpInstance.bricks()
+
+    const settings = {
+      initialization: {
+        amount: (this.config.amount / 100),
+      },
+      customization: {
+        visual: {
+          hidePaymentButton: true,
+          style: { theme: 'bootstrap' }
+        }
+      },
+      callbacks: {
+        onReady: () => document.getElementById('cardPaymentBrick_container').scrollIntoView(),
+        onError: (error) => {
+          console.error(JSON.stringify(error))
+          document.getElementById('card-errors').textContent = error.message
+        },
+      },
+    }
+
+    window.cardPaymentBrickController = await bricksBuilder.create('cardPayment', 'cardPaymentBrick_container', settings)
+  },
+  unmount() {
+    window.cardPaymentBrickController.unmount()
+  },
+  async createToken() {
+    const data = await window.cardPaymentBrickController.getFormData()
+
+    if (!data) {
+      return null
+    }
+
+    document.getElementById('checkout_payment_paymentMethod').value = data.payment_method_id
+    document.getElementById('checkout_payment_installments').value = data.installments ? data.installments : 1
+
+    const cardTokenData = {
+      cardholderName: document.getElementById('cardPaymentBrick_container').querySelector('input[name="HOLDER_NAME"]').value,
+      identificationType: data.payer.identification.type,
+      identificationNumber: data.payer.identification.number,
+    }
+
+    try {
+      const token = await this.mpInstance.fields.createCardToken(cardTokenData);
+      return token.id
+    } catch(err) {
+      if (err.message) {
+        throw new Error(err.message)
+      } else {
+        throw new Error('An unexpected error occurred, please try again later')
+      }
+    }
   }
-})
+}

--- a/js/app/widgets/StripePaymentForm.js
+++ b/js/app/widgets/StripePaymentForm.js
@@ -109,8 +109,13 @@ const containsMethod = (methods, method) => !!_.find(methods, m => m.type === me
 const handleCardPayment = (cc, options, form, submitButton, savedPaymentMethodId = null) => {
   cc.createToken(savedPaymentMethodId)
     .then(token => {
-      options.tokenElement.setAttribute('value', token)
-      form.submit()
+      if (token) {
+        options.tokenElement.setAttribute('value', token)
+        form.submit()
+      } else {
+        $('.btn-payment').removeClass('btn-payment__loading')
+        enableBtn(submitButton)
+      }
     })
     .catch(e => {
       $('.btn-payment').removeClass('btn-payment__loading')
@@ -143,7 +148,7 @@ export default function(form, options) {
 
     switch (gatewayForCard) {
       case 'mercadopago':
-        Object.assign(CreditCard.prototype, mercadopago({ onChange: toggleButton }))
+        Object.assign(CreditCard.prototype, mercadopago)
         break
       case 'stripe':
       default:
@@ -235,10 +240,6 @@ export default function(form, options) {
               cashDisclaimer.remove()
             }
 
-            if ("mercadopago" === options.card) {
-              document.getElementById('mercadopago_identification_fields').style.display = "block"
-            }
-
             cc.mount(document.getElementById('card-element'), value, response.data, options).then(() => {
               document.getElementById('card-element').scrollIntoView()
               enableBtn(submitButton)
@@ -254,10 +255,6 @@ export default function(form, options) {
             if (document.getElementById('card-element').children.length) {
               // remove cc form if it was previously mounted
               cc && cc.unmount()
-              if ("mercadopago" === options.card) {
-                // remove mercadopago identification fields if it was previously selected
-                document.getElementById('mercadopago_identification_fields').style.display = "none"
-              }
             }
 
             enableBtn(submitButton)
@@ -287,10 +284,6 @@ export default function(form, options) {
     .forEach(el => el.classList.add('d-none'))
 
   if (methods.length === 1 && containsMethod(methods, 'card')) {
-    if ("mercadopago" === options.card) {
-      document.getElementById('mercadopago_identification_fields').style.display = "block"
-    }
-
     cc.mount(document.getElementById('card-element'), null, null, options).then(() => enableBtn(submitButton))
   } else {
 

--- a/js/app/widgets/StripePaymentForm.js
+++ b/js/app/widgets/StripePaymentForm.js
@@ -9,6 +9,8 @@ import stripe from '../payment/stripe'
 import mercadopago from '../payment/mercadopago'
 import { Disclaimer } from '../payment/cashOnDelivery'
 
+import { useTranslation } from 'react-i18next'
+
 function disableBtn(btn) {
   btn.setAttribute('disabled', '')
   btn.disabled = true
@@ -24,6 +26,7 @@ const methodPickerStyles = {
   flexDirection: 'row',
   alignItems: 'center',
   justifyContent: 'space-between',
+  marginTop: '8px'
 }
 
 const methodPickerBtnClassNames = {
@@ -32,7 +35,16 @@ const methodPickerBtnClassNames = {
   'p-2': true
 }
 
+const methodStyles = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'start',
+  justifyContent: 'space-between',
+}
+
 const PaymentMethodPicker = ({ methods, onSelect }) => {
+
+  const { t } = useTranslation()
 
   const [ method, setMethod ] = useState('')
 
@@ -50,46 +62,58 @@ const PaymentMethodPicker = ({ methods, onSelect }) => {
 
         case 'card':
           return (
-            <button key={ m.type } type="button" className={ classNames({ ...methodPickerBtnClassNames, active: method === 'card' }) }
-              onClick={ () => setMethod('card') }>
-              <PaymentMethodIcon code={ m.type } height="45" />
-            </button>
+            <div style={ methodStyles }>
+              <label>{ t('PM_CREDIT_OR_DEBIT_CARD') }</label>
+              <button key={ m.type } type="button" className={ classNames({ ...methodPickerBtnClassNames, active: method === 'card' }) }
+                onClick={ () => setMethod('card') }>
+                <PaymentMethodIcon code={ m.type } height="45" />
+              </button>
+            </div>
           )
 
         case 'giropay':
 
           return (
-            <button key={ m.type } type="button" className={ classNames({ ...methodPickerBtnClassNames, active: method === 'giropay' }) }
-              onClick={ () => setMethod('giropay') }>
-              <PaymentMethodIcon code={ m.type } height="45" />
-            </button>
+            <div style={ methodStyles }>
+              <label>{ t('PM_GIROPAY') }</label>
+              <button key={ m.type } type="button" className={ classNames({ ...methodPickerBtnClassNames, active: method === 'giropay' }) }
+                onClick={ () => setMethod('giropay') }>
+                <PaymentMethodIcon code={ m.type } height="45" />
+              </button>
+            </div>
           )
 
         case 'edenred':
         case 'edenred+card':
 
           return (
-            <button key={ m.type } type="button" className={ classNames({ ...methodPickerBtnClassNames, active: method === m.type }) }
-              onClick={ () => {
+            <div style={ methodStyles }>
+              <label>{ t('PM_EDENRED') }</label>
+              <button key={ m.type } type="button" className={ classNames({ ...methodPickerBtnClassNames, active: method === m.type }) }
+                onClick={ () => {
 
-                if (!m.data.edenredIsConnected) {
-                  window.location.href = m.data.edenredAuthorizeUrl
-                  return
-                }
+                  if (!m.data.edenredIsConnected) {
+                    window.location.href = m.data.edenredAuthorizeUrl
+                    return
+                  }
 
-                setMethod(m.type)
-              }}>
-              <PaymentMethodIcon code={ m.type } height="45" />
-            </button>
+                  setMethod(m.type)
+                }}>
+                <PaymentMethodIcon code={ m.type } height="45" />
+              </button>
+            </div>
           )
 
         case 'cash_on_delivery':
 
           return (
-            <button key={ m.type } type="button" className={ classNames({ ...methodPickerBtnClassNames, active: method === m.type }) }
-              onClick={ () => setMethod('cash_on_delivery') }>
-              <PaymentMethodIcon code={ m.type } height="45" />
-            </button>
+            <div style={ methodStyles }>
+              <label>{ t('PM_CASH') }</label>
+              <button key={ m.type } type="button" className={ classNames({ ...methodPickerBtnClassNames, active: method === m.type }) }
+                onClick={ () => setMethod('cash_on_delivery') }>
+                <PaymentMethodIcon code={ m.type } height="45" />
+              </button>
+              </div>
           )
 
         }

--- a/js/app/widgets/StripePaymentForm.js
+++ b/js/app/widgets/StripePaymentForm.js
@@ -128,8 +128,6 @@ export default function(form, options) {
 
   const submitButton = form.querySelector('input[type="submit"],button[type="submit"]')
 
-  const toggleButton = isValidForm => isValidForm ? enableBtn(submitButton) : disableBtn(submitButton)
-
   const methods = Array
     .from(form.querySelectorAll('input[name="checkout_payment[method]"]'))
     .map((el) => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -110,7 +110,6 @@
         "react-i18next": "^11.18.6",
         "react-markdown": "^8.0.3",
         "react-modal": "^3.16.1",
-        "react-payment-inputs": "^1.1.9",
         "react-phone-number-input": "^3.2.12",
         "react-redux": "^7.2.9",
         "react-select": "^4.3.1",
@@ -18397,16 +18396,6 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18",
         "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18"
-      }
-    },
-    "node_modules/react-payment-inputs": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/react-payment-inputs/-/react-payment-inputs-1.1.9.tgz",
-      "integrity": "sha512-k5j6fFCqcYRqbLP8UjWxJlNZXwVCO0pApXBLYvZZkTCPlqxXyumcnkxToHbLwLfO4Sxey3lD3At9Hwi8AAw0Ig==",
-      "dev": true,
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "styled-components": ">=4.0.0"
       }
     },
     "node_modules/react-phone-number-input": {
@@ -37208,13 +37197,6 @@
         "react-lifecycles-compat": "^3.0.0",
         "warning": "^4.0.3"
       }
-    },
-    "react-payment-inputs": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/react-payment-inputs/-/react-payment-inputs-1.1.9.tgz",
-      "integrity": "sha512-k5j6fFCqcYRqbLP8UjWxJlNZXwVCO0pApXBLYvZZkTCPlqxXyumcnkxToHbLwLfO4Sxey3lD3At9Hwi8AAw0Ig==",
-      "dev": true,
-      "requires": {}
     },
     "react-phone-number-input": {
       "version": "3.2.12",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "react-i18next": "^11.18.6",
     "react-markdown": "^8.0.3",
     "react-modal": "^3.16.1",
-    "react-payment-inputs": "^1.1.9",
     "react-phone-number-input": "^3.2.12",
     "react-redux": "^7.2.9",
     "react-select": "^4.3.1",

--- a/templates/embed/delivery/summary.html.twig
+++ b/templates/embed/delivery/summary.html.twig
@@ -54,29 +54,6 @@
     {{ form_row(form.method) }}
   {% endif %}
 
-  {% if gateway == 'mercadopago' and (mercadopago_can_enable_testmode() or mercadopago_can_enable_livemode()) %}
-    <div id="mercadopago_identification_fields" style="display: none;">
-      <div class="form-group">
-        <label for="email">{{ 'order.payer.email'|trans }}</label>
-        <input class="form-control" id="email" name="email" type="text" value="{{ order.customer.email }}" />
-      </div>
-      {#
-      In Mexico, we don't need identification documents
-      https://www.mercadopago.com.br/developers/en/guides/resources/localization/identification-types/
-      #}
-      {% if country != 'mx' %}
-        <div class="form-group">
-          <label for="docType">{{ 'order.payer.identificationType'|trans }}</label>
-          <select class="form-control" id="docType" name="docType" data-checkout="docType" type="text"></select>
-        </div>
-        <div class="form-group">
-          <label for="docNumber">{{ 'order.payer.identificationNumber'|trans }}</label>
-          <input class="form-control" id="docNumber" name="docNumber" data-checkout="docNumber" type="text"/>
-        </div>
-      {% endif %}
-    </div>
-  {% endif %}
-
   {{ form_widget(form.stripePayment.stripeToken) }}
   {{ form_widget(form.stripePayment.savedPaymentMethodId) }}
   <div id="card-element">
@@ -119,7 +96,7 @@
 {% endif %}
 
 {% if gateway == 'mercadopago' %}
-<script src="https://secure.mlstatic.com/sdk/javascript/v1/mercadopago.js"></script>
+<script src="https://sdk.mercadopago.com/js/v2"></script>
 {% set gateway_configs = gateway_configs|merge({
   mercadopago: {
     publishableKey: coopcycle_setting('mercadopago_publishable_key'),

--- a/templates/order/payment.html.twig
+++ b/templates/order/payment.html.twig
@@ -26,30 +26,6 @@
           </div>
         </div>
 
-        {% if gateway == 'mercadopago' and (mercadopago_can_enable_testmode() or mercadopago_can_enable_livemode()) %}
-          <div id="mercadopago_identification_fields" style="display: none;">
-            <h4 class="bg-light p-3 m-0 mb-4">{{ 'order.payer.title'|trans }}</h4>
-            <div class="form-group">
-              <label for="email">{{ 'order.payer.email'|trans }}</label>
-              <input class="form-control" id="email" name="email" type="text" />
-            </div>
-            {#
-            In Mexico, we don't need identification documents
-            https://www.mercadopago.com.br/developers/en/guides/resources/localization/identification-types/
-            #}
-            {% if country != 'mx' %}
-              <div class="form-group">
-                <label for="docType">{{ 'order.payer.identificationType'|trans }}</label>
-                <select class="form-control" id="docType" name="docType" data-checkout="docType" type="text"></select>
-              </div>
-              <div class="form-group">
-                <label for="docNumber">{{ 'order.payer.identificationNumber'|trans }}</label>
-                <input class="form-control" id="docNumber" name="docNumber" data-checkout="docNumber" type="text"/>
-              </div>
-            {% endif %}
-          </div>
-        {% endif %}
-
         <div>
           <h4 class="bg-light p-3 m-0 mb-4">{% trans %}order.payment.title{% endtrans %}</h4>
           <div>
@@ -129,7 +105,7 @@
 {% endif %}
 
 {% if gateway == 'mercadopago' and (mercadopago_can_enable_testmode() or mercadopago_can_enable_livemode()) %}
-<script src="https://secure.mlstatic.com/sdk/javascript/v1/mercadopago.js"></script>
+<script src="https://sdk.mercadopago.com/js/v2"></script>
 {% set gateway_configs = gateway_configs|merge({
   mercadopago: {
     publishableKey: coopcycle_setting('mercadopago_publishable_key'),

--- a/templates/public/order.html.twig
+++ b/templates/public/order.html.twig
@@ -113,7 +113,7 @@
 {% endif %}
 
 {% if gateway == 'mercadopago' %}
-<script src="https://secure.mlstatic.com/sdk/javascript/v1/mercadopago.js"></script>
+<script src="https://sdk.mercadopago.com/js/v2"></script>
 {% set gateway_configs = gateway_configs|merge({
   mercadopago: {
     publishableKey: coopcycle_setting('mercadopago_test_publishable_key'),


### PR DESCRIPTION
Fixes #3701 

- [x] Added support for payment methods which don't support deferred capture.
- [x] Migration of MP SDK V1 to V2 (this migration is already a must for test credentials, in a short time will be a must for production as well)
- [x] With MP SDK V2 implemented, a new and better way to handle front end integration with MercadoPago is available [MP Bricks](https://www.mercadopago.com.ar/developers/en/docs/checkout-bricks/card-payment-brick/introduction)
- [x] Added labels to each icon on Payment Methods picker

https://github.com/coopcycle/coopcycle-web/assets/4819244/28f6f22e-6872-41bd-ae84-2135e164abeb