### PR TITLE
Implement shipping time calculation for multiple pickups

### DIFF
--- a/src/Entity/Sylius/Order.php
+++ b/src/Entity/Sylius/Order.php
@@ -1736,4 +1736,9 @@ class Order extends BaseOrder implements OrderInterface
     {
         return null !== $this->businessAccount;
     }
+
+    public function getPickupAddresses(): Collection
+    {
+        return $this->getRestaurants()->map(fn (LocalBusiness $restaurant): Address => $restaurant->getAddress());
+    }
 }

--- a/src/Service/RouteOptimizer.php
+++ b/src/Service/RouteOptimizer.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Service;
 
+use AppBundle\Entity\Address;
 use AppBundle\Entity\Delivery;
 use AppBundle\Entity\Task;
 use AppBundle\Vroom\RoutingProblem;
@@ -10,19 +11,22 @@ use AppBundle\Vroom\Job;
 use AppBundle\Vroom\Shipment;
 use AppBundle\Vroom\Vehicle;
 use AppBundle\Entity\TaskCollection;
+use Carbon\Carbon;
+use Geocoder\Model\Coordinates;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
-* a class to connect a given routing problem with the vroom api to return optimal results
-*/
-
+ * A class to connect a given routing problem with the vroom api to return optimal results
+ */
 class RouteOptimizer
 {
     private $vroomClient;
 
-    public function __construct(HttpClientInterface $vroomClient)
+    public function __construct(HttpClientInterface $vroomClient, SettingsManager $settingsManager)
     {
         $this->vroomClient = $vroomClient;
+        $this->settingsManager = $settingsManager;
     }
 
     /**
@@ -98,5 +102,132 @@ class RouteOptimizer
         $routingProblem->addVehicle($vehicle);
 
         return $routingProblem;
+    }
+
+    /**
+     * @see https://github.com/VROOM-Project/vroom/issues/313
+     *
+     * @param Address[] $pickups
+     * @param Address $delivery
+     * @param \SplObjectStorage $registry
+     *
+     * @return RoutingProblem
+     */
+    public function createRoutingProblemForPickupsAndDelivery(
+        array $pickups, Address $delivery, \SplObjectStorage $registry)
+    {
+        $timeWindow = [
+            (int) Carbon::now()->startOfDay()->format('U'),
+            (int) Carbon::now()->endOfDay()->format('U')
+        ];
+
+        // We generate auto-increment identifiers using the SplObjectStorage
+        $ids = 1;
+
+        $registry->attach($delivery, $ids++);
+        foreach ($pickups as $address) {
+            $registry->attach($address, $ids++);
+        }
+
+        $routingProblem = new RoutingProblem();
+
+        $deliveryJob = new Job();
+
+        $deliveryJob->id = $registry[$delivery];
+        $deliveryJob->location = [
+            $delivery->getGeo()->getLongitude(),
+            $delivery->getGeo()->getLatitude()
+        ];
+        $deliveryJob->time_windows = [
+            $timeWindow
+        ];
+
+        foreach ($pickups as $address) {
+
+            $job = new Job();
+
+            $job->id = $registry[$address];
+            $job->location = [
+                $address->getGeo()->getLongitude(),
+                $address->getGeo()->getLatitude()
+            ];
+            $job->time_windows = [
+                $timeWindow
+            ];
+
+            $shipment = new Shipment();
+            $shipment->pickup = $job;
+            $shipment->delivery = $deliveryJob;
+
+            $routingProblem->addShipment($shipment);
+        }
+
+        $shipments = $routingProblem->getShipments();
+
+        // FIXME
+        // Would make more sense to start from the warehouse/hub once this concept is introduced
+        // In any case, we are only interested in the ordering, not the duration
+
+        $vehicle = new Vehicle(1, 'bike');
+        [ $latitude, $longitude ] = explode(',', $this->settingsManager->get('latlng'));
+        $vehicle->setStart(new Coordinates($latitude, $longitude));
+
+        $routingProblem->addVehicle($vehicle);
+
+        return $routingProblem;
+    }
+
+    /**
+     * @param Address[] $pickups
+     * @param Address $delivery
+     *
+     * @return Address[]
+     */
+    public function optimizePickupsAndDelivery(array $pickups, Address $delivery)
+    {
+        $addresses = [];
+
+        // Bail early, no need to optimize
+        if (count($pickups) === 1) {
+
+            return [ $pickups[0], $delivery ];
+        }
+
+        $registry = new \SplObjectStorage();
+        $problem = $this->createRoutingProblemForPickupsAndDelivery($pickups, $delivery, $registry);
+
+        $solution = $this->execute($problem);
+
+        $addressesById = [];
+        foreach ($registry as $address) {
+            $id = $registry[$address];
+            $addressesById[$id] = $address;
+        }
+
+        foreach ($solution['routes'][0]['steps'] as $step) {
+            if ('pickup' === $step['type']) {
+                $addresses[] = $addressesById[$step['id']];
+            }
+        }
+
+        $addresses[] = $delivery;
+
+        return $addresses;
+    }
+
+    /**
+     * @param RoutingProblem $problem
+     * @return array
+     */
+    public function execute(RoutingProblem $problem)
+    {
+        $normalizer = new RoutingProblemNormalizer();
+
+        $response = $this->vroomClient->request('POST', '', [
+            'headers' => ['Content-Type'=> 'application/json'],
+            'body' => json_encode($normalizer->normalize($problem)),
+        ]);
+
+        return json_decode((string) $response->getContent(), true);
     }
 }

