### PR TITLE
menu redesign fixes

### DIFF
--- a/js/app/restaurant/item.scss
+++ b/js/app/restaurant/item.scss
@@ -30,7 +30,12 @@
     @media (min-width: $screen-xs-min) {
       min-width: 350px;
       width: auto;
+      max-width: calc(100% - 2rem);
     }
+  }
+
+  .modal-body {
+    overflow-x: auto;
   }
 
   .table-opening-hours {

--- a/js/app/restaurant/item.scss
+++ b/js/app/restaurant/item.scss
@@ -19,6 +19,10 @@
   }
 }
 
+.footer {
+  margin-top: 0;
+}
+
 #restaurant-opening-hours-modal {
   .modal-dialog {
     // width: inherit from bootstrap .modal-dialog

--- a/js/app/restaurant/item.scss
+++ b/js/app/restaurant/item.scss
@@ -28,7 +28,8 @@
     // width: inherit from bootstrap .modal-dialog
 
     @media (min-width: $screen-xs-min) {
-      width: 350px;
+      min-width: 350px;
+      width: auto;
     }
   }
 

--- a/templates/restaurant/index.html.twig
+++ b/templates/restaurant/index.html.twig
@@ -141,7 +141,7 @@
 
       <div class="row">
         <div class="col-xs-12 col-lg-8">
-          {% set restaurant_banner = coopcycle_asset(restaurant, 'bannerImageFile', 'restaurant_banner') %}
+          {% set restaurant_banner = coopcycle_asset(restaurant, 'bannerImageFile', 'restaurant_banner')|placeholder_image(filter='restaurant_banner', obj=restaurant) %}
           {% include 'restaurant/_partials/restaurant_info.html.twig' %}
         </div>
         <div class="col-xs-12 col-lg-4">


### PR DESCRIPTION
Fixes:

✅ opening hours might not fit into the modal, for example: https://demo.coopcycle.org/fr/restaurant/33-la-cabane-du-sud

✅ menu: white margin on the bottom of the page

✅ placeholder banners are not displayed on the restaurant page