### PR TITLE
Product pricing option for business restaurant group

### DIFF
--- a/app/DoctrineMigrations/Version20240103181510.php
+++ b/app/DoctrineMigrations/Version20240103181510.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240103181510 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_product_variant ADD business_restaurant_group_id INT DEFAULT NULL');
+        $this->addSql('ALTER TABLE sylius_product_variant ADD CONSTRAINT FK_A29B523C4EC76B FOREIGN KEY (business_restaurant_group_id) REFERENCES business_restaurant_group (id) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_A29B523C4EC76B ON sylius_product_variant (business_restaurant_group_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE sylius_product_variant DROP CONSTRAINT FK_A29B523C4EC76B');
+        $this->addSql('DROP INDEX IDX_A29B523C4EC76B');
+        $this->addSql('ALTER TABLE sylius_product_variant DROP business_restaurant_group_id');
+    }
+}

--- a/app/config/services/forms.yml
+++ b/app/config/services/forms.yml
@@ -114,7 +114,9 @@ services:
     arguments:
       $productAttributeRepository: '@sylius.repository.product_attribute'
       $productAttributeValueFactory: '@sylius.factory.product_attribute_value'
+      $variantResolver: "@coopcycle.sylius.product_variant_resolver.lazy"
       $taxIncl: '%env(bool:COOPCYCLE_TAX_INCL)%'
+      $businessAccountEnabled: '%env(bool:BUSINESS_ACCOUNT_ENABLED)%'
     tags: [ form.type ]
 
   AppBundle\Form\Checkout\CheckoutAddressType:
@@ -195,6 +197,7 @@ services:
   AppBundle\Form\Type\PriceWithTaxType:
     tags: [ form.type ]
     arguments:
+      $variantResolver: "@coopcycle.sylius.product_variant_resolver.lazy"
       $taxIncl: '%env(bool:COOPCYCLE_TAX_INCL)%'
 
   AppBundle\Form\CustomizeType:
@@ -282,4 +285,7 @@ services:
     tags: [ form.type ]
 
   AppBundle\Form\LocalBusinessWithMenuType:
+    tags: [ form.type ]
+
+  AppBundle\Form\BusinessRestaurantGroupPriceType:
     tags: [ form.type ]

--- a/js/app/product/form.js
+++ b/js/app/product/form.js
@@ -108,8 +108,7 @@ const getRateAmount = (el) => {
   return _.reduce(rates, (acc, rate) => acc + rate.amount, 0)
 }
 
-document.querySelectorAll('[data-tax-categories]').forEach(el => {
-
+const attachPricesAndTaxEventListeners = (el) => {
   const taxIncl = JSON.parse(el.dataset.taxIncl)
 
   const taxIncludedEl = document.querySelector(el.dataset.included)
@@ -162,7 +161,9 @@ document.querySelectorAll('[data-tax-categories]').forEach(el => {
 
     taxExcludedEl.value = numbro(taxExcluded / 100).format({ mantissa: 2 })
   })
-})
+}
+
+document.querySelectorAll('[data-tax-categories]').forEach(el => attachPricesAndTaxEventListeners(el))
 
 const SET_IMAGES = '@product/SET_IMAGES'
 const setImages = createAction(SET_IMAGES)
@@ -200,3 +201,30 @@ if (imageEditor && formData) {
     })
   })
 }
+
+const businessRestaurantGroupPricesAddButton = document.querySelector('#product_businessRestaurantGroupPrices_add')
+
+if (businessRestaurantGroupPricesAddButton) {
+  businessRestaurantGroupPricesAddButton.addEventListener('click', function() {
+    const listTarget = $(this).attr('data-target')
+    let newWidget = $(this).attr('data-prototype')
+    const counter = $(listTarget).children().length
+
+    newWidget = newWidget.replace(/__price__/g, counter)
+
+    $(newWidget).appendTo($(listTarget))
+
+    const widgetDoc = document.querySelector(`#${$(newWidget).attr('id')}`)
+    attachPricesAndTaxEventListeners(widgetDoc.querySelector('[data-tax-categories]'))
+  })
+}
+
+$("#product_businessRestaurantGroupPrices").on('click', '[data-delete]', function() {
+  const target = $($(this).attr('data-target'))
+
+  if (target.length === 0) {
+    return
+  }
+
+  target.remove()
+})

