### PR TITLE
Validate Google Maps API Key

### DIFF
--- a/app/config/services/twig.yml
+++ b/app/config/services/twig.yml
@@ -60,3 +60,7 @@ services:
   Twig\Extra\Markdown\MarkdownExtension:
     tags:
       - { name: twig.extension }
+
+  AppBundle\Twig\SettingResolver:
+    arguments:
+      $cache: '@craue_config_cache_provider'

--- a/app/config/services/validators.yml
+++ b/app/config/services/validators.yml
@@ -72,3 +72,9 @@ services:
   AppBundle\Validator\Constraints\DabbaOrderValidator:
     tags:
       - { name: validator.constraint_validator }
+
+  AppBundle\Validator\Constraints\GoogleApiKeyValidator:
+    arguments:
+      $country: "%country_iso%"
+    tags:
+      - { name: validator.constraint_validator }

--- a/app/config/services/validators.yml
+++ b/app/config/services/validators.yml
@@ -74,7 +74,5 @@ services:
       - { name: validator.constraint_validator }
 
   AppBundle\Validator\Constraints\GoogleApiKeyValidator:
-    arguments:
-      $country: "%country_iso%"
     tags:
       - { name: validator.constraint_validator }

--- a/features/settings.feature
+++ b/features/settings.feature
@@ -6,7 +6,6 @@ Feature: Settings
     And the setting "stripe_test_publishable_key" has value "pk_1234567890"
     And the setting "mercadopago_test_publishable_key" has value "TEST_123456"
     And the setting "mercadopago_access_token" has value "TEST_123456"
-    And the setting "google_api_key" has value "abc123456"
     And the setting "currency_code" has value "eur"
     And the setting "phone_number" has value "+33612345678"
     And the setting "administrator_email" has value "dev@coopcycle.org"
@@ -25,7 +24,6 @@ Feature: Settings
         "stripe_publishable_key":"pk_1234567890",
         "payment_gateway":"stripe",
         "mercadopago_publishable_key":"TEST_123456",
-        "google_api_key":"abc123456",
         "latlng":"48.856613,2.352222",
         "currency_code":"eur",
         "phone_number":"+33612345678",

--- a/src/Action/Settings.php
+++ b/src/Action/Settings.php
@@ -32,7 +32,6 @@ class Settings
         'stripe_publishable_key',
         'payment_gateway',
         'mercadopago_publishable_key',
-        'google_api_key',
         'latlng',
         'currency_code',
         'administrator_email',

--- a/src/Service/SettingsManager.php
+++ b/src/Service/SettingsManager.php
@@ -23,7 +23,6 @@ class SettingsManager
     private $mandatorySettings = [
         'brand_name',
         'administrator_email',
-        'google_api_key',
         'latlng',
         'currency_code',
     ];
@@ -37,7 +36,6 @@ class SettingsManager
         'stripe_live_connect_client_id',
         'payment_gateway',
         'payment_method_publishable_key',
-        'google_api_key',
         'mercadopago_test_publishable_key',
         'mercadopago_live_publishable_key',
         'mercadopago_test_access_token',

--- a/src/Service/SettingsManager.php
+++ b/src/Service/SettingsManager.php
@@ -20,13 +20,6 @@ class SettingsManager
     private $doctrine;
     private $gatewayResolver;
 
