### PR TITLE
Notifications improvements

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -683,6 +683,8 @@ fos_js_routing:
         - profile_jwt
         - profile_notifications
         - profile_notifications_mark_as_read
+        - profile_notifications_remove
+        - profile_notification_remove
         - dashboard_order_accept
         - dashboard_order_refuse
         - dashboard_order_cancel

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,4 @@
+import './styles/app.css';
+
+// start the Stimulus application
+import './bootstrap.js';

--- a/assets/bootstrap.js
+++ b/assets/bootstrap.js
@@ -1,0 +1,12 @@
+import { startStimulusApp } from '@symfony/stimulus-bridge';
+// import turbo_controller from '@symfony/ux-turbo';
+
+// Registers Stimulus controllers from controllers.json and in the controllers/ directory
+export const app = startStimulusApp(require.context(
+    '@symfony/stimulus-bridge/lazy-controller-loader!./controllers',
+    true,
+    /\.(j|t)sx?$/
+));
+
+// register any custom, 3rd party controllers here
+// app.register('turbo_controller', turbo_controller);

--- a/assets/controllers.json
+++ b/assets/controllers.json
@@ -1,0 +1,15 @@
+{
+    "controllers": {
+        "@symfony/ux-turbo": {
+            "turbo-core": {
+                "enabled": true,
+                "fetch": "eager"
+            },
+            "mercure-turbo-stream": {
+                "enabled": false,
+                "fetch": "eager"
+            }
+        }
+    },
+    "entrypoints": []
+}

--- a/assets/styles/app.css
+++ b/assets/styles/app.css
@@ -1,0 +1,3 @@
+body {
+    background-color: lightgray;
+}

--- a/composer.json
+++ b/composer.json
@@ -134,7 +134,9 @@
         "sylius/calendar": "^0.3",
         "twig/markdown-extra": "^3.4",
         "league/commonmark": "^2.3",
