### PR TITLE
Apply pricing rules for deliveries with multiple tasks.

### DIFF
--- a/src/Entity/Delivery.php
+++ b/src/Entity/Delivery.php
@@ -417,11 +417,8 @@ class Delivery extends TaskCollection implements TaskCollectionInterface, Packag
     {
         $taskObject = new \stdClass();
         if ($task) {
-            $taskObject->address = $task->getAddress();
-            $taskObject->createdAt = $task->getCreatedAt();
-            $taskObject->after = $task->getAfter();
-            $taskObject->before = $task->getBefore();
-            $taskObject->doorstep = $task->isDoorstep();
+
+            return $task->toExpressionLanguageObject();
         }
 
         return $taskObject;

--- a/src/ExpressionLanguage/PickupExpressionLanguageProvider.php
+++ b/src/ExpressionLanguage/PickupExpressionLanguageProvider.php
@@ -69,6 +69,12 @@ class PickupExpressionLanguageProvider implements ExpressionFunctionProviderInte
 
         $timeRangeLengthEvaluator = function ($arguments, $task, $unit) {
 
+            // May happen for multiple points
+            // FIXME Won't work as expected when using "less than", i.e time_range_length(pickup) < 3
+            if (null === $task->after || null === $task->before) {
+                return -1;
+            }
+
             $after = Carbon::instance($task->after);
             $before = Carbon::instance($task->before);
 

--- a/src/ExpressionLanguage/PickupExpressionLanguageProvider.php
+++ b/src/ExpressionLanguage/PickupExpressionLanguageProvider.php
@@ -24,6 +24,12 @@ class PickupExpressionLanguageProvider implements ExpressionFunctionProviderInte
                 $now = Carbon::instance($task->createdAt);
             }
 
+            // May happen for multiple points
+            // FIXME Won't work as expected when using "less than", i.e diff_days(pickup) < 3
+            if (null === $task->before) {
+                return -1;
+            }
+
             $before = Carbon::instance($task->before);
             $diff = $before->diffInDays($now);
 
@@ -44,6 +50,12 @@ class PickupExpressionLanguageProvider implements ExpressionFunctionProviderInte
 
             if (isset($task->createdAt) && null !== $task->createdAt) {
                 $now = Carbon::instance($task->createdAt);
+            }
+
+            // May happen for multiple points
+            // FIXME Won't work as expected when using "less than", i.e diff_days(pickup) < 3
+            if (null === $task->before) {
+                return -1;
             }
 
             $before = Carbon::instance($task->before);

--- a/src/Pricing/PricingRuleMatcherInterface.php
+++ b/src/Pricing/PricingRuleMatcherInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AppBundle\Pricing;
+
+use AppBundle\Entity\Delivery\PricingRule;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+interface PricingRuleMatcherInterface
+{
+    public function matchesPricingRule(PricingRule $pricingRule, ExpressionLanguage $language = null);
+    public function toExpressionLanguageValues();
+}

--- a/src/Service/DeliveryManager.php
+++ b/src/Service/DeliveryManager.php
@@ -64,16 +64,33 @@ class DeliveryManager
             $totalPrice = 0;
             $matchedAtLeastOne = false;
 
-            foreach ($ruleSet->getRules() as $rule) {
-                if ($rule->matches($delivery, $this->expressionLanguage)) {
+            if (count($delivery->getTasks()) > 2) {
+                foreach ($delivery->getTasks() as $task) {
+                    foreach ($ruleSet->getRules() as $rule) {
+                        if ($task->matchesPricingRule($rule, $this->expressionLanguage)) {
 
-                    $price = $rule->evaluatePrice($delivery, $this->expressionLanguage);
+                            $price = $rule->evaluatePrice($delivery, $this->expressionLanguage);
 
-                    $this->logger->info(sprintf('Matched rule "%s", adding %d to price', $rule->getExpression(), $price));
+                            $this->logger->info(sprintf('Matched rule "%s", adding %d to price', $rule->getExpression(), $price));
 
-                    $totalPrice += $price;
+                            $totalPrice += $price;
 
-                    $matchedAtLeastOne = true;
+                            $matchedAtLeastOne = true;
+                        }
+                    }
+                }
+            } else {
+                foreach ($ruleSet->getRules() as $rule) {
+                    if ($rule->matches($delivery, $this->expressionLanguage)) {
+
+                        $price = $rule->evaluatePrice($delivery, $this->expressionLanguage);
+
+                        $this->logger->info(sprintf('Matched rule "%s", adding %d to price', $rule->getExpression(), $price));
+
+                        $totalPrice += $price;
+
+                        $matchedAtLeastOne = true;
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixes #3047

This is the simplest implementation possible, without modifying the pricing editor. 
When using the "All the matching rules" method of calculation AND having multiple tasks, the system will iterate over all the tasks, and try to apply the rules. 

⚠️ There are still some limitations. 

- Some conditions don't make sense at the task level, for example the distance. 

- Also, timing conditions won't work as expected when using "less than" operator. It is because when using the "Difference (hours)" condition, it translates to an expression like `diff_hours(pickup) < 3`. The current implementation returns `-1` when the task is not of the expected type (i.e, when evaluating a dropoff), so it will still match the "less than" operator. A solution would be to change the generated expression, to avoid using an operator, and use a boolean. For example it would generate an expression like `time_diff(pickup, "<", 3)`. 