### PR TITLE
Add legal fields in settings

### DIFF
--- a/src/Form/SettingsType.php
+++ b/src/Form/SettingsType.php
@@ -115,7 +115,15 @@ class SettingsType extends AbstractType
             ->add('sms_gateway_config', HiddenType::class, [
                 'required' => false,
                 'label' => 'form.settings.sms_gateway_config.label',
-            ]);
+        ])->add('company_legal_name', TextType::class, [
+            'required' => false,
+            'label' => 'form.settings.company_legal_name.label',
+            'help' => 'form.settings.company_legal_name.help',
+        ])->add('company_legal_id', TextType::class, [
+            'required' => false,
+            'label' => 'form.settings.company_legal_id.label',
+            'help' => 'form.settings.company_legal_id.help',
+        ]);
 
         // When cash on delivery is enabled, we want customers to register
         if (!$this->cashEnabled) {

--- a/src/Utils/Settings.php
+++ b/src/Utils/Settings.php
@@ -110,6 +110,10 @@ class Settings
 
     public $autocomplete_provider;
 
+    public $company_legal_name;
+
+    public $company_legal_id;
+
     /**
      * The regex to validate Google API Key was found on https://github.com/odomojuli/RegExAPI
      *

--- a/templates/admin/settings.html.twig
+++ b/templates/admin/settings.html.twig
@@ -30,6 +30,8 @@
       {{ form_row(form.brand_name) }}
       {{ form_row(form.administrator_email) }}
       {{ form_row(form.phone_number) }}
+      {{ form_row(form.company_legal_name) }}
+      {{ form_row(form.company_legal_id) }}
     </div>
   </div>
 

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1434,3 +1434,8 @@ business_restaurant_group.label: Business restaurant group
 adminDashboard.business_restaurant_groups.title: Business restaurant groups
 navbar.switch_to_business: '%name% account'
 navbar.switch_to_personal: Personal account
+form.settings.company_legal_name.label: "Legal name of the company"
+form.settings.company_legal_name.help: "Please enter the full legal name of the company as it appears on its official documents."
+form.settings.company_legal_id.label: "Company registration number or EIN"
+form.settings.company_legal_id.help: "This number is usually available on the company's official documents, such as invoices or contracts."
+

--- a/translations/messages.fr.yml
+++ b/translations/messages.fr.yml
@@ -1412,3 +1412,7 @@ deliveries.importing: Le fichier %filename% va bientôt être importé.
 deliveries.imports.created_at: Créé le
 adminDashboard.business_restaurant_groups.title: Groupes de restaurants d'entreprise
 registration.flow.finish: "Terminer mon inscription"
+form.settings.company_legal_name.label: "Nom légal de l'entreprise"
+form.settings.company_legal_name.help: "Veuillez entrer le nom légal complet de l'entreprise tel qu'il apparaît sur ses documents officiels."
+form.settings.company_legal_id.label: "Numéro de SIRET"
+form.settings.company_legal_id.help: "Ce numéro est généralement disponible sur les documents officiels de l'entreprise, tels que les factures ou les contrats."


### PR DESCRIPTION
Now coop admins are asked to fill `company_legal_name` and `company_legal_id` in their settings.

![image](https://github.com/coopcycle/coopcycle-web/assets/5613584/43cfb528-037c-45cc-bef0-af0fd8019756)