-        "acseo/typesense-bundle": "dev-service-as-getter"
+        "acseo/typesense-bundle": "dev-service-as-getter",
+        "symfony/stimulus-bundle": "^2.10",
+        "symfony/ux-turbo": "^2.10"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c27675de450d9f7a0b2366a71fe4606",
+    "content-hash": "d2f3b284ba1533ce011353cc70f0f484",
     "packages": [
         {
             "name": "acseo/typesense-bundle",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2f3b284ba1533ce011353cc70f0f484",
+    "content-hash": "6d8b4081fabfd3fa19b48784d084b2f7",
     "packages": [
         {
             "name": "acseo/typesense-bundle",
@@ -18499,6 +18499,74 @@
             "time": "2023-07-19T20:11:33+00:00"
         },
         {
+            "name": "symfony/stimulus-bundle",
+            "version": "v2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stimulus-bundle.git",
+                "reference": "257ef052bebe491d7c29e9a4a8009edb82269e15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stimulus-bundle/zipball/257ef052bebe491d7c29e9a4a8009edb82269e15",
+                "reference": "257ef052bebe491d7c29e9a4a8009edb82269e15",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/finder": "^5.4|^6.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "twig/twig": "^2.15.3|^3.4.3"
+            },
+            "require-dev": {
+                "symfony/asset-mapper": "6.3.x-dev",
+                "symfony/framework-bundle": "^5.4|^6.0",
+                "symfony/phpunit-bridge": "^5.4|^6.0",
+                "symfony/twig-bundle": "^5.4|^6.0",
+                "zenstruck/browser": "^1.4"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\UX\\StimulusBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Integration with your Symfony app & Stimulus!",
+            "keywords": [
+                "symfony-ux"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/stimulus-bundle/tree/v2.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-06-29T19:46:37+00:00"
+        },
+        {
             "name": "symfony/symfony",
             "version": "v5.4.28",
             "source": {
@@ -18718,6 +18786,102 @@
                 }
             ],
             "time": "2023-08-26T13:48:05+00:00"
+        },
+        {
+            "name": "symfony/ux-turbo",
+            "version": "v2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/ux-turbo.git",
+                "reference": "9762c373ed54c3642a4ae64b9254bc1c454f7da0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/ux-turbo/zipball/9762c373ed54c3642a4ae64b9254bc1c454f7da0",
+                "reference": "9762c373ed54c3642a4ae64b9254bc1c454f7da0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/stimulus-bundle": "^2.9.1"
+            },
+            "conflict": {
+                "symfony/flex": "<1.13"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.12",
+                "doctrine/doctrine-bundle": "^2.4.3",
+                "doctrine/orm": "^2.8 | 3.0",
+                "phpstan/phpstan": "^1.10",
+                "symfony/debug-bundle": "^5.4|^6.0",
+                "symfony/expression-language": "^5.4|^6.0",
+                "symfony/form": "^5.4|^6.0",
+                "symfony/framework-bundle": "^5.4|^6.0",
+                "symfony/mercure-bundle": "^0.3.4",
+                "symfony/messenger": "^5.4|^6.0",
+                "symfony/panther": "^1.0|^2.0",
+                "symfony/phpunit-bridge": "^5.4|^6.0",
+                "symfony/property-access": "^5.4|^6.0",
+                "symfony/security-core": "^5.4|^6.0",
+                "symfony/stopwatch": "^5.4|^6.0",
+                "symfony/twig-bundle": "^5.4|^6.0",
+                "symfony/web-profiler-bundle": "^5.4|^6.0",
+                "symfony/webpack-encore-bundle": "^1.11"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/ux",
+                    "url": "https://github.com/symfony/ux"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\UX\\Turbo\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "kevin@dunglas.fr"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Hotwire Turbo integration for Symfony",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "hotwire",
+                "javascript",
+                "mercure",
+                "symfony-ux",
+                "turbo",
+                "turbo-stream"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/ux-turbo/tree/v2.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-06-19T13:59:38+00:00"
         },
         {
             "name": "symfony/webpack-encore-bundle",

--- a/js/app/i18n/locales/en.json
+++ b/js/app/i18n/locales/en.json
@@ -335,6 +335,7 @@
         "PM_CASH": "Cash",
         "PM_EDENRED": "Edenred",
         "PM_GIROPAY": "Giropay",
-        "ADMIN_DASHBOARD_SETTINGS_TOURS_ENABLED": "Show tours panel"
+        "ADMIN_DASHBOARD_SETTINGS_TOURS_ENABLED": "Show tours panel",
+        "SEE_ALL": "See all"
     }
 }

--- a/js/app/i18n/locales/es.json
+++ b/js/app/i18n/locales/es.json
@@ -318,6 +318,7 @@
         "PM_CASH": "Efectivo",
         "PM_EDENRED": "Edenred",
         "PM_GIROPAY": "Giropay",
-        "ADMIN_DASHBOARD_SETTINGS_TOURS_ENABLED": "Mostrar el tablero de rutas"
+        "ADMIN_DASHBOARD_SETTINGS_TOURS_ENABLED": "Mostrar el tablero de rutas",
+        "SEE_ALL": "Ver todo"
     }
 }

