### PR TITLE
Notify restaurante/dispatcher when an order is delayed

### DIFF
--- a/js/app/foodtech/dashboard/redux/actions.js
+++ b/js/app/foodtech/dashboard/redux/actions.js
@@ -10,6 +10,7 @@ export const ORDER_ACCEPTED = 'ORDER_ACCEPTED'
 export const ORDER_REFUSED = 'ORDER_REFUSED'
 export const ORDER_CANCELLED = 'ORDER_CANCELLED'
 export const ORDER_FULFILLED = 'ORDER_FULFILLED'
+export const ORDER_DELAYED = 'ORDER_DELAYED'
 
 export const FETCH_REQUEST = 'FETCH_REQUEST'
 export const ACCEPT_ORDER_REQUEST_SUCCESS = 'ACCEPT_ORDER_REQUEST_SUCCESS'
@@ -40,6 +41,7 @@ export const orderAccepted = createAction(ORDER_ACCEPTED)
 export const orderRefused = createAction(ORDER_REFUSED)
 export const orderCancelled = createAction(ORDER_CANCELLED)
 export const orderFulfilled = createAction(ORDER_FULFILLED)
+export const orderDelayed = createAction(ORDER_DELAYED)
 
 export const fetchRequest = createAction(FETCH_REQUEST)
 export const acceptOrderRequestSuccess = createAction(ACCEPT_ORDER_REQUEST_SUCCESS)

--- a/js/app/foodtech/dashboard/redux/middlewares.js
+++ b/js/app/foodtech/dashboard/redux/middlewares.js
@@ -8,6 +8,8 @@ import {
   orderRefused,
   orderCancelled,
   orderFulfilled,
+  orderDelayed,
+  ORDER_DELAYED,
   ORDER_CREATED,
   initHttpClient,
   INIT_HTTP_CLIENT,
@@ -48,6 +50,9 @@ export const socketIO = ({ dispatch, getState }) => {
           break
         case 'order:fulfilled':
           dispatch(orderFulfilled(event.data.order))
+          break
+        case 'order:delayed':
+          dispatch(orderDelayed(event.data.order))
           break
       }
     })
@@ -139,6 +144,19 @@ export const notification = ({ getState }) => {
         notify(restaurant.name, {
           body: asText(shippingTimeRange),
           tag: 'order:created',
+        })
+      }
+    }
+
+    if (action.type === ORDER_DELAYED) {
+      const { restaurant, number, shippingTimeRange } = action.payload
+      if (window.Notification && Notification.permission === 'granted') {
+        notify(restaurant.name, {
+          body: i18n.t('ORDER_DELAYED_NOTIFICATION', {
+            orderNumber: number,
+            shippingTimeRange: asText(shippingTimeRange)
+          }),
+          tag: 'order:delayed',
         })
       }
     }

--- a/js/app/foodtech/dashboard/redux/reducers.js
+++ b/js/app/foodtech/dashboard/redux/reducers.js
@@ -11,6 +11,7 @@ import {
   ORDER_REFUSED,
   ORDER_CANCELLED,
   ORDER_FULFILLED,
+  ORDER_DELAYED,
   FETCH_REQUEST,
   ACCEPT_ORDER_REQUEST_SUCCESS,
   ACCEPT_ORDER_REQUEST_FAILURE,
@@ -190,6 +191,13 @@ export default (state = initialState, action = {}) => {
     return {
       ...state,
       orders: replaceOrder(state.orders, Object.assign({}, action.payload, { state: 'fulfilled' })),
+    }
+
+  case ORDER_DELAYED:
+
+    return {
+      ...state,
+      orders: replaceOrder(state.orders, Object.assign({}, action.payload), true),
     }
 
   case SET_CURRENT_ORDER:

--- a/js/app/i18n/locales/en.json
+++ b/js/app/i18n/locales/en.json
@@ -337,6 +337,7 @@
         "PM_EDENRED": "Edenred",
         "PM_GIROPAY": "Giropay",
         "ADMIN_DASHBOARD_SETTINGS_TOURS_ENABLED": "Show tours panel",
-        "SEE_ALL": "See all"
+        "SEE_ALL": "See all",
+        "ORDER_DELAYED_NOTIFICATION": "Order {{orderNumber}} was delayed. New shipping time range: {{shippingTimeRange}}"
     }
 }

--- a/js/app/i18n/locales/es.json
+++ b/js/app/i18n/locales/es.json
@@ -319,6 +319,7 @@
         "PM_EDENRED": "Edenred",
         "PM_GIROPAY": "Giropay",
         "ADMIN_DASHBOARD_SETTINGS_TOURS_ENABLED": "Mostrar el tablero de rutas",
-        "SEE_ALL": "Ver todo"
+        "SEE_ALL": "Ver todo",
+        "ORDER_DELAYED_NOTIFICATION": "Orden {{orderNumber}} atrasada. Nuevo rango horario de entrega: {{shippingTimeRange}}"
     }
 }

--- a/js/app/i18n/locales/fr.json
+++ b/js/app/i18n/locales/fr.json
@@ -294,6 +294,7 @@
         "CART_LOOPEAT_RETURNS_RETURNS_AMOUNT": "Montant des retours",
         "CART_LOOPEAT_RETURNS_RETURNS_DIFF": "Différence",
         "CART_LOOPEAT_RETURNS_TYPE": "Type de boîte",
-        "CART_LOOPEAT_RETURNS_QUANTITY": "Quantité"
+        "CART_LOOPEAT_RETURNS_QUANTITY": "Quantité",
+        "ORDER_DELAYED_NOTIFICATION": "La commande {{orderNumber}} a été retardée. Nouveau créneau de livraison : {{shippingTimeRange}}"
     }
 }


### PR DESCRIPTION
Closes #3081 

When an order is delayed a new notification will be shown notifying to restaurant when the dispatcher delays an order and vice versa if restaurant delays an order. This notification will be visible only if the user is or has a tab open in the orders dashboard (admin or restaurant).


https://github.com/coopcycle/coopcycle-web/assets/4819244/5f6fb2c3-6cf7-4c10-bfa6-def3fa960f4c

