### PR TITLE
New action to delete all notifications at once

### DIFF
--- a/js/app/i18n/locales/en.json
+++ b/js/app/i18n/locales/en.json
@@ -338,6 +338,7 @@
         "PM_GIROPAY": "Giropay",
         "ADMIN_DASHBOARD_SETTINGS_TOURS_ENABLED": "Show tours panel",
         "SEE_ALL": "See all",
-        "ORDER_DELAYED_NOTIFICATION": "Order {{orderNumber}} was delayed. New shipping time range: {{shippingTimeRange}}"
+        "ORDER_DELAYED_NOTIFICATION": "Order {{orderNumber}} was delayed. New shipping time range: {{shippingTimeRange}}",
+        "DELETE_ALL": "Delete all"
     }
 }

--- a/js/app/i18n/locales/es.json
+++ b/js/app/i18n/locales/es.json
@@ -320,6 +320,7 @@
         "PM_GIROPAY": "Giropay",
         "ADMIN_DASHBOARD_SETTINGS_TOURS_ENABLED": "Mostrar el tablero de rutas",
         "SEE_ALL": "Ver todo",
-        "ORDER_DELAYED_NOTIFICATION": "Orden {{orderNumber}} atrasada. Nuevo rango horario de entrega: {{shippingTimeRange}}"
+        "ORDER_DELAYED_NOTIFICATION": "Orden {{orderNumber}} atrasada. Nuevo rango horario de entrega: {{shippingTimeRange}}",
+        "DELETE_ALL": "Eliminar todo"
     }
 }

--- a/js/app/notifications/NotificationList.js
+++ b/js/app/notifications/NotificationList.js
@@ -46,7 +46,7 @@ class NotificationList extends React.Component {
               </a>
               <a disabled={ this.state.loading } role="button" href="#" className="text-reset"
                 onClick={ () => onRemove(notification) }>
-                <i className="fa fa-trash"></i>
+                <i className="fa fa-close"></i>
               </a>
             </li>
           ))}

--- a/js/app/notifications/NotificationList.js
+++ b/js/app/notifications/NotificationList.js
@@ -6,6 +6,24 @@ moment.locale($('html').attr('lang'))
 
 class NotificationList extends React.Component {
 
+  constructor() {
+    super()
+
+    this.state = {
+      loading: false,
+    }
+
+    this.onDeleteAll = this.onDeleteAll.bind(this)
+  }
+
+  onDeleteAll() {
+    this.setState({loading: true})
+    this.props.onDeleteAll()
+      .then(() => {
+        this.setState({loading: false})
+      })
+  }
+
   render() {
 
     const { notifications, count, onSeeAll, onRemove } = this.props
@@ -26,19 +44,22 @@ class NotificationList extends React.Component {
                 <br />
                 <small>{ moment.unix(notification.timestamp).fromNow() }</small>
               </a>
-              <a role="button" href="#" className="text-reset"
+              <a disabled={ this.state.loading } role="button" href="#" className="text-reset"
                 onClick={ () => onRemove(notification) }>
                 <i className="fa fa-trash"></i>
               </a>
             </li>
           ))}
         </ul>
-        {
-          count > notifications.length &&
-          <button type="button" className="btn btn-block btn-primary mt-2" onClick={ onSeeAll }>
+        <div className="d-flex mt-2">
+          <button disabled={ this.state.loading } type="button" className="btn btn-block btn-primary mt-0 mr-2" onClick={ onSeeAll }>
             { this.props.t('SEE_ALL') } ({count})
           </button>
-        }
+          <button disabled={ this.state.loading } type="button" className="btn btn-block btn-danger mt-0" onClick={ this.onDeleteAll }>
+            { this.state.loading && <span><i className="fa fa-spinner fa-spin mr-2"></i></span> }
+            { this.props.t('DELETE_ALL') } ({count})
+          </button>
+        </div>
       </div>
     )
   }

--- a/js/app/notifications/index.js
+++ b/js/app/notifications/index.js
@@ -17,7 +17,7 @@ const zeroStyleDark = {
   boxShadow: '0 0 0 1px #d9d9d9 inset'
 }
 