--- a/js/app/notifications/NotificationList.js
+++ b/js/app/notifications/NotificationList.js
@@ -6,28 +6,9 @@ moment.locale($('html').attr('lang'))
 
 class NotificationList extends React.Component {
 
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      notifications: props.notifications.slice(0, 5)
-    }
-  }
-
-  unshift(notification) {
-    const { notifications } = this.state
-    notifications.unshift(notification)
-    this.setState({ notifications: notifications.slice(0, 5) })
-  }
-
-  toArray() {
-    const { notifications } = this.state
-    return notifications
-  }
-
   render() {
 
-    const { notifications } = this.state
+    const { notifications, count, onSeeAll, onRemove } = this.props
 
     if (notifications.length === 0) {
       return (
@@ -36,17 +17,29 @@ class NotificationList extends React.Component {
     }
 
     return (
-      <ul className="nav nav-pills nav-stacked">
-        { notifications.map((notification, key) => (
-          <li key={ `notification-${key}` }>
-            <a>
-              { notification.message }
-              <br />
-              <small>{ moment.unix(notification.timestamp).fromNow() }</small>
-            </a>
-          </li>
-        ))}
-      </ul>
+      <div>
+        <ul className="nav nav-pills nav-stacked" style={ {height: '60vh', overflow: 'auto'} }>
+          { notifications.map((notification, key) => (
+            <li className='d-flex justify-content-between align-items-center' key={ `notification-${key}` }>
+              <a className='flex-grow-1'>
+                { notification.message }
+                <br />
+                <small>{ moment.unix(notification.timestamp).fromNow() }</small>
+              </a>
+              <a role="button" href="#" className="text-reset"
+                onClick={ () => onRemove(notification) }>
+                <i className="fa fa-trash"></i>
+              </a>
+            </li>
+          ))}
+        </ul>
+        {
+          count > notifications.length &&
+          <button type="button" className="btn btn-block btn-primary mt-2" onClick={ onSeeAll }>
+            { this.props.t('SEE_ALL') } ({count})
+          </button>
+        }
+      </div>
     )
   }
 }

--- a/js/app/notifications/index.js
+++ b/js/app/notifications/index.js
@@ -17,9 +17,8 @@ const zeroStyleDark = {
   boxShadow: '0 0 0 1px #d9d9d9 inset'
 }
 
-const Notifications = ({ initialNotifications, initialCount, onOpen, centrifuge, namespace, username, theme }) => {
+const Notifications = ({ initialNotifications, initialCount, centrifuge, namespace, username, theme, onSeeAll, removeURL }) => {
 
-  const [ visible, setVisible ] = useState(false)
   const [ notifications, setNotifications ] = useState(initialNotifications)
   const [ count, setCount ] = useState(initialCount)
 
@@ -43,11 +42,15 @@ const Notifications = ({ initialNotifications, initialCount, onOpen, centrifuge,
     centrifuge.connect()
   }, [])
 
-  useEffect(() => {
-    if (visible) {
-      onOpen(notifications)
-    }
-  }, [ visible ])
+  const onRemove = (notification) => {
+    $.ajax(`${removeURL}/${notification.id}?format=json`, {
+      type: 'DELETE',
+      contentType: 'application/json',
+    }).then((res) => {
+      setNotifications(Object.values(res.notifications))
+      setCount(res.unread)
+    })
+  }
 
   const badgeProps = count === 0 ?
     { style: theme === 'dark' ? zeroStyleDark : zeroStyle } : { style: { backgroundColor: '#52c41a' } }
@@ -55,12 +58,9 @@ const Notifications = ({ initialNotifications, initialCount, onOpen, centrifuge,
   return (
     <Popover
       placement="bottomRight"
-      content={ <NotificationList notifications={ notifications } /> }
+      content={ <NotificationList onSeeAll={ onSeeAll } onRemove={ onRemove } count={ count } notifications={ notifications } /> }
       title="Notifications"
-      trigger="click"
-      visible={ visible }
-      onVisibleChange={ value => setVisible(value) }
-    >
+      trigger="click">
       <a href="#">
         <Badge count={ count } showZero { ...badgeProps } title={ `${count} new notification(s)` } />
       </a>
@@ -88,14 +88,8 @@ function bootstrap(el, options) {
     render(<Notifications
       initialNotifications={ notifications }
       initialCount={ unread }
-      onOpen={ (notifications) => {
-        const notificationsIds = notifications.map(notification => notification.id)
-        $.ajax(options.markAsReadURL, {
-          type: 'POST',
-          contentType: 'application/json',
-          data: JSON.stringify(notificationsIds),
-        })
-      }}
+      removeURL={ options.removeNotificationURL }
+      onSeeAll={ () => { window.location.href = options.notificationsURL } }
       centrifuge={ centrifuge }
       namespace={ options.namespace }
       username={ options.username }
@@ -108,7 +102,7 @@ $.getJSON(window.Routing.generate('profile_jwt'))
   .then(result => {
     const options = {
       notificationsURL: window.Routing.generate('profile_notifications'),
-      markAsReadURL:    window.Routing.generate('profile_notifications_mark_as_read'),
+      removeNotificationURL:    window.Routing.generate('profile_notification_remove'),
       token:     result.cent_tok,
       namespace: result.cent_ns,
       username:  result.cent_usr,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@hotwired/stimulus": "^3.2.2",
+        "@symfony/stimulus-bridge": "^3.2.2",
         "dotenv": "^8.6.0",
         "form-data": "^2.3.3",
         "lodash": "^4.17.21",
@@ -28,6 +30,7 @@
         "@release-notes/changelog-parser": "^0.1.2",
         "@stripe/react-stripe-js": "^1.7.0",
         "@stripe/stripe-js": "^1.22.0",
+        "@symfony/ux-turbo": "file:vendor/symfony/ux-turbo/assets",
         "@symfony/webpack-encore": "^1.1.2",
         "antd": "^4.24.5",
         "autoprefixer": "^10.4.13",
@@ -2398,6 +2401,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@hotwired/stimulus": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
+      "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A=="
+    },
+    "node_modules/@hotwired/stimulus-webpack-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus-webpack-helpers/-/stimulus-webpack-helpers-1.0.1.tgz",
+      "integrity": "sha512-wa/zupVG0eWxRYJjC1IiPBdt3Lruv0RqGN+/DTMmUWUyMAEB27KXmVY6a8YpUVTM7QwVuaLNGW4EqDgrS2upXQ==",
+      "peerDependencies": {
+        "@hotwired/stimulus": ">= 3.0"
+      }
+    },
+    "node_modules/@hotwired/turbo": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.3.0.tgz",
+      "integrity": "sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -3448,6 +3473,89 @@
       "integrity": "sha512-drlXsNvd/s9S1+Ghja0aDB81N3Wr/6iRAZ7MOzKv7AtKxVdvGpOwESw3z1lHl/Wx/rvPpA7whKdB3W2CnVSArw==",
       "dev": true
     },
+    "node_modules/@symfony/stimulus-bridge": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@symfony/stimulus-bridge/-/stimulus-bridge-3.2.2.tgz",
+      "integrity": "sha512-kIaUEGPXW7g14zsHkIvQWw8cmfCdXSqsEQx18fuHPBb+R0h8nYPyY+e9uVtTuHlE2wHwAjrJoc6YBBK4a7CpKA==",
+      "dependencies": {
+        "@hotwired/stimulus-webpack-helpers": "^1.0.1",
+        "@types/webpack-env": "^1.16.4",
+        "acorn": "^8.0.5",
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      },
+      "peerDependencies": {
+        "@hotwired/stimulus": "^3.0"
+      }
+    },
+    "node_modules/@symfony/stimulus-bridge/node_modules/acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/@symfony/stimulus-bridge/node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@symfony/stimulus-bridge/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/@symfony/stimulus-bridge/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/@symfony/stimulus-bridge/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/@symfony/stimulus-bridge/node_modules/schema-utils": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@symfony/ux-turbo": {
+      "resolved": "vendor/symfony/ux-turbo/assets",
+      "link": true
+    },
     "node_modules/@symfony/webpack-encore": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@symfony/webpack-encore/-/webpack-encore-1.8.2.tgz",
@@ -3836,8 +3944,7 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "dev": true
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
@@ -4047,6 +4154,11 @@
         "anymatch": "^3.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/@types/webpack-env": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.1.tgz",
+      "integrity": "sha512-D0HJET2/UY6k9L6y3f5BL+IDxZmPkYmPT4+qBrRdmRLYRuV0qNKizMgTvYxXZYn+36zjPeoDZAEYBCM6XB+gww=="
     },
     "node_modules/@types/webpack-sources": {
       "version": "3.2.0",
@@ -5557,7 +5669,6 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -7151,6 +7262,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
+      "dev": true
+    },
     "node_modules/cssnano": {
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.11.tgz",
@@ -8094,7 +8211,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -9547,8 +9663,7 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "node_modules/fast-levenshtein": {
       "version": "3.0.0",
@@ -11771,6 +11886,16 @@
         "node": ">= 10.14.2"
       }
     },
+    "node_modules/jest-canvas-mock": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.2.tgz",
+      "integrity": "sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==",
+      "dev": true,
+      "dependencies": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "node_modules/jest-changed-files": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
@@ -13498,7 +13623,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
       "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-      "dev": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -13971,7 +14095,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
       "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-      "dev": true,
       "dependencies": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -15271,6 +15394,21 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "^1.1.4"
+      }
+    },
+    "node_modules/moo-color/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -17365,7 +17503,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -22171,7 +22308,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -23333,6 +23469,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "vendor/symfony/ux-turbo/assets": {
+      "name": "@symfony/ux-turbo",
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@hotwired/stimulus": "^3.0.0",
+        "@hotwired/turbo": "^7.1.0",
+        "jest-canvas-mock": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@hotwired/stimulus": "^3.0.0",
+        "@hotwired/turbo": "^7.0.1"
       }
     }
   },