-    private $mandatorySettings = [
-        'brand_name',
-        'administrator_email',
-        'latlng',
-        'currency_code',
-    ];
-
     private $secretSettings = [
         'stripe_test_publishable_key',
         'stripe_test_secret_key',
@@ -311,22 +304,6 @@ class SettingsManager
     {
         $this->doctrine->getManagerForClass($this->configEntityName)->flush();
         $this->craueCache->clear();
-    }
-
-    public function isFullyConfigured()
-    {
-        foreach ($this->mandatorySettings as $name) {
-            try {
-                $value = $this->craueConfig->get($name);
-                if (null === $value) {
-                    return false;
-                }
-            } catch (\RuntimeException $e) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     public function asEntity()

--- a/src/Twig/CoopCycleExtension.php
+++ b/src/Twig/CoopCycleExtension.php
@@ -100,6 +100,7 @@ class CoopCycleExtension extends AbstractExtension
             new TwigFunction('loopeat_name', array(LoopeatRuntime::class, 'getName')),
             new TwigFunction('restaurant_tags', array(LocalBusinessRuntime::class, 'tags')),
             new TwigFunction('restaurant_badges', array(LocalBusinessRuntime::class, 'badges')),
+            new TwigFunction('coopcycle_configtest', array(SettingResolver::class, 'configTest')),
         );
     }
 

--- a/src/Twig/SettingResolver.php
+++ b/src/Twig/SettingResolver.php
@@ -21,13 +21,13 @@ class SettingResolver implements RuntimeExtensionInterface
         ValidatorInterface $validator,
         TranslatorInterface $translator,
         UrlGeneratorInterface $urlGenerator,
-        CacheInterface $appCache)
+        CacheInterface $cache)
     {
         $this->settingsManager = $settingsManager;
         $this->validator = $validator;
         $this->translator = $translator;
         $this->urlGenerator = $urlGenerator;
-        $this->appCache = $appCache;
+        $this->cache = $cache;
     }
 
     public function resolveSetting($name)
@@ -60,7 +60,7 @@ class SettingResolver implements RuntimeExtensionInterface
             ]);
         }
 