--- a/src/Entity/BusinessRestaurantGroupPriceWithTax.php
+++ b/src/Entity/BusinessRestaurantGroupPriceWithTax.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Entity;
 
 use AppBundle\Entity\BusinessRestaurantGroup;
+use Sylius\Component\Taxation\Model\TaxCategoryInterface;
 
 class BusinessRestaurantGroupPriceWithTax
 {

--- a/src/Entity/BusinessRestaurantGroupPriceWithTax.php
+++ b/src/Entity/BusinessRestaurantGroupPriceWithTax.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace AppBundle\Entity;
+
+use AppBundle\Entity\BusinessRestaurantGroup;
+
+class BusinessRestaurantGroupPriceWithTax
+{
+    /**
+     * @var BusinessRestaurantGroup
+     */
+    private $businessRestaurantGroup;
+
+    /**
+     * @var int
+     */
+    private $price;
+
+    /**
+     * @var TaxCategoryInterface
+     */
+    private $taxCategory;
+
+    private $priceWithTax;
+
+    public function __construct(BusinessRestaurantGroup $businessRestaurantGroup = null, $price = null, $taxCategory = null)
+    {
+        $this->businessRestaurantGroup = $businessRestaurantGroup;
+        $this->price = $price;
+        $this->taxCategory = $taxCategory;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBusinessRestaurantGroup()
+    {
+        return $this->businessRestaurantGroup;
+    }
+
+    /**
+     * @param mixed $businessRestaurantGroup
+     *
+     * @return self
+     */
+    public function setBusinessRestaurantGroup($businessRestaurantGroup)
+    {
+        $this->businessRestaurantGroup = $businessRestaurantGroup;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPrice()
+    {
+        return $this->price;
+    }
+
+    /**
+     * @param mixed $price
+     *
+     * @return self
+     */
+    public function setPrice($price)
+    {
+        $this->price = $price;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getTaxCategory()
+    {
+        return $this->taxCategory;
+    }
+
+    /**
+     * @param mixed $taxCategory
+     *
+     * @return self
+     */
+    public function setTaxCategory($taxCategory)
+    {
+        $this->taxCategory = $taxCategory;
+
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPriceWithTax()
+    {
+        return $this->priceWithTax;
+    }
+
+    /**
+     * @param mixed $priceWithTax
+     *
+     * @return self
+     */
+    public function setPriceWithTax($priceWithTax)
+    {
+        $this->priceWithTax = $priceWithTax;
+
+        return $this;
+    }
+}

--- a/src/Entity/Sylius/ProductVariant.php
+++ b/src/Entity/Sylius/ProductVariant.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Entity\Sylius;
 
+use AppBundle\Entity\BusinessRestaurantGroup;
 use AppBundle\Sylius\Product\ProductVariantInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
@@ -20,6 +21,11 @@ class ProductVariant extends BaseProductVariant implements ProductVariantInterfa
      * @var TaxCategoryInterface
      */
     protected $taxCategory;
+
+    /**
+     * @var BusinessRestaurantGroup
+     */
+    protected $businessRestaurantGroup;
 
     /**
      * {@inheritdoc}
@@ -151,5 +157,25 @@ class ProductVariant extends BaseProductVariant implements ProductVariantInterfa
         }
 
         return false;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBusinessRestaurantGroup()
+    {
+        return $this->businessRestaurantGroup;
+    }
+
+    /**
+     * @param mixed $businessRestaurantGroup
+     *
+     * @return self
+     */
+    public function setBusinessRestaurantGroup($businessRestaurantGroup)
+    {
+        $this->businessRestaurantGroup = $businessRestaurantGroup;
+
+        return $this;
     }
 }

--- a/src/Form/BusinessRestaurantGroupPriceType.php
+++ b/src/Form/BusinessRestaurantGroupPriceType.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace AppBundle\Form;
+
+use AppBundle\Entity\BusinessRestaurantGroup;
+use AppBundle\Entity\BusinessRestaurantGroupPriceWithTax;
+use AppBundle\Form\Type\PriceWithTaxType;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class BusinessRestaurantGroupPriceType extends AbstractType
+{
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($options) {
+
+            $form = $event->getForm();
+
+            $form
+                ->add('businessRestaurantGroup', EntityType::class, [
+                    'class' => BusinessRestaurantGroup::class,
+                    'label' => 'business_restaurant_group.label',
+                    'choice_label' => 'name',
+                    'choice_value' => 'id',
+                    'placeholder' => 'form.product.business_restaurant_group.price_definition.placeholder',
+                ])
+                ->add('priceWithTax', PriceWithTaxType::class, [
+                    'label' => false,
+                    'for_local_business_group' =>true,
+                ]);
+        });
+
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($options) {
+            $form = $event->getForm();
+            $businessRestaurantGroupPriceWithTax = $form->getData();
+
+            if ($businessRestaurantGroupPriceWithTax && $businessRestaurantGroupPriceWithTax->getBusinessRestaurantGroup()) {
+                $config = $form->get('priceWithTax')->getConfig();
+                $priceForHubOptions = $config->getOptions();
+                $priceForHubOptions['local_business_group'] = $businessRestaurantGroupPriceWithTax->getBusinessRestaurantGroup();
+
+                $form->add('priceWithTax', get_class($config->getType()->getInnerType()), $priceForHubOptions);
+            }
+        });
+
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) use ($options) {
+            $form = $event->getForm();
+            $businessRestaurantGroupPriceWithTax = $event->getData();
+
+            $priceFormName = $options["taxIncl"] ? 'taxIncluded' : 'taxExcluded';
+            $price = $form->get('priceWithTax')->get($priceFormName)->getData();
+
+            $taxCategory = $form->get('priceWithTax')->get('taxCategory')->getData();
+
+            $businessRestaurantGroupPriceWithTax->setPrice($price);
+            $businessRestaurantGroupPriceWithTax->setTaxCategory($taxCategory);
+        });
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'data_class' => BusinessRestaurantGroupPriceWithTax::class,
+            'owner' => null,
+            'taxIncl' => true,
+            'choices' => []
+        ));
+    }
+
+}