@@ -24975,6 +25126,23 @@
         }
       }
     },
+    "@hotwired/stimulus": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus/-/stimulus-3.2.2.tgz",
+      "integrity": "sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A=="
+    },
+    "@hotwired/stimulus-webpack-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@hotwired/stimulus-webpack-helpers/-/stimulus-webpack-helpers-1.0.1.tgz",
+      "integrity": "sha512-wa/zupVG0eWxRYJjC1IiPBdt3Lruv0RqGN+/DTMmUWUyMAEB27KXmVY6a8YpUVTM7QwVuaLNGW4EqDgrS2upXQ==",
+      "requires": {}
+    },
+    "@hotwired/turbo": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@hotwired/turbo/-/turbo-7.3.0.tgz",
+      "integrity": "sha512-Dcu+NaSvHLT7EjrDrkEmH4qET2ZJZ5IcCWmNXxNQTBwlnE5tBZfN6WxZ842n5cHV52DH/AKNirbPBtcEXDLW4g==",
+      "dev": true
+    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -25803,6 +25971,70 @@
       "integrity": "sha512-drlXsNvd/s9S1+Ghja0aDB81N3Wr/6iRAZ7MOzKv7AtKxVdvGpOwESw3z1lHl/Wx/rvPpA7whKdB3W2CnVSArw==",
       "dev": true
     },