-        $isGoogleApiKeyValid = $this->appCache->get('settings.google_api_key_invalid', function (ItemInterface $item) use ($settings) {
+        $isGoogleApiKeyValid = $this->cache->get('google_api_key_invalid', function (ItemInterface $item) use ($settings) {
 
             $item->expiresAfter(
                 \DateInterval::createFromDateString('1 day')

--- a/src/Twig/SettingResolver.php
+++ b/src/Twig/SettingResolver.php
@@ -3,16 +3,27 @@
 namespace AppBundle\Twig;
 
 use AppBundle\Service\SettingsManager;
-use Twig\Extension\RuntimeExtensionInterface;
 use AppBundle\Utils\GeoUtils;
+use AppBundle\Validator\Constraints\GoogleApiKey;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Extension\RuntimeExtensionInterface;
 
 class SettingResolver implements RuntimeExtensionInterface
 {
     private $settingsManager;
 
-    public function __construct(SettingsManager $settingsManager)
+    public function __construct(
+        SettingsManager $settingsManager,
+        ValidatorInterface $validator,
+        TranslatorInterface $translator,
+        UrlGeneratorInterface $urlGenerator)
     {
         $this->settingsManager = $settingsManager;
+        $this->validator = $validator;
+        $this->translator = $translator;
+        $this->urlGenerator = $urlGenerator;
     }
 
     public function resolveSetting($name)
@@ -27,5 +38,32 @@ class SettingResolver implements RuntimeExtensionInterface
         [ $lat, $lng ] = explode(',', $latlng);
 
         return implode(',', GeoUtils::getViewbox($lat, $lng, 15));
+    }
+
+    /**
+     * @return string[]
+     */
+    public function configTest(): array
+    {
+        $settings = $this->settingsManager->asEntity();
+
+        $messages = [];
+
+        $violations = $this->validator->validate($settings, null, ['groups' => 'mandatory']);
+        if (count($violations) > 0) {
+            $messages[] = $this->translator->trans('admin.settings.missing_mandatory_settings', [
+                '%settings_url%' => $this->urlGenerator->generate('admin_settings')
+            ]);
+        }
+
+        $violations = $this->validator->validate($settings);
+        if (count($violations) > 0) {
+            $invalidApiKey = array_filter(iterator_to_array($violations), fn ($v) => $v->getCode() === GoogleApiKey::INVALID_API_KEY_ERROR);
+            if (count($invalidApiKey) === 1) {
+                $messages[] = $this->translator->trans(id: 'googlemaps.api_key.invalid', domain: 'validators');
+            }
+        }
+
+        return $messages;
     }
 }

--- a/src/Utils/Settings.php
+++ b/src/Utils/Settings.php
@@ -8,8 +8,15 @@ use AppBundle\Validator\Constraints\GoogleApiKey as AssertGoogleApiKey;
 
 class Settings
 {
+    /**
+     * @Assert\NotBlank(groups={"Default", "mandatory"})
+     */
     public $brand_name;
 
+    /**
+     * @Assert\NotBlank(groups={"Default", "mandatory"})
+     * @Assert\Email(groups={"Default", "mandatory"})
+     */
     public $administrator_email;
 
     /**
@@ -58,10 +65,16 @@ class Settings
      */
     public $stripe_livemode;
 
+    /**
+     * @Assert\NotBlank(groups={"Default", "mandatory"})
+     */
     public $latlng;
 
     public $subject_to_vat;
 
+    /**
+     * @Assert\NotBlank(groups={"Default", "mandatory"})
+     */
     public $currency_code;
 
     /**

--- a/src/Utils/Settings.php
+++ b/src/Utils/Settings.php
@@ -4,6 +4,7 @@ namespace AppBundle\Utils;
 
 use Symfony\Component\Validator\Constraints as Assert;
 use Misd\PhoneNumberBundle\Validator\Constraints\PhoneNumber as AssertPhoneNumber;
+use AppBundle\Validator\Constraints\GoogleApiKey as AssertGoogleApiKey;
 
 class Settings
 {
@@ -106,6 +107,7 @@ class Settings
      *   message="This value should not be blank."
      * )
      * @Assert\Regex("/AIza[0-9A-Za-z-_]{35}/")
+     * @AssertGoogleApiKey()
      */
     public $google_api_key_custom;
 

--- a/src/Utils/Settings.php
+++ b/src/Utils/Settings.php
@@ -58,8 +58,6 @@ class Settings
      */
     public $stripe_livemode;
 
-    public $google_api_key;
-
     public $latlng;
 
     public $subject_to_vat;

--- a/src/Validator/Constraints/GoogleApiKey.php
+++ b/src/Validator/Constraints/GoogleApiKey.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AppBundle\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @Annotation
+ */
+class GoogleApiKey extends Constraint
+{
+    public $invalidApiKeyMessage = 'googlemaps.api_key.invalid';
+
+    public function validatedBy()
+    {
+        return get_class($this).'Validator';
+    }
+
+    public function getTargets()
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
+}

--- a/src/Validator/Constraints/GoogleApiKey.php
+++ b/src/Validator/Constraints/GoogleApiKey.php
@@ -9,6 +9,8 @@ use Symfony\Component\Validator\Constraint;
  */
 class GoogleApiKey extends Constraint
 {
+    public const INVALID_API_KEY_ERROR = '13dfb729-edf0-480a-a653-69c9cafccaef';
+
     public $invalidApiKeyMessage = 'googlemaps.api_key.invalid';
 
     public function validatedBy()

--- a/src/Validator/Constraints/GoogleApiKeyValidator.php
+++ b/src/Validator/Constraints/GoogleApiKeyValidator.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace AppBundle\Validator\Constraints;
+
+use AppBundle\Utils\Settings;
+use Geocoder\Exception\InvalidCredentials;
+use Geocoder\Exception\InvalidServerResponse;
+use Geocoder\Provider\GoogleMaps\GoogleMaps;
+use Geocoder\Query\ReverseQuery;
+use Geocoder\StatefulGeocoder;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\HttpClient\HttplugClient;
+
+class GoogleApiKeyValidator extends ConstraintValidator
+{
+    public function __construct(private string $country)
+    {
+        $this->country = $country;
+    }
+
+    public function validate($value, Constraint $constraint)
+    {
+        $object = $this->context->getObject();
+
+        // Paris, France
+        $latitude = 48.856613;
+        $longitude = 2.352222;
+
+        if ($object instanceof Settings) {
+            [ $latitude, $longitude ] = explode(',', $object->latlng);
+        }
+
+        $httpClient = new HttplugClient();
+
+        $region = strtoupper($this->country);
+
+        $geocoder = new StatefulGeocoder(
+            new GoogleMaps($httpClient, $region, $value)
+        );
+
+        try {
+            $results = $geocoder->reverseQuery(
+                ReverseQuery::fromCoordinates($latitude, $longitude)
+            );
+        } catch (InvalidCredentials | InvalidServerResponse $e) {
+            $this->context->buildViolation($constraint->invalidApiKeyMessage)
+                ->addViolation();
+        }
+    }
+}

--- a/src/Validator/Constraints/GoogleApiKeyValidator.php
+++ b/src/Validator/Constraints/GoogleApiKeyValidator.php
@@ -15,11 +15,6 @@ use Symfony\Component\HttpClient\HttplugClient;
 
 class GoogleApiKeyValidator extends ConstraintValidator
 {
-    public function __construct(private string $country)
-    {
-        $this->country = $country;
-    }
-
     public function validate($value, Constraint $constraint)
     {
         $object = $this->context->getObject();
@@ -34,10 +29,8 @@ class GoogleApiKeyValidator extends ConstraintValidator
 
         $httpClient = new HttplugClient();
 
-        $region = strtoupper($this->country);
-
         $geocoder = new StatefulGeocoder(
-            new GoogleMaps($httpClient, $region, $value)
+            new GoogleMaps(client: $httpClient, apiKey: $value)
         );
 
         try {

--- a/src/Validator/Constraints/GoogleApiKeyValidator.php
+++ b/src/Validator/Constraints/GoogleApiKeyValidator.php
@@ -39,6 +39,7 @@ class GoogleApiKeyValidator extends ConstraintValidator
             );
         } catch (InvalidCredentials | InvalidServerResponse $e) {
             $this->context->buildViolation($constraint->invalidApiKeyMessage)
+                ->setCode(GoogleApiKey::INVALID_API_KEY_ERROR)
                 ->addViolation();
         }
     }

--- a/templates/admin.html.twig
+++ b/templates/admin.html.twig
@@ -6,23 +6,14 @@
 
 {% block banner %}
   {% include '_partials/maintenance.html.twig' %}
-  {% if not settings_manager.fullyConfigured or (coopcycle_setting('autocomplete_provider')|default(autocomplete_adapter)|default('algolia')) == 'algolia' %}
-  <div class="alert alert-danger">
+  {% if not settings_manager.fullyConfigured %}
+  <div class="alert alert-danger" style="margin-top: -20px;">
     <ul class="list-unstyled">
-      {% if not settings_manager.fullyConfigured %}
       <li>
       {% trans with { '%settings_url%': path('admin_settings') } %}
       admin.settings.missing_mandatory_settings
       {% endtrans %}
       </li>
-      {% endif %}
-      {% if (coopcycle_setting('autocomplete_provider')|default(autocomplete_adapter)|default('algolia')) == 'algolia' %}
-      <li>
-      {% trans with { '%settings_url%': path('admin_settings') } %}
-      admin.settings.stop_using_algolia
-      {% endtrans %}
-      </li>
-      {% endif %}
     </ul>
   </div>
   {% endif %}

--- a/templates/admin.html.twig
+++ b/templates/admin.html.twig
@@ -6,14 +6,15 @@
 
 {% block banner %}
   {% include '_partials/maintenance.html.twig' %}
-  {% if not settings_manager.fullyConfigured %}
+  {% set error_messages = coopcycle_configtest() %}
+  {% if error_messages is not empty %}
   <div class="alert alert-danger" style="margin-top: -20px;">
     <ul class="list-unstyled">
+      {% for error_message in error_messages %}
       <li>
-      {% trans with { '%settings_url%': path('admin_settings') } %}
-      admin.settings.missing_mandatory_settings
-      {% endtrans %}
+      {{ error_message|raw }}
       </li>
+      {% endfor %}
     </ul>
   </div>
   {% endif %}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1272,8 +1272,6 @@ homepage.featured: Featured
 homepage.exclusive: Exclusives
 homepage.shops.new: New shops
 users.disabled: Disabled
-admin.settings.stop_using_algolia: |
-  You are using the Algolia suggestions engine, which <a href="https://www.algolia.com/blog/product/sunsetting-our-places-feature/">will stop working from May 31, 2022</a >. Go to the <a href="%settings_url%">settings page</a> to configure another engine, such as <a href="https://docs.coopcycle.org/en/admin/google/">Google Maps</a>
 shops.filters.clear_all: Clear all
 shops.filters.title.types: Types
 shops.filters.title.categories: Categories

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -1248,8 +1248,6 @@ homepage.featured: À la une
 homepage.exclusive: Exclusivités
 homepage.shops.new: Nouveautés
 users.disabled: Désactivés
-admin.settings.stop_using_algolia: |
-  Vous utilisez le moteur de suggestions Algolia, qui <a href="https://www.algolia.com/blog/product/sunsetting-our-places-feature/">cessera de fonctionner à partir du 31 mai 2022</a>. Aller à la <a href="%settings_url%">page des paramètres</a> pour configurer un autre moteur, comme par exemple <a href="https://docs.coopcycle.org/en/admin/google/">Google Maps</a>
 shops.filters.clear_all: Effacer tout
 shops.filters.title.types: Type de commerce
 shops.filters.title.categories: Catégories

--- a/translations/validators.en.yml
+++ b/translations/validators.en.yml
@@ -62,4 +62,4 @@ order.adjustments.unexpectedCount: Unexpected number of "%type%" adjustments
 
 dabba.insufficient_wallet: Your Dabba wallet is missing %amount%
 
-googlemaps.api_key.invalid: This Google Maps API Key is not valid
+googlemaps.api_key.invalid: The Google Maps API Key is not valid

--- a/translations/validators.en.yml
+++ b/translations/validators.en.yml
@@ -61,3 +61,5 @@ pricing_rule.expression.syntax_error: Syntax error in expression "%expression%"
 order.adjustments.unexpectedCount: Unexpected number of "%type%" adjustments
 
 dabba.insufficient_wallet: Your Dabba wallet is missing %amount%
+
+googlemaps.api_key.invalid: This Google Maps API Key is not valid

--- a/translations/validators.fr.yml
+++ b/translations/validators.fr.yml
@@ -43,6 +43,8 @@ loopeat.insufficient_balance: Votre cagnotte %name% est insuffisante pour béné
 restaurant.contract.variableCustomerAmount.pickOne: Veuillez sélectionner une tarification
 restaurant.contract.variableDeliveryPrice.pickOne: Veuillez sélectionner une tarification
 
+googlemaps.api_key.invalid: La clé d'API Google Maps API Key n'est pas valide
+
 checkout.user_with_same_email_exists: Un compte avec le même email existe déjà
 
 time_range_jump.next_day: Il n'est plus possible de commander pour aujourd'hui

--- a/translations/validators.fr.yml
+++ b/translations/validators.fr.yml
@@ -43,8 +43,6 @@ loopeat.insufficient_balance: Votre cagnotte %name% est insuffisante pour béné
 restaurant.contract.variableCustomerAmount.pickOne: Veuillez sélectionner une tarification
 restaurant.contract.variableDeliveryPrice.pickOne: Veuillez sélectionner une tarification
 
-googlemaps.api_key.invalid: La clé d'API Google Maps API Key n'est pas valide
-
 checkout.user_with_same_email_exists: Un compte avec le même email existe déjà
 
 time_range_jump.next_day: Il n'est plus possible de commander pour aujourd'hui
@@ -53,3 +51,4 @@ order.shippingTimeRange.notAvailable: Indisponible pour l'instant
 
 dabba.insufficient_wallet: Il vous manque %amount% sur votre cagnotte Dabba
 
+googlemaps.api_key.invalid: La clé d'API Google Maps n'est pas valide


### PR DESCRIPTION
We will now periodically (every 24h) send a request to Google Maps API, to make sure the API Key is still valid. 

Fixes #3910 

Also removes deprecated code for Algolia 