### PR TITLE
Tours fixes 1.1

### DIFF
--- a/js/app/dashboard/components/context-menus/TasksContextMenu.js
+++ b/js/app/dashboard/components/context-menus/TasksContextMenu.js
@@ -153,16 +153,9 @@ const DynamicMenu = () => {
   const linkedTasksIds = useSelector(selectLinkedTasksIds)
   const taskIdToTourIdMap = useSelector(selectTaskIdToTourIdMap)
   const selectedTasksBelongsToTour = selectedTasks.some(t => taskIdToTourIdMap.has(t['@id']))
+  const isValidMultiselect = isValidTasksMultiSelect(selectedTasks, taskIdToTourIdMap)
 
-  let actions
-
-  if(!isValidTasksMultiSelect(selectedTasks, taskIdToTourIdMap)){
-    toast.warn(t('ADMIN_DASHBOARD_INVALID_TASKS_SELECTION'), {autoclose: 15000})
-    actions = []
-  } else {
-    actions = getAvailableActionsForTasks(selectedTasks, unassignedTasks, linkedTasksIds, selectedTasksBelongsToTour)
-
-  }
+  const actions = getAvailableActionsForTasks(selectedTasks, unassignedTasks, linkedTasksIds, selectedTasksBelongsToTour)
 
   const dispatch = useDispatch()
 
@@ -174,98 +167,103 @@ const DynamicMenu = () => {
 
   return (
     <Menu id="task-contextmenu">
-      <Item
-        hidden={ !(actions.includes(UNASSIGN_SINGLE) && selectedTask) }
-        onClick={ () => _unassign([ selectedTask ], (username, tasks) => dispatch(unassignTasks(username, tasks))) }
-      >
-        { selectedTask && t('ADMIN_DASHBOARD_UNASSIGN_TASK', { id: selectedTask.id }) }
-      </Item>
-      <Item
-        hidden={ !(actions.includes(MOVE_TO_TOP) && selectedTask) }
-        onClick={ () => dispatch(moveToTop(selectedTask)) }
-      >
-        { t('ADMIN_DASHBOARD_MOVE_TO_TOP') }
-      </Item>
-      <Item
-        hidden={ !(actions.includes(MOVE_TO_BOTTOM) && selectedTask) }
-        onClick={ () => dispatch(moveToBottom(selectedTask)) }
-      >
-        { t('ADMIN_DASHBOARD_MOVE_TO_BOTTOM') }
-      </Item>
-      <Item
-        hidden={ !actions.includes(UNASSIGN_MULTI) }
-        onClick={ () => _unassign(tasksToUnassign, (username, tasks) => dispatch(unassignTasks(username, tasks))) }
-      >
-        { t('ADMIN_DASHBOARD_UNASSIGN_TASKS_MULTI', { count: tasksToUnassign.length }) }
-      </Item>
-      <Item
-        hidden={ !actions.includes(CANCEL_MULTI) }
-        onClick={ () => dispatch(cancelTasks(selectedTasks)) }
-      >
-        { t('ADMIN_DASHBOARD_CANCEL_TASKS_MULTI', { count: selectedTasks.length }) }
-      </Item>
-      <Item
-        hidden={ !actions.includes(MOVE_TO_NEXT_DAY_MULTI) }
-        onClick={ () => dispatch(moveTasksToNextDay(selectedTasks)) }
-      >
-        { t('ADMIN_DASHBOARD_MOVE_TO_NEXT_DAY_MULTI', { count: selectedTasks.length }) }
-      </Item>
-      <Item
-        hidden={ !actions.includes(MOVE_TO_NEXT_WORKING_DAY_MULTI) }
-        onClick={ () => dispatch(moveTasksToNextWorkingDay(selectedTasks)) }
-      >
-        { t('ADMIN_DASHBOARD_MOVE_TO_NEXT_WORKING_DAY_MULTI', { count: selectedTasks.length, nextWorkingDay: moment(nextWorkingDay).format('LL') }) }
-      </Item>
-      <Item
-        hidden={ !actions.includes(CREATE_GROUP) }
-        onClick={ () => dispatch(openCreateGroupModal()) }
-      >
-        { t('ADMIN_DASHBOARD_CREATE_GROUP') }
-      </Item>
-      <Item
-        hidden={ !actions.includes(ADD_TO_GROUP) }
-        onClick={ () => dispatch(openAddTaskToGroupModal(selectedTasks)) }
-      >
-        { t('ADMIN_DASHBOARD_ADD_TO_GROUP') }
-      </Item>
-      <Item
-        hidden={ !actions.includes(REMOVE_FROM_GROUP) }
-        onClick={ () => dispatch(removeTasksFromGroup(selectedTasks)) }
-      >
-        { t('ADMIN_DASHBOARD_REMOVE_FROM_GROUP') }
-      </Item>
-      <Item
-        hidden={ !actions.includes(RESTORE) }
-        onClick={ () => dispatch(restoreTasks(selectedTasks)) }
-      >
-        { t('ADMIN_DASHBOARD_RESTORE') }
-      </Item>
-      <Item
-        hidden={ !actions.includes(RESCHEDULE) }
-        onClick={ () => {
-          dispatch(setCurrentTask(selectedTasks[0]))
-          dispatch(openTaskRescheduleModal())
-        }}
-        >
-        { t('ADMIN_DASHBOARD_RESCHEDULE') }
-      </Item>
-      <Item
-        hidden={ !actions.includes(CREATE_DELIVERY) }
-        onClick={ () => dispatch(openCreateDeliveryModal()) }
-      >
-        { t('ADMIN_DASHBOARD_CREATE_DELIVERY') }
-      </Item>
-      <Item
-        hidden={ !actions.includes(CREATE_TOUR) }
-        onClick={ () => dispatch(openCreateTourModal()) }
-      >
-        { t('ADMIN_DASHBOARD_CREATE_TOUR') }
-      </Item>
-      { actions.length === 0 && (
-        <Item disabled>
-          { t('ADMIN_DASHBOARD_NO_ACTION_AVAILABLE') }
-        </Item>
-      )}
+      { isValidMultiselect ?
+        <>
+          <Item
+            hidden={ !(actions.includes(UNASSIGN_SINGLE) && selectedTask) }
+            onClick={ () => _unassign([ selectedTask ], (username, tasks) => dispatch(unassignTasks(username, tasks))) }
+          >
+            { selectedTask && t('ADMIN_DASHBOARD_UNASSIGN_TASK', { id: selectedTask.id }) }
+          </Item>
+          <Item
+            hidden={ !(actions.includes(MOVE_TO_TOP) && selectedTask) }
+            onClick={ () => dispatch(moveToTop(selectedTask)) }
+          >
+            { t('ADMIN_DASHBOARD_MOVE_TO_TOP') }
+          </Item>
+          <Item
+            hidden={ !(actions.includes(MOVE_TO_BOTTOM) && selectedTask) }
+            onClick={ () => dispatch(moveToBottom(selectedTask)) }
+          >
+            { t('ADMIN_DASHBOARD_MOVE_TO_BOTTOM') }
+          </Item>
+          <Item
+            hidden={ !actions.includes(UNASSIGN_MULTI) }
+            onClick={ () => _unassign(tasksToUnassign, (username, tasks) => dispatch(unassignTasks(username, tasks))) }
+          >
+            { t('ADMIN_DASHBOARD_UNASSIGN_TASKS_MULTI', { count: tasksToUnassign.length }) }
+          </Item>
+          <Item
+            hidden={ !actions.includes(CANCEL_MULTI) }
+            onClick={ () => dispatch(cancelTasks(selectedTasks)) }
+          >
+            { t('ADMIN_DASHBOARD_CANCEL_TASKS_MULTI', { count: selectedTasks.length }) }
+          </Item>
+          <Item
+            hidden={ !actions.includes(MOVE_TO_NEXT_DAY_MULTI) }
+            onClick={ () => dispatch(moveTasksToNextDay(selectedTasks)) }
+          >
+            { t('ADMIN_DASHBOARD_MOVE_TO_NEXT_DAY_MULTI', { count: selectedTasks.length }) }
+          </Item>
+          <Item
+            hidden={ !actions.includes(MOVE_TO_NEXT_WORKING_DAY_MULTI) }
+            onClick={ () => dispatch(moveTasksToNextWorkingDay(selectedTasks)) }
+          >
+            { t('ADMIN_DASHBOARD_MOVE_TO_NEXT_WORKING_DAY_MULTI', { count: selectedTasks.length, nextWorkingDay: moment(nextWorkingDay).format('LL') }) }
+          </Item>
+          <Item
+            hidden={ !actions.includes(CREATE_GROUP) }
+            onClick={ () => dispatch(openCreateGroupModal()) }
+          >
+            { t('ADMIN_DASHBOARD_CREATE_GROUP') }
+          </Item>
+          <Item
+            hidden={ !actions.includes(ADD_TO_GROUP) }
+            onClick={ () => dispatch(openAddTaskToGroupModal(selectedTasks)) }
+          >
+            { t('ADMIN_DASHBOARD_ADD_TO_GROUP') }
+          </Item>
+          <Item
+            hidden={ !actions.includes(REMOVE_FROM_GROUP) }
+            onClick={ () => dispatch(removeTasksFromGroup(selectedTasks)) }
+          >
+            { t('ADMIN_DASHBOARD_REMOVE_FROM_GROUP') }
+          </Item>
+          <Item
+            hidden={ !actions.includes(RESTORE) }
+            onClick={ () => dispatch(restoreTasks(selectedTasks)) }
+          >
+            { t('ADMIN_DASHBOARD_RESTORE') }
+          </Item>
+          <Item
+            hidden={ !actions.includes(RESCHEDULE) }
+            onClick={ () => {
+              dispatch(setCurrentTask(selectedTasks[0]))
+              dispatch(openTaskRescheduleModal())
+            }}
+            >
+            { t('ADMIN_DASHBOARD_RESCHEDULE') }
+          </Item>
+          <Item
+            hidden={ !actions.includes(CREATE_DELIVERY) }
+            onClick={ () => dispatch(openCreateDeliveryModal()) }
+          >
+            { t('ADMIN_DASHBOARD_CREATE_DELIVERY') }
+          </Item>
+          <Item
+            hidden={ !actions.includes(CREATE_TOUR) }
+            onClick={ () => dispatch(openCreateTourModal()) }
+          >
+            { t('ADMIN_DASHBOARD_CREATE_TOUR') }
+          </Item>
+          { actions.length === 0 && (
+            <Item disabled>
+              { t('ADMIN_DASHBOARD_NO_ACTION_AVAILABLE') }
+            </Item>
+          )}
+        </> :
+        <Item disabled={true}>{t('ADMIN_DASHBOARD_INVALID_TASKS_SELECTION')}</Item>
+      }
     </Menu>
   )
 }

--- a/js/app/dashboard/components/context-menus/TasksContextMenu.js
+++ b/js/app/dashboard/components/context-menus/TasksContextMenu.js
@@ -24,7 +24,6 @@ import {
 } from '../../redux/actions'
 import {selectLinkedTasksIds, selectNextWorkingDay, selectSelectedTasks} from '../../redux/selectors'
 import {selectUnassignedTasks} from '../../../coopcycle-frontend-js/logistics/redux'
-import { toast } from 'react-toastify'
 
 import 'react-contexify/dist/ReactContexify.css'
 import { selectTaskIdToTourIdMap } from '../../../../shared/src/logistics/redux/selectors'

--- a/js/app/dashboard/redux/__tests__/utils.test.js
+++ b/js/app/dashboard/redux/__tests__/utils.test.js
@@ -65,11 +65,11 @@ describe('withLinkedTasks', () => {
     }
   ]
 
+  const taskIdToTourIdMap = new Map()
+
   it('should return expected results with one task', () => {
 
-    const actual = withLinkedTasks([
-      { '@id': '/api/tasks/4', next: '/api/tasks/5' }
-    ], allTasks)
+    const actual = withLinkedTasks([{ '@id': '/api/tasks/4', next: '/api/tasks/5' }], allTasks, taskIdToTourIdMap)
 
     expect(actual).toEqual([
       {
@@ -84,10 +84,13 @@ describe('withLinkedTasks', () => {
 
   it('should return expected results with multiple tasks', () => {
 
-    const actual = withLinkedTasks([
-      { '@id': '/api/tasks/4', next: '/api/tasks/5' },
-      { '@id': '/api/tasks/2', previous: '/api/tasks/1' }
-    ], allTasks)
+    const actual = withLinkedTasks(
+      [
+        { '@id': '/api/tasks/4', next: '/api/tasks/5' },
+        { '@id': '/api/tasks/2', previous: '/api/tasks/1' }
+      ],
+      allTasks,
+      taskIdToTourIdMap)
 
     expect(actual).toEqual([
       {
@@ -107,37 +110,12 @@ describe('withLinkedTasks', () => {
     ])
   })
 
-  it('should return twice the tasks if two tasks linked together as function arguments', () => {
+  it('should return not twice the tasks if two tasks linked together as function arguments', () => {
 
     const actual = withLinkedTasks([
       { '@id': '/api/tasks/4', next: '/api/tasks/5' },
       { '@id': '/api/tasks/5', previous: '/api/tasks/4' }
-    ], allTasks)
-
-    expect(actual).toEqual([
-      {
-        '@id': '/api/tasks/4',
-        next: '/api/tasks/5'
-      }, {
-        '@id': '/api/tasks/5',
-        previous: '/api/tasks/4',
-      },
-      {
-        '@id': '/api/tasks/4',
-        next: '/api/tasks/5'
-      }, {
-        '@id': '/api/tasks/5',
-        previous: '/api/tasks/4',
-      },
-    ])
-  })
-
-  it('should return once tasks if two tasks linked together as function arguments and unique flag is given', () => {
-
-    const actual = withLinkedTasks([
-      { '@id': '/api/tasks/4', next: '/api/tasks/5' },
-      { '@id': '/api/tasks/5', previous: '/api/tasks/4' }
-    ], allTasks, true)
+    ], allTasks, taskIdToTourIdMap)
 
     expect(actual).toEqual([
       {
@@ -150,39 +128,18 @@ describe('withLinkedTasks', () => {
     ])
   })
 
-  it('should return once tasks when unique flag is given + keep the original tasks order', () => {
-
-    const actual = withLinkedTasks([
-      { '@id': '/api/tasks/4', next: '/api/tasks/5' },
-      { '@id': '/api/tasks/9',},
-      { '@id': '/api/tasks/5', previous: '/api/tasks/4' }
-    ], allTasks, true)
-
-    expect(actual).toEqual([
-      {
-        '@id': '/api/tasks/4',
-        next: '/api/tasks/5'
-      }, 
-      { '@id': '/api/tasks/9',},
-      {
-        '@id': '/api/tasks/5',
-        previous: '/api/tasks/4',
-      }
-    ])
-  })
-
-  it('should return once tasks when unique flag is given + find the linked tasks', () => {
+  it('should find the linked tasks', () => {
 
     const actual = withLinkedTasks([
       {
         '@id': '/api/tasks/6',
       },
-      { '@id': '/api/tasks/9',}, 
+      { '@id': '/api/tasks/9',},
       {
         '@id': '/api/tasks/8',
         previous: '/api/tasks/6',
       },
-    ], allTasks, true)
+    ], allTasks, taskIdToTourIdMap)
 
     expect(actual).toEqual([
       {
@@ -192,11 +149,11 @@ describe('withLinkedTasks', () => {
         '@id': '/api/tasks/7',
         previous: '/api/tasks/6',
       },
-      { '@id': '/api/tasks/9',}, 
       {
         '@id': '/api/tasks/8',
         previous: '/api/tasks/7',
       },
+      { '@id': '/api/tasks/9',},
     ])
   })
 
@@ -204,7 +161,7 @@ describe('withLinkedTasks', () => {
 
     const actual = withLinkedTasks({
       '@id': '/api/tasks/6'
-    }, allTasks)
+    }, allTasks, taskIdToTourIdMap)
 
     expect(actual).toEqual([
       {
@@ -223,7 +180,7 @@ describe('withLinkedTasks', () => {
 
     const actual = withLinkedTasks({
       '@id': '/api/tasks/9'
-    }, allTasks)
+    }, allTasks, taskIdToTourIdMap)
 
     expect(actual).toEqual([
       {

--- a/js/app/dashboard/redux/__tests__/utils.test.js
+++ b/js/app/dashboard/redux/__tests__/utils.test.js
@@ -1,6 +1,6 @@
 import {
   withoutTasks,
-  withLinkedTasks,
+  withOrderTasksForDragNDrop,
   timeframeToPercentage,
   nowToPercentage,
   isInDateRange,
@@ -31,7 +31,7 @@ describe('withoutTasks', () => {
   })
 })
 
-describe('withLinkedTasks', () => {
+describe('withOrderTasksForDragNDrop', () => {
 
   const allTasks = [
     {
@@ -59,6 +59,10 @@ describe('withLinkedTasks', () => {
       '@id': '/api/tasks/8',
       previous: '/api/tasks/7',
     },
+    {
+      '@id': '/api/tasks/10',
+      previous: '/api/tasks/8',
+    },
     // Not linked
     {
       '@id': '/api/tasks/9',
@@ -66,10 +70,11 @@ describe('withLinkedTasks', () => {
   ]
 
   const taskIdToTourIdMap = new Map()
+  taskIdToTourIdMap.set('/api/tasks/10', '/api/tours/1')
 
   it('should return expected results with one task', () => {
 
-    const actual = withLinkedTasks([{ '@id': '/api/tasks/4', next: '/api/tasks/5' }], allTasks, taskIdToTourIdMap)
+    const actual = withOrderTasksForDragNDrop([{ '@id': '/api/tasks/4', next: '/api/tasks/5' }], allTasks, taskIdToTourIdMap)
 
     expect(actual).toEqual([
       {
@@ -84,7 +89,7 @@ describe('withLinkedTasks', () => {
 
   it('should return expected results with multiple tasks', () => {
 
-    const actual = withLinkedTasks(
+    const actual = withOrderTasksForDragNDrop(
       [
         { '@id': '/api/tasks/4', next: '/api/tasks/5' },
         { '@id': '/api/tasks/2', previous: '/api/tasks/1' }
@@ -112,7 +117,7 @@ describe('withLinkedTasks', () => {
 
   it('should return not twice the tasks if two tasks linked together as function arguments', () => {
 
-    const actual = withLinkedTasks([
+    const actual = withOrderTasksForDragNDrop([
       { '@id': '/api/tasks/4', next: '/api/tasks/5' },
       { '@id': '/api/tasks/5', previous: '/api/tasks/4' }
     ], allTasks, taskIdToTourIdMap)
@@ -130,7 +135,7 @@ describe('withLinkedTasks', () => {
 
   it('should find the linked tasks', () => {
 
-    const actual = withLinkedTasks([
+    const actual = withOrderTasksForDragNDrop([
       {
         '@id': '/api/tasks/6',
       },
@@ -159,7 +164,7 @@ describe('withLinkedTasks', () => {
 
   it('should return expected results with multiple tasks (without next)', () => {
 
-    const actual = withLinkedTasks({
+    const actual = withOrderTasksForDragNDrop({
       '@id': '/api/tasks/6'
     }, allTasks, taskIdToTourIdMap)
 
@@ -178,7 +183,7 @@ describe('withLinkedTasks', () => {
 
   it('should return expected results with unlinked task', () => {
 
-    const actual = withLinkedTasks({
+    const actual = withOrderTasksForDragNDrop({
       '@id': '/api/tasks/9'
     }, allTasks, taskIdToTourIdMap)
 
@@ -186,6 +191,25 @@ describe('withLinkedTasks', () => {
       {
         '@id': '/api/tasks/9',
       }
+    ])
+  })
+
+  it('should not return linked tasks in a different tour', () => {
+
+    const actual = withOrderTasksForDragNDrop({
+      '@id': '/api/tasks/8'
+    }, allTasks, taskIdToTourIdMap)
+
+    expect(actual).toEqual([
+      {
+        '@id': '/api/tasks/6',
+      }, {
+        '@id': '/api/tasks/7',
+        previous: '/api/tasks/6',
+      }, {
+        '@id': '/api/tasks/8',
+        previous: '/api/tasks/7',
+      },
     ])
   })
 

--- a/js/app/dashboard/redux/actions.js
+++ b/js/app/dashboard/redux/actions.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import axios from 'axios'
 import moment from 'moment'
 
-import { taskComparator, withoutTasks, withLinkedTasks, isInDateRange } from './utils'
+import { taskComparator, withoutTasks, isInDateRange } from './utils'
 import {
   selectSelectedDate,
   selectTaskLists,
@@ -207,7 +207,6 @@ export function assignAfter(username, task, after) {
   return function(dispatch, getState) {
 
     let state = getState()
-    let allTasks = selectAllTasks(state)
     let taskLists = selectTaskLists(state)
 
     const taskList = _.find(taskLists, taskList => taskList.username === username)
@@ -216,7 +215,7 @@ export function assignAfter(username, task, after) {
     if (-1 !== taskIndex) {
       const newTaskListItems = taskList.items.slice()
       Array.prototype.splice.apply(newTaskListItems,
-        Array.prototype.concat([ taskIndex + 1, 0 ], withLinkedTasks(task, allTasks))
+        Array.prototype.concat([ taskIndex + 1, 0 ], task)
       )
       dispatch(modifyTaskList(username, newTaskListItems))
     }

--- a/js/app/dashboard/redux/handleDrag.js
+++ b/js/app/dashboard/redux/handleDrag.js
@@ -135,21 +135,17 @@ export function handleDragEnd(
       selectedTasks = tour.items
     }
 
-    // we want to move linked tasks together only in this case, so the dispatcher can have fine-grained control
-    if (source.droppableId === 'unassigned') {
-      selectedTasks =  withLinkedTasks(selectedTasks, allTasks, true)
-      selectedTasks = selectedTasks.filter(
-        t => !belongsToTour(t)(getState()) && !t.isAssigned // these are already somewhere nice!
-      )
-    }
-
     if (selectedTasks.length === 0) return // can happen, for example dropping empty tour
 
+    const taskIdToTourIdMap = selectTaskIdToTourIdMap(getState())
 
-    if(!isValidTasksMultiSelect(selectedTasks, selectTaskIdToTourIdMap(getState()))){
+    if(!isValidTasksMultiSelect(selectedTasks, taskIdToTourIdMap)){
       toast.warn(i18next.t('ADMIN_DASHBOARD_INVALID_TASKS_SELECTION'), {autoclose: 15000})
       return
     }
+
+    // when we drag n drop we want all tasks of the order/delivery to move alongside
+    selectedTasks =  withLinkedTasks(selectedTasks, allTasks, taskIdToTourIdMap)
 
     if (destination.droppableId === 'unassigned') {
       if (!belongsToTour(selectedTasks[0])(getState())) {

--- a/js/app/dashboard/redux/handleDrag.js
+++ b/js/app/dashboard/redux/handleDrag.js
@@ -7,7 +7,7 @@ import { clearSelectedTasks,
   removeTasksFromTour as removeTasksFromTourAction,
   unassignTasks as unassignTasksAction } from "./actions"
 import { belongsToTour, selectGroups, selectSelectedTasks } from "./selectors"
-import { isValidTasksMultiSelect, withLinkedTasks } from "./utils"
+import { isValidTasksMultiSelect, withOrderTasksForDragNDrop } from "./utils"
 import { toast } from 'react-toastify'
 import i18next from "i18next"
 
@@ -145,7 +145,9 @@ export function handleDragEnd(
     }
 
     // when we drag n drop we want all tasks of the order/delivery to move alongside
-    selectedTasks =  withLinkedTasks(selectedTasks, allTasks, taskIdToTourIdMap)
+    if (source.droppableId !== destination.droppableId) {
+      selectedTasks =  withOrderTasksForDragNDrop(selectedTasks, allTasks, taskIdToTourIdMap)
+    }
 
     if (destination.droppableId === 'unassigned') {
       if (!belongsToTour(selectedTasks[0])(getState())) {

--- a/js/app/dashboard/redux/reducers.js
+++ b/js/app/dashboard/redux/reducers.js
@@ -33,7 +33,6 @@ import {
   OPEN_IMPORT_MODAL,
   CLOSE_IMPORT_MODAL,
   CLEAR_SELECTED_TASKS,
-  MODIFY_TASK_LIST_REQUEST_SUCCESS,
   RIGHT_PANEL_MORE_THAN_HALF,
   RIGHT_PANEL_LESS_THAN_HALF,
   OPEN_RECURRENCE_RULE_MODAL,
@@ -60,6 +59,9 @@ import {
   CREATE_TOUR_REQUEST_SUCCESS,
   CREATE_GROUP_REQUEST,
   CREATE_GROUP_SUCCESS,
+  MODIFY_TASK_LIST_REQUEST,
+  MODIFY_TOUR_REQUEST,
+  ADD_TASK_TO_GROUP_REQUEST,
 } from './actions'
 
 import {
@@ -149,7 +151,11 @@ export const selectedTasks = (state = [], action) => {
   case SELECT_TASKS:
     return action.taskIds
   case CLEAR_SELECTED_TASKS:
-  case MODIFY_TASK_LIST_REQUEST_SUCCESS:
+  case MODIFY_TASK_LIST_REQUEST:
+  case MODIFY_TOUR_REQUEST:
+  case CREATE_TOUR_REQUEST:
+  case CREATE_GROUP_REQUEST:
+  case ADD_TASK_TO_GROUP_REQUEST:
     // OPTIMIZATION
     // Make sure the array if not already empty
     // before returning a new reference

--- a/js/app/dashboard/redux/selectors.js
+++ b/js/app/dashboard/redux/selectors.js
@@ -104,7 +104,7 @@ export const selectStandaloneTasks = createSelector(
     let standaloneTasks = unassignedTasks
 
     if (taskListGroupMode === 'GROUP_MODE_FOLDERS') {
-      standaloneTasks = filter(unassignedTasks, task => !belongsToGroup(task) && !taskIdToTourIdMap.has(task['@id']))
+      standaloneTasks = filter(unassignedTasks, task => !belongsToGroup(task))
     }
 
     // Order by dropoff desc, with pickup before
@@ -138,7 +138,7 @@ export const selectStandaloneTasks = createSelector(
       })
     }
 
-    return standaloneTasks
+    return filter(standaloneTasks, t => !taskIdToTourIdMap.has(t['@id']))
   }
 )
 

--- a/js/app/dashboard/redux/utils.js
+++ b/js/app/dashboard/redux/utils.js
@@ -15,7 +15,7 @@ export function withoutTasks(state, tasks) {
   )
 }
 
-export function withLinkedTasks(tasks, allTasks, taskIdToTourIdMap) {
+export function withOrderTasksForDragNDrop(tasks, allTasks, taskIdToTourIdMap) {
 
   if (!Array.isArray(tasks)) {
     tasks = [ tasks ]
@@ -32,6 +32,7 @@ export function withLinkedTasks(tasks, allTasks, taskIdToTourIdMap) {
         if (!(taskWasAlreadyAdded)) {
           const taskToAdd = _.find(allTasks, t => t['@id'] === taskId)
 
+          // we don't want to move tasks that have been assigned to other courier, or moved individually to another tour..
           if (isValidTasksMultiSelect([task, taskToAdd], taskIdToTourIdMap)) {
             newTasks.push(taskToAdd)
           }
@@ -41,10 +42,6 @@ export function withLinkedTasks(tasks, allTasks, taskIdToTourIdMap) {
       // task which is not in a order/delivery
       newTasks.push(task)
     }
-  })
-
-  newTasks.sort((a, b) => {
-    return moment(a.before).isBefore(b.before) ? -1 : 1
   })
 
  return newTasks


### PR DESCRIPTION
Following fixes :
- filter out duplicate tasks in "unassigned tasks / unassigned tours" (bug with the options for sorting unassigned tasks) #4067
- move order tasks together on drag n drop (even for unassign) #4064  
- clear out task selection on create tour, modify tour, create group, modify group #4071