+    "@symfony/stimulus-bridge": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@symfony/stimulus-bridge/-/stimulus-bridge-3.2.2.tgz",
+      "integrity": "sha512-kIaUEGPXW7g14zsHkIvQWw8cmfCdXSqsEQx18fuHPBb+R0h8nYPyY+e9uVtTuHlE2wHwAjrJoc6YBBK4a7CpKA==",
+      "requires": {
+        "@hotwired/stimulus-webpack-helpers": "^1.0.1",
+        "@types/webpack-env": "^1.16.4",
+        "acorn": "^8.0.5",
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+          "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+          "requires": {}
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "schema-utils": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+          "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
+    "@symfony/ux-turbo": {
+      "version": "file:vendor/symfony/ux-turbo/assets",
+      "requires": {
+        "@hotwired/stimulus": "^3.0.0",
+        "@hotwired/turbo": "^7.1.0",
+        "jest-canvas-mock": "^2.3.0"
+      }
+    },
     "@symfony/webpack-encore": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/@symfony/webpack-encore/-/webpack-encore-1.8.2.tgz",
@@ -26154,8 +26386,7 @@
     "@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
-      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
-      "dev": true
+      "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
     "@types/long": {
       "version": "4.0.2",
@@ -26365,6 +26596,11 @@
         "anymatch": "^3.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "@types/webpack-env": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.18.1.tgz",
+      "integrity": "sha512-D0HJET2/UY6k9L6y3f5BL+IDxZmPkYmPT4+qBrRdmRLYRuV0qNKizMgTvYxXZYn+36zjPeoDZAEYBCM6XB+gww=="
     },
     "@types/webpack-sources": {
       "version": "3.2.0",
@@ -27535,8 +27771,7 @@
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
-      "dev": true
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
     },
     "bignumber.js": {
       "version": "8.1.1",
@@ -28789,6 +29024,12 @@
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
+    "cssfontparser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz",
+      "integrity": "sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==",
+      "dev": true
+    },
     "cssnano": {
       "version": "5.1.11",
       "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.1.11.tgz",
@@ -29522,8 +29763,7 @@
     "emojis-list": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-      "dev": true
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -30659,8 +30899,7 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-levenshtein": {
       "version": "3.0.0",
@@ -32328,6 +32567,16 @@
         "jest-cli": "^26.6.3"
       }
     },