-const Notifications = ({ initialNotifications, initialCount, centrifuge, namespace, username, theme, onSeeAll, removeURL }) => {
+const Notifications = ({ initialNotifications, initialCount, centrifuge, namespace, username, theme, onSeeAll, removeURL, removeNotificationsURL }) => {
 
   const [ notifications, setNotifications ] = useState(initialNotifications)
   const [ count, setCount ] = useState(initialCount)
@@ -52,13 +52,23 @@ const Notifications = ({ initialNotifications, initialCount, centrifuge, namespa
     })
   }
 
+  const onDeleteAll = async () => {
+    return $.ajax(`${removeNotificationsURL}?all=true&format=json`, {
+      type: 'POST',
+      contentType: 'application/json',
+    }).then((res) => {
+      setNotifications(Object.values(res.notifications))
+      setCount(res.unread)
+    })
+  }
+
   const badgeProps = count === 0 ?
     { style: theme === 'dark' ? zeroStyleDark : zeroStyle } : { style: { backgroundColor: '#52c41a' } }
 
   return (
     <Popover
       placement="bottomRight"
-      content={ <NotificationList onSeeAll={ onSeeAll } onRemove={ onRemove } count={ count } notifications={ notifications } /> }
+      content={ <NotificationList onSeeAll={ onSeeAll } onRemove={ onRemove } onDeleteAll={ onDeleteAll } count={ count } notifications={ notifications } /> }
       title="Notifications"
       trigger="click">
       <a href="#">
@@ -89,6 +99,7 @@ function bootstrap(el, options) {
       initialNotifications={ notifications }
       initialCount={ unread }
       removeURL={ options.removeNotificationURL }
+      removeNotificationsURL={ options.removeNotificationsURL }
       onSeeAll={ () => { window.location.href = options.notificationsURL } }
       centrifuge={ centrifuge }
       namespace={ options.namespace }
@@ -103,6 +114,7 @@ $.getJSON(window.Routing.generate('profile_jwt'))
     const options = {
       notificationsURL: window.Routing.generate('profile_notifications'),
       removeNotificationURL:    window.Routing.generate('profile_notification_remove'),
+      removeNotificationsURL: window.Routing.generate('profile_notifications_remove'),
       token:     result.cent_tok,
       namespace: result.cent_ns,
       username:  result.cent_usr,

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -405,12 +405,14 @@ class ProfileController extends AbstractController
      */
     public function notificationsAction(Request $request, TopBarNotifications $topBarNotifications, NormalizerInterface $normalizer)
     {
+        $unread = (int) $topBarNotifications->countNotifications($this->getUser());
+
         if ($request->query->has('format') && 'json' === $request->query->get('format')) {
             $notifications = $topBarNotifications->getNotifications($this->getUser());
 
             return new JsonResponse([
                 'notifications' => $normalizer->normalize($notifications, 'json'),
-                'unread' => (int) $topBarNotifications->countNotifications($this->getUser())
+                'unread' => $unread
             ]);
         }
 
@@ -422,6 +424,7 @@ class ProfileController extends AbstractController
             'notifications' => $notifications,
             'currentPage' => $page,
             'nextPage' => $page + 1,
+            'hasNextPage' => $unread / TopBarNotifications::NOTIFICATIONS_OFFSET > $page,
         ]);
     }
 
@@ -450,14 +453,14 @@ class ProfileController extends AbstractController
     public function removeNotificationAction(Request $request, TopBarNotifications $topBarNotifications, NormalizerInterface $normalizer)
     {
         $topBarNotifications->markAsRead($this->getUser(), [$request->get('id')]);
-
+        $unread = (int) $topBarNotifications->countNotifications($this->getUser());
 
         if ($request->query->has('format') && 'json' === $request->query->get('format')) {
             $notifications = $topBarNotifications->getNotifications($this->getUser());
 
             return new JsonResponse([
                 'notifications' => $normalizer->normalize($notifications, 'json'),
-                'unread' => (int) $topBarNotifications->countNotifications($this->getUser())
+                'unread' => $unread
             ]);
         }
 
@@ -477,6 +480,7 @@ class ProfileController extends AbstractController
             'notifications' => $notifications,
             'currentPage' => $page,
             'nextPage' => $page + 1,
+            'hasNextPage' => $unread / TopBarNotifications::NOTIFICATIONS_OFFSET > $page,
         ]);
     }
 

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -430,13 +430,16 @@ class ProfileController extends AbstractController
      */
     public function removeNotificationsAction(Request $request, TopBarNotifications $topBarNotifications, NormalizerInterface $normalizer)
     {
-        $ids = [];
-        $content = $request->getContent();
-        if (!empty($content)) {
-            parse_str($content, $ids);
+        if ($request->query->has('all') && 'true' === $request->query->get('all')) {
+            $topBarNotifications->markAllAsRead($this->getUser());
+        } else {
+            $ids = [];
+            $content = $request->getContent();
+            if (!empty($content)) {
+                parse_str($content, $ids);
+            }
+            $topBarNotifications->markAsRead($this->getUser(), array_keys($ids));
         }
-
-        $topBarNotifications->markAsRead($this->getUser(), array_keys($ids));
 
         return $this->notificationsAction($request, $topBarNotifications, $normalizer);
     }

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -424,7 +424,7 @@ class ProfileController extends AbstractController
             'notifications' => $notifications,
             'currentPage' => $page,
             'nextPage' => $page + 1,
-            'hasNextPage' => $unread / TopBarNotifications::NOTIFICATIONS_OFFSET > $page,
+            'hasNextPage' => ($unread / TopBarNotifications::NOTIFICATIONS_OFFSET) > $page,
         ]);
     }
 