--- a/src/Sylius/Order/OrderInterface.php
+++ b/src/Sylius/Order/OrderInterface.php
@@ -230,4 +230,9 @@ interface OrderInterface extends
     public function setBusinessAccount(BusinessAccount $businessAccount): void;
 
     public function isBusiness(): bool;
+
+    /**
+     * @return Collection
+     */
+    public function getPickupAddresses(): Collection;
 }

--- a/src/Utils/ShippingTimeCalculator.php
+++ b/src/Utils/ShippingTimeCalculator.php
@@ -2,6 +2,8 @@
 
 namespace AppBundle\Utils;
 
+use AppBundle\Entity\Address;
+use AppBundle\Service\RouteOptimizer;
 use AppBundle\Service\RoutingInterface;
 use AppBundle\Sylius\Order\OrderInterface;
 use Carbon\CarbonInterval;
@@ -11,25 +13,27 @@ class ShippingTimeCalculator
     private $routing;
     private $fallback;
 
-    public function __construct(RoutingInterface $routing, $fallback = '10 minutes')
+    public function __construct(RoutingInterface $routing, RouteOptimizer $optimizer, $fallback = '10 minutes')
     {
         $this->routing = $routing;
+        $this->optimizer = $optimizer;
         $this->fallback = $fallback;
     }
 
     public function calculate(OrderInterface $order): string
     {
-        $pickupAddress = $order->getPickupAddress();
+        $pickupAddresses = $order->getPickupAddresses()->toArray();
         $dropoffAddress = $order->getShippingAddress();
 
         if (null === $dropoffAddress || null === $dropoffAddress->getGeo()) {
             return $this->fallback;
         }
 
-        $seconds = $this->routing->getDuration(
-            $pickupAddress->getGeo(),
-            $dropoffAddress->getGeo()
-        );
+        $addresses = $this->optimizer->optimizePickupsAndDelivery($pickupAddresses, $dropoffAddress);
+
+        $coordinates = array_map(fn (Address $a) => $a->getGeo(), $addresses);
+
+        $seconds = $this->routing->getDuration(...$coordinates);
 
         if (0 === $seconds) {
             return $this->fallback;

--- a/tests/AppBundle/Service/RouteOptimizerTest.php
+++ b/tests/AppBundle/Service/RouteOptimizerTest.php
@@ -8,6 +8,7 @@ use AppBundle\Entity\Delivery;
 use AppBundle\Entity\Task;
 use AppBundle\Entity\TaskCollection;
 use AppBundle\Service\RouteOptimizer;
+use AppBundle\Service\SettingsManager;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -20,6 +21,8 @@ class RouteOptimizerTest extends KernelTestCase
         parent::setUp();
 
         self::bootKernel();
+
+        $this->settingsManager = $this->prophesize(SettingsManager::class);
 
         $this->client = self::$container->get('vroom.client');
     }
@@ -76,7 +79,7 @@ class RouteOptimizerTest extends KernelTestCase
         $taskCollection = $this->prophesize(TaskCollection::class);
         $taskCollection->getTasks()->willReturn($taskList);
 
-        $optimizer = new RouteOptimizer($this->client);
+        $optimizer = new RouteOptimizer($this->client, $this->settingsManager->reveal());
 
         $problem = $optimizer->createRoutingProblem($taskCollection->reveal());
 
@@ -125,7 +128,7 @@ class RouteOptimizerTest extends KernelTestCase
         $taskCollection = $this->prophesize(TaskCollection::class);
         $taskCollection->getTasks()->willReturn($taskList);
 
-        $optimizer = new RouteOptimizer($this->client);
+        $optimizer = new RouteOptimizer($this->client, $this->settingsManager->reveal());
 
         $result = $optimizer->optimize($taskCollection->reveal());
 


### PR DESCRIPTION
Currently, to calculate the shipping time, we calculate the travel time by bike between the pickup address and the dropoff address. 

In the context of business accounts, the pickup address is kind of "random", because it is resolved from the first restaurant of the group

https://github.com/coopcycle/coopcycle-web/blob/d2c6c354408a611cf4d1ed23e0a48701a9196443/src/Entity/BusinessRestaurantGroup.php#L65-L75

This pull request makes a better calculation of the shipping time in this context, and also in the context of multiple pickups in the future: the travel time is calculated using pickup addresses sorted from the farest to the closest, with a final dropoff. 