--- a/src/Form/BusinessRestaurantGroupPriceType.php
+++ b/src/Form/BusinessRestaurantGroupPriceType.php
@@ -17,7 +17,7 @@ class BusinessRestaurantGroupPriceType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use($options) {
 
             $form = $event->getForm();
 
@@ -25,6 +25,7 @@ class BusinessRestaurantGroupPriceType extends AbstractType
                 ->add('businessRestaurantGroup', EntityType::class, [
                     'class' => BusinessRestaurantGroup::class,
                     'label' => 'business_restaurant_group.label',
+                    'choices' => $options['choices'],
                     'choice_label' => 'name',
                     'choice_value' => 'id',
                     'placeholder' => 'form.product.business_restaurant_group.price_definition.placeholder',

--- a/src/Form/BusinessRestaurantGroupPriceType.php
+++ b/src/Form/BusinessRestaurantGroupPriceType.php
@@ -17,7 +17,7 @@ class BusinessRestaurantGroupPriceType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($options) {
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
 
             $form = $event->getForm();
 
@@ -35,7 +35,7 @@ class BusinessRestaurantGroupPriceType extends AbstractType
                 ]);
         });
 
-        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($options) {
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) {
             $form = $event->getForm();
             $businessRestaurantGroupPriceWithTax = $form->getData();
 

--- a/src/Form/ProductType.php
+++ b/src/Form/ProductType.php
@@ -2,6 +2,8 @@
 
 namespace AppBundle\Form;
 
+use AppBundle\Entity\BusinessRestaurantGroup;
+use AppBundle\Entity\BusinessRestaurantGroupPriceWithTax;
 use AppBundle\Entity\ReusablePackaging;
 use AppBundle\Entity\LocalBusiness\CatalogInterface;
 use AppBundle\Entity\Sylius\Product;
@@ -9,8 +11,11 @@ use AppBundle\Entity\Sylius\ProductOption;
 use AppBundle\Enum\Allergen;
 use AppBundle\Enum\RestrictedDiet;
 use AppBundle\Form\Type\PriceWithTaxType;
+use AppBundle\Sylius\Product\LazyProductVariantResolverInterface;
 use AppBundle\Sylius\Product\ProductInterface;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 use Sylius\Component\Product\Factory\ProductVariantFactoryInterface;
@@ -42,6 +47,9 @@ class ProductType extends AbstractType
     private $productAttributeRepository;
     private $productAttributeValueFactory;
     private $localeProvider;
+    private $translator;
+    private $entityManager;
+    private $variantResolver;
     private $hasChangedName = false;
 
     public function __construct(
@@ -50,14 +58,20 @@ class ProductType extends AbstractType
         FactoryInterface $productAttributeValueFactory,
         LocaleProviderInterface $localeProvider,
         TranslatorInterface $translator,
-        bool $taxIncl = true)
+        EntityManagerInterface $entityManager,
+        LazyProductVariantResolverInterface $variantResolver,
+        bool $taxIncl = true,
+        bool $businessAccountEnabled = false)
     {
         $this->variantFactory = $variantFactory;
         $this->productAttributeRepository = $productAttributeRepository;
         $this->productAttributeValueFactory = $productAttributeValueFactory;
         $this->localeProvider = $localeProvider;
         $this->translator = $translator;
+        $this->entityManager = $entityManager;
+        $this->variantResolver = $variantResolver;
         $this->taxIncl = $taxIncl;
+        $this->businessAccountEnabled = $businessAccountEnabled;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -108,7 +122,36 @@ class ProductType extends AbstractType
             'mapped' => false,
         ]);
 
-        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($options) {
+        $businessRestaurantGroups = null;
+        if ($this->businessAccountEnabled && null !== $options['owner']) {
+            $qb = $this->entityManager->getRepository(BusinessRestaurantGroup::class)
+                ->createQueryBuilder('g')
+                ->innerJoin('g.restaurants', 'r')
+                ->where('r.id = :restaurant')
+                ->setParameter('restaurant', $options['owner'])
+                ->orderBy('g.name');
+
+            $businessRestaurantGroups = $qb->getQuery()->getResult();
+
+            if (count($businessRestaurantGroups) > 0) {
+                $builder->add('businessRestaurantGroupPrices', CollectionType::class, [
+                    'entry_type' => BusinessRestaurantGroupPriceType::class,
+                    'entry_options' => [
+                        'taxIncl' => $this->taxIncl,
+                        'owner' => $options['owner'],
+                        'choices' => $businessRestaurantGroups
+                    ],
+                    'label' => 'form.product.business_restaurant_group.price_definition.label',
+                    'mapped' => false,
+                    'allow_add' => true,
+                    'allow_delete' => true,
+                    'prototype_name' => '__price__'
+                ]);
+            }
+
+        }
+
+        $builder->addEventListener(FormEvents::POST_SET_DATA, function (FormEvent $event) use ($options, $businessRestaurantGroups) {
 
             $form = $event->getForm();
             $product = $event->getData();
@@ -148,6 +191,22 @@ class ProductType extends AbstractType
                         ;
                 }
 
+                if ($form->has('businessRestaurantGroupPrices')) {
+                    $data = [];
+
+                    foreach($businessRestaurantGroups as $businessRestaurantGroup) {
+                        $variant = $this->variantResolver->getVariantForBusinessRestaurantGroup($product, $businessRestaurantGroup);
+                        if ($variant) {
+                            $data[] = new BusinessRestaurantGroupPriceWithTax(
+                                            $businessRestaurantGroup,
+                                            $variant->getPrice(),
+                                            $variant->getTaxCategory()
+                                        );;
+                        }
+                    }
+
+                    $form->get('businessRestaurantGroupPrices')->setData($data);
+                }
             }
 
             $this->postSetDataEnumAttribute($product, 'ALLERGENS', $form->get('allergens'));
@@ -206,7 +265,7 @@ class ProductType extends AbstractType
             }
         });
 
-        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) use ($options) {
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) use ($options, $businessRestaurantGroups) {
 
             $form = $event->getForm();
             $product = $event->getData();
@@ -254,6 +313,36 @@ class ProductType extends AbstractType
                     $variant->setName($product->getName());
                     $variant->setPrice($price);
                     $variant->setTaxCategory($taxCategory);
+                }
+            }
+
+            if ($form->has('businessRestaurantGroupPrices')) {
+                $businessRestaurantGroupPrices = $form->get('businessRestaurantGroupPrices')->getData();
+
+                $submitedBusinessRestaurantGroups = new ArrayCollection();
+                foreach ($businessRestaurantGroupPrices as $businessRestaurantGroupPrice) {
+                    $submitedBusinessRestaurantGroups->add($businessRestaurantGroupPrice->getBusinessRestaurantGroup());
+
+                    if (null === $product->getId()) {
+                        $this->createAndAddVariantForProduct($product, $businessRestaurantGroupPrice);
+                    } else {
+                        $variant = $this->variantResolver->getVariantForBusinessRestaurantGroup($product, $businessRestaurantGroupPrice->getBusinessRestaurantGroup());
+
+                        if ($variant === null) {
+                            $this->createAndAddVariantForProduct($product, $businessRestaurantGroupPrice);
+                        } else {
+                            $variant->setName($product->getName());
+                            $variant->setPrice($businessRestaurantGroupPrice->getPrice());
+                            $variant->setTaxCategory($businessRestaurantGroupPrice->getTaxCategory());
+                        }
+                    }
+                }
+
+                foreach ($businessRestaurantGroups as $businessRestaurantGroup) {
+                    if (!$submitedBusinessRestaurantGroups->contains($businessRestaurantGroup)) {
+                        $variantToRemove = $this->variantResolver->getVariantForBusinessRestaurantGroup($product, $businessRestaurantGroup);
+                        $product->removeVariant($variantToRemove);
+                    }
                 }
             }
 
@@ -318,6 +407,22 @@ class ProductType extends AbstractType
         }
 
         return [];
+    }
+
+    private function createAndAddVariantForProduct(
+        Product $product,
+        BusinessRestaurantGroupPriceWithTax $businessRestaurantGroupPrice
+    )
+    {
+        $variant = $this->variantFactory->createForProduct($product);
+
+        $variant->setName($product->getName());
+        $variant->setCode(Uuid::uuid4()->toString());
+        $variant->setPrice($businessRestaurantGroupPrice->getPrice());
+        $variant->setTaxCategory($businessRestaurantGroupPrice->getTaxCategory());
+        $variant->setBusinessRestaurantGroup($businessRestaurantGroupPrice->getBusinessRestaurantGroup());
+
+        $product->addVariant($variant);
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Form/ProductType.php
+++ b/src/Form/ProductType.php
@@ -4,6 +4,7 @@ namespace AppBundle\Form;
 
 use AppBundle\Entity\BusinessRestaurantGroup;
 use AppBundle\Entity\BusinessRestaurantGroupPriceWithTax;
+use AppBundle\Entity\BusinessRestaurantGroupRestaurantMenu;
 use AppBundle\Entity\ReusablePackaging;
 use AppBundle\Entity\LocalBusiness\CatalogInterface;
 use AppBundle\Entity\Sylius\Product;
@@ -16,6 +17,7 @@ use AppBundle\Sylius\Product\ProductInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query\Expr;
 use Ramsey\Uuid\Uuid;
 use Sylius\Component\Locale\Provider\LocaleProviderInterface;
 use Sylius\Component\Product\Factory\ProductVariantFactoryInterface;
@@ -125,11 +127,11 @@ class ProductType extends AbstractType
         $businessRestaurantGroups = null;
         if ($this->businessAccountEnabled && null !== $options['owner']) {
             $qb = $this->entityManager->getRepository(BusinessRestaurantGroup::class)
-                ->createQueryBuilder('g')
-                ->innerJoin('g.restaurants', 'r')
-                ->where('r.id = :restaurant')
+                ->createQueryBuilder('b')
+                ->select('b')
+                ->innerJoin(BusinessRestaurantGroupRestaurantMenu::class, 'g', Expr\Join::WITH, 'g.businessRestaurantGroup = b.id AND g.restaurant = :restaurant')
                 ->setParameter('restaurant', $options['owner'])
-                ->orderBy('g.name');
+                ->orderBy('b.name');
 
             $businessRestaurantGroups = $qb->getQuery()->getResult();
 

--- a/src/Form/ProductType.php
+++ b/src/Form/ProductType.php
@@ -321,7 +321,7 @@ class ProductType extends AbstractType
 
                 $submitedBusinessRestaurantGroups = new ArrayCollection();
                 foreach ($businessRestaurantGroupPrices as $businessRestaurantGroupPrice) {
-                    $submitedBusinessRestaurantGroups->add($businessRestaurantGroupPrice->getBusinessRestaurantGroup());
+                    $submitedBusinessRestaurantGroups->add($businessRestaurantGroupPrice->getBusinessRestaurantGroup()->getId());
 
                     if (null === $product->getId()) {
                         $this->createAndAddVariantForProduct($product, $businessRestaurantGroupPrice);
@@ -339,7 +339,7 @@ class ProductType extends AbstractType
                 }
 
                 foreach ($businessRestaurantGroups as $businessRestaurantGroup) {
-                    if (!$submitedBusinessRestaurantGroups->contains($businessRestaurantGroup)) {
+                    if (!in_array($businessRestaurantGroup->getId(), $submitedBusinessRestaurantGroups->toArray())) {
                         $variantToRemove = $this->variantResolver->getVariantForBusinessRestaurantGroup($product, $businessRestaurantGroup);
                         $product->removeVariant($variantToRemove);
                     }

--- a/src/Resources/config/doctrine/Sylius.ProductVariant.orm.xml
+++ b/src/Resources/config/doctrine/Sylius.ProductVariant.orm.xml
@@ -13,5 +13,10 @@
         <join-column name="tax_category_id" referenced-column-name="id" nullable="false"/>
       </join-columns>
     </many-to-one>
+    <many-to-one field="businessRestaurantGroup" target-entity="AppBundle\Entity\BusinessRestaurantGroup">
+      <join-columns>
+        <join-column name="business_restaurant_group_id" referenced-column-name="id"/>
+      </join-columns>
+    </many-to-one>
   </entity>
 </doctrine-mapping>

--- a/src/Sylius/Product/LazyProductVariantResolver.php
+++ b/src/Sylius/Product/LazyProductVariantResolver.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Sylius\Product;
 
+use AppBundle\Entity\BusinessRestaurantGroup;
 use Ramsey\Uuid\Uuid;
 use Sylius\Component\Product\Factory\ProductVariantFactoryInterface;
 use Sylius\Component\Product\Model\ProductInterface;
@@ -96,5 +97,18 @@ class LazyProductVariantResolver implements LazyProductVariantResolverInterface
         }
 
         return true;
+    }
+
+    public function getVariantForBusinessRestaurantGroup(ProductInterface $product, BusinessRestaurantGroup $businessRestaurantGroup): ?ProductVariantInterface
+    {
+        foreach ($product->getVariants() as $variant) {
+            $variantBusinessRestaurantGroup = $variant->getBusinessRestaurantGroup();
+
+            if (null !== $variantBusinessRestaurantGroup && $businessRestaurantGroup->getId() === $variantBusinessRestaurantGroup->getId()) {
+                return $variant;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Sylius/Product/LazyProductVariantResolverInterface.php
+++ b/src/Sylius/Product/LazyProductVariantResolverInterface.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Sylius\Product;
 
+use AppBundle\Entity\BusinessRestaurantGroup;
 use Sylius\Component\Product\Model\ProductInterface;
 use Sylius\Component\Product\Model\ProductVariantInterface;
 use Sylius\Component\Product\Resolver\ProductVariantResolverInterface as BaseProductVariantResolverInterface;
@@ -15,4 +16,12 @@ interface LazyProductVariantResolverInterface extends BaseProductVariantResolver
      * @return ProductVariantInterface|null
      */
     public function getVariantForOptionValues(ProductInterface $product, \Traversable $optionValues): ?ProductVariantInterface;
+
+    /**
+     * @param ProductInterface $product
+     * @param BusinessRestaurantGroup $businessRestaurantGroup
+     *
+     * @return ProductVariantInterface|null
+     */
+    public function getVariantForBusinessRestaurantGroup(ProductInterface $product, BusinessRestaurantGroup $businessRestaurantGroup): ?ProductVariantInterface;
 }

--- a/templates/form/product.html.twig
+++ b/templates/form/product.html.twig
@@ -21,3 +21,50 @@
   </button>
   </div>
 {% endblock %}
+
+{% block businessRestaurantGrouppPrices_widget %}
+  <div id="{{ form.vars.id }}" class="form-group mt-2">
+    {{ form_label(form) }}
+    <div id="{{ form.vars.id }}_list">
+      {% for child in form %}
+        {{ form_widget(child) }}
+        <hr />
+      {% endfor %}
+    </div>
+    <div class="text-right">
+      <button type="button" class="btn btn-default" id="{{ form.vars.id }}_add"
+        data-target="#{{ form.vars.id }}_list"
+        data-prototype="{{ form_widget(form.vars.prototype)|e }}">
+        {{ 'basics.add'|trans }}
+        </button>
+    </div>
+  </div>
+{% endblock %}
+
+{% block _product_businessRestaurantGroupPrices_widget %}
+  {{ block('businessRestaurantGrouppPrices_widget') }}
+{% endblock %}
+
+{% block businessRestaurantGroup_price_entry_widget %}
+  <div id="{{ form.vars.id }}" class="row">
+    <div class="col-sm-3">
+      {{ form_row(form.businessRestaurantGroup) }}
+    </div>
+    <div class="col-sm-8">
+      {{ form_widget(form.priceWithTax) }}
+    </div>
+    <div class="col-sm-1">
+      <div class="form-group">
+        <label class="control-label">{{ 'basics.delete'|trans }}</label>
+        <button type="button" class="btn btn-default"
+          data-delete data-target="#{{ form.vars.id }}">
+          <i class="fa fa-trash-o"></i>
+        </button>
+      </div>
+    </div>
+  </div>
+{% endblock %}
+
+{% block _product_businessRestaurantGroupPrices_entry_widget %}
+  {{ block('businessRestaurantGroup_price_entry_widget') }}
+{% endblock %}

--- a/templates/restaurant/product.html.twig
+++ b/templates/restaurant/product.html.twig
@@ -78,6 +78,10 @@
 
   {{ form_widget(form.priceWithTax) }}
 
+  {% if form.businessRestaurantGroupPrices is defined %}
+    {{ form_widget(form.businessRestaurantGroupPrices) }}
+  {% endif %}
+
   {{ form_row(form.options, { attr: { class: "product__form__options--sortable" } }) }}
 
   <section class="mb-4">

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1426,3 +1426,6 @@ deliveries.imports.created_at: Created at
 form.business_restaurant_group.restaurants_with_menu: Restaurants with menu
 form.business_restaurant_group.restaurant: Restaurant
 form.business_restaurant_group.menu: Menu
+form.product.business_restaurant_group.price_definition.label: Define prices for Business Restaurant Groups
+form.product.business_restaurant_group.price_definition.placeholder: Please select one
+business_restaurant_group.label: Business restaurant group

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -1408,3 +1408,6 @@ deliveries.imports.created_at: Creado el
 form.business_restaurant_group.restaurants_with_menu: Restaurantes con menú
 form.business_restaurant_group.restaurant: Restaurante
 form.business_restaurant_group.menu: Menú
+form.product.business_restaurant_group.price_definition.label: Definir precios para grupo de restaurantes para empresas
+form.product.business_restaurant_group.price_definition.placeholder: Por favor seleccione uno
+business_restaurant_group.label: Grupo de restaurantes para empresas


### PR DESCRIPTION
As mentioned [in this issue](https://github.com/coopcycle/coopcycle-web/issues/3877) we need a way to define different prices for a `BusinessAccount` (or Platform catering). 
With this PR users are able to define an extra price for each existing `BusinessRestaurantGroup` (similar entity as Hubs).

https://github.com/coopcycle/coopcycle-web/assets/4819244/02f23295-5007-44da-a455-d58ff7459d53