@@ -464,13 +464,14 @@ class ProfileController extends AbstractController
             ]);
         }
 
+        /** @var int $page */
         $page = 1;
         $content = $request->getContent();
         if (!empty($content)) {
             $contentArray = [];
             parse_str($content, $contentArray);
             if (array_key_exists('page', $contentArray)) {
-                $page = $contentArray['page'];
+                $page = (int) $contentArray['page'];
             }
         }
 
@@ -480,7 +481,7 @@ class ProfileController extends AbstractController
             'notifications' => $notifications,
             'currentPage' => $page,
             'nextPage' => $page + 1,
-            'hasNextPage' => $unread / TopBarNotifications::NOTIFICATIONS_OFFSET > $page,
+            'hasNextPage' => ($unread / TopBarNotifications::NOTIFICATIONS_OFFSET) > $page,
         ]);
     }
 

--- a/src/Service/TopBarNotifications.php
+++ b/src/Service/TopBarNotifications.php
@@ -9,6 +9,8 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 class TopBarNotifications
 {
+    const NOTIFICATIONS_OFFSET = 20;
+
     private $redis;
     private $messageBus;
 
@@ -25,9 +27,7 @@ class TopBarNotifications
         $listKey = sprintf('user:%s:notifications', $user->getUsername());
         $hashKey = sprintf('user:%s:notifications_data', $user->getUsername());
 
-        $offsetStop = 20;
-
-        $uuids = $this->redis->lrange($listKey, $offsetStop * ($page - 1) , ($offsetStop * $page) - 1);
+        $uuids = $this->redis->lrange($listKey, self::NOTIFICATIONS_OFFSET * ($page - 1) , (self::NOTIFICATIONS_OFFSET * $page) - 1);
 
         $notifications = [];
         foreach ($uuids as $uuid) {

--- a/src/Service/TopBarNotifications.php
+++ b/src/Service/TopBarNotifications.php
@@ -63,4 +63,19 @@ class TopBarNotifications
             new UpdateNotificationsCount($user->getUsername(), $count)
         );
     }
+
+    public function markAllAsRead(UserInterface $user)
+    {
+        $listKey = sprintf('user:%s:notifications', $user->getUsername());
+        $hashKey = sprintf('user:%s:notifications_data', $user->getUsername());
+
+        $this->redis->del($listKey);
+        $this->redis->del($hashKey);
+
+        $count = $this->redis->llen($listKey);
+
+        $this->messageBus->dispatch(
+            new UpdateNotificationsCount($user->getUsername(), $count)
+        );
+    }
 }

--- a/templates/profile/notifications.html.twig
+++ b/templates/profile/notifications.html.twig
@@ -28,7 +28,7 @@
               <td class="text-right">{{ notification.timestamp|ago }}</td>
               <td class="text-center">
                 <a role="button" href="{{ path('profile_notification_remove', {id: notification.id, page: currentPage}) }}" data-turbo-method="delete">
-                  <i class="fa fa-trash"></i>
+                  <i class="fa fa-close"></i>
                 </a>
               </td>
             </tr>

--- a/templates/profile/notifications.html.twig
+++ b/templates/profile/notifications.html.twig
@@ -35,11 +35,13 @@
           {% endfor %}
         </tbody>
       </table>
-      <turbo-frame id="notifications-list-{{nextPage}}" src="{{ path('profile_notifications', {page: nextPage}) }}" loading="lazy">
-        <div class="d-flex justify-content-center">
-          <i class="fa fa-spinner fa-spin"></i>
-        </div>
-      </turbo-frame>
+      {% if hasNextPage %}
+        <turbo-frame id="notifications-list-{{nextPage}}" src="{{ path('profile_notifications', {page: nextPage}) }}" loading="lazy">
+          <div class="d-flex justify-content-center">
+            <i class="fa fa-spinner fa-spin"></i>
+          </div>
+        </turbo-frame>
+      {% endif %}
     </turbo-frame>
   </form>
 </turbo-frame>


### PR DESCRIPTION
Closes #3773 

- [x] New action in notifications modal to delete all existing notifications at once.

https://github.com/coopcycle/coopcycle-web/assets/4819244/948ba11c-ce84-466f-85cd-ed913465f650

- [x] Changed the 'remove notification' icon for a 'close icon'
<img src="https://github.com/coopcycle/coopcycle-web/assets/4819244/d62466d4-256b-4e6b-8867-09309a50e347" width="600" />

- [x] Added a new var to stop loading notifications when there isn't a next page