+    "jest-canvas-mock": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.2.tgz",
+      "integrity": "sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==",
+      "dev": true,
+      "requires": {
+        "cssfontparser": "^1.2.1",
+        "moo-color": "^1.0.2"
+      }
+    },
     "jest-changed-files": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.6.2.tgz",
@@ -33641,8 +33890,7 @@
     "json5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
-      "dev": true
+      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
     },
     "jsonfile": {
       "version": "6.1.0",
@@ -34007,7 +34255,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
       "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
-      "dev": true,
       "requires": {
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
@@ -34906,6 +35153,23 @@
       "dev": true,
       "requires": {
         "moment": ">= 2.9.0"
+      }
+    },
+    "moo-color": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz",
+      "integrity": "sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "^1.1.4"
+      },
+      "dependencies": {
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
       }
     },
     "mri": {
@@ -36453,8 +36717,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.11.0",
@@ -40186,7 +40449,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@hotwired/stimulus": "^3.2.2",
+    "@symfony/stimulus-bridge": "^3.2.2",
     "dotenv": "^8.6.0",
     "form-data": "^2.3.3",
     "lodash": "^4.17.21",
@@ -35,6 +37,7 @@
     "@stripe/react-stripe-js": "^1.7.0",
     "@stripe/stripe-js": "^1.22.0",
     "@symfony/webpack-encore": "^1.1.2",
+    "@symfony/ux-turbo": "file:vendor/symfony/ux-turbo/assets",
     "antd": "^4.24.5",
     "autoprefixer": "^10.4.13",
     "axios": "^0.25.0",

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -472,8 +472,8 @@ class ProfileController extends AbstractController
 
         return $this->render('profile/notifications.html.twig', [
             'notifications' => $notifications,
-            'currentPage' => $page ?? 1,
-            'nextPage' => ($page ?? 1) + 1,
+            'currentPage' => $page,
+            'nextPage' => $page + 1,
         ]);
     }
 

--- a/src/Service/TopBarNotifications.php
+++ b/src/Service/TopBarNotifications.php
@@ -20,12 +20,14 @@ class TopBarNotifications
         $this->messageBus = $messageBus;
     }
 
-    public function getLastNotifications(UserInterface $user)
+    public function getNotifications(UserInterface $user, $page = 1)
     {
         $listKey = sprintf('user:%s:notifications', $user->getUsername());
         $hashKey = sprintf('user:%s:notifications_data', $user->getUsername());
 
-        $uuids = $this->redis->lrange($listKey, 0, 5);
+        $offsetStop = 20;
+
+        $uuids = $this->redis->lrange($listKey, $offsetStop * ($page - 1) , ($offsetStop * $page) - 1);
 
         $notifications = [];
         foreach ($uuids as $uuid) {

--- a/templates/profile/notifications.html.twig
+++ b/templates/profile/notifications.html.twig
@@ -1,20 +1,73 @@
 {% extends "profile.html.twig" %}
 
 {% block content %}
-{% if notifications|length > 0 %}
-<table class="table">
-  <tbody>
-    {% for notification in notifications %}
-      <tr>
-        <td>{{ notification.message }}</td>
-        <td class="text-right">{{ notification.timestamp|time_diff }}</td>
-      </tr>
-    {% endfor %}
-  </tbody>
-</table>
-{% else %}
-  <div class="alert alert-warning">
-    {{ 'notifications.empty'|trans }}
-  </div>
-{% endif %}
+<turbo-frame id="notifications">
+  <form action="{{ path('profile_notifications_remove') }}" method="post">
+    <div class="d-flex justify-content-start align-items-center">
+      <div class="form-group m-2">
+        <div class="checkbox">
+          <label>
+            <input type="checkbox" id="select-all" />
+            {{ 'basics.select_all'|trans }}
+          </label>
+        </div>
+      </div>
+      <div class="form-group m-2">
+        <input id="notifications-remove-btn" class="btn btn-sm btn-primary" type="submit" value="{{ 'basics.delete_selected'|trans }}" />
+      </div>
+    </div>
+    <turbo-frame id="notifications-list-{{currentPage}}">
+      <table id="notifications-table" class="table mb-0">
+        <tbody>
+          {% for notification in notifications %}
+            <tr>
+              <td>
+                <input type="checkbox" id="{{notification.id}}" name="{{notification.id}}" />
+              </td>
+              <td>{{ notification.message }}</td>
+              <td class="text-right">{{ notification.timestamp|ago }}</td>
+              <td class="text-center">
+                <a role="button" href="{{ path('profile_notification_remove', {id: notification.id, page: currentPage}) }}" data-turbo-method="delete">
+                  <i class="fa fa-trash"></i>
+                </a>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <turbo-frame id="notifications-list-{{nextPage}}" src="{{ path('profile_notifications', {page: nextPage}) }}" loading="lazy">
+        <div class="d-flex justify-content-center">
+          <i class="fa fa-spinner fa-spin"></i>
+        </div>
+      </turbo-frame>
+    </turbo-frame>
+  </form>
+</turbo-frame>
+{% endblock %}
+
+{% block scripts %}
+  {{ encore_entry_script_tags('app') }}
+  <script>
+    const originalNotificationRemoveBtnLabel = $('#notifications-remove-btn').val();
+
+    $(document).on('change', '#select-all', function() {
+      $('#notifications-table input[type="checkbox"]').prop('checked', $(this).prop('checked'));
+      setNotificationRemoveBtnLabel()
+    })
+
+    $(document).on('change', '#notifications-table input[type="checkbox"]', function() {
+      setNotificationRemoveBtnLabel()
+    })
+
+    function setNotificationRemoveBtnLabel() {
+      const countChecked = $('#notifications-table input[type="checkbox"]:checked').length;
+
+      if (countChecked > 0) {
+        $('#notifications-remove-btn').val(`${originalNotificationRemoveBtnLabel} (${countChecked})`)
+      } else {
+        $('#notifications-remove-btn').val(originalNotificationRemoveBtnLabel)
+      }
+    }
+  </script>
+>>>>>>> 2b994c11f (infinite scroll in notifications screen with turbo)
 {% endblock %}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -868,6 +868,8 @@ basics.send_invitation: Send an invitation
 basics.send_invitation.confirm: Your invitation has been sent! You can now edit the
   settings of the new user.
 basics.configure: Configure
+basics.select_all: Select all
+basics.delete_selected: Delete selected
 profile.password.change: Change your password
 authentication.forgot_password: Forgot password?
 authentication.not_registered_yet: Not registered yet?

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -581,6 +581,8 @@ basics.name: Nombre
 basics.today: Hoy
 basics.are_you_sure: ¿Estás segur@?
 basics.no_entries: Ningun elemento por el momento
+basics.select_all: Seleccionar todo
+basics.delete_selected: Eliminar seleccionados
 profile.password.change: Cambiar la contraseña
 authentication.forgot_password: ¿Contraseña olvidada?
 authentication.not_registered_yet: ¿Todavía no estas registrado?

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ Encore
   // .setPublicPath('http://192.168.0.11:8080')
   // .setManifestKeyPrefix('/build')
 
+  .addEntry('app', './assets/app.js')
   .addEntry('adhoc-order', './js/app/adhoc_order/index.js')
   .addEntry('admin-orders', './js/app/admin/orders.js')
   .addEntry('admin-restaurants', './js/app/admin/restaurants.js')
@@ -68,6 +69,8 @@ Encore
     /moment[/\\]locale$/,
     /ca|de|es|fr|pl|pt-br/
   ))
+
+  .enableStimulusBridge('./assets/controllers.json')
 
   .enableSingleRuntimeChunk()
   .splitEntryChunks()


### PR DESCRIPTION
Fixes #3655 and part of #3653 

This improvement uses "Symfony UX Turbo" a library with a lot of UX features and in this case we are using it to implement an infinite scroll in the notifications screen. 
Links of interest:
https://symfony.com/bundles/ux-turbo/current/index.html
https://turbo.hotwired.dev/handbook/frames
https://symfonycasts.com/screencast/symfony-doctrine/forever-scroll

Now the notifications are not automatically removed when user open the modal. Now notifications can only be removed after clicking the "remove" icon on each notification or selecting multiple notifications in the notification screen.

Here a video to see how work now the notification modal and the screen:

https://github.com/coopcycle/coopcycle-web/assets/4819244/75ec1032-e37f-4d50-ae3b-252c16723cf9


 