### PR TITLE
clean: keep tour as an untouched group when optimizing

### DIFF
--- a/features/fixtures/ORM/optimizer/set1.yml
+++ b/features/fixtures/ORM/optimizer/set1.yml
@@ -1,0 +1,109 @@
+AppBundle\Entity\Base\GeoCoordinates:
+  geo_1:
+    __construct: [ "48.864577", "2.333338" ]
+  geo_2:
+    __construct: [ "48.846656", "2.369052" ]
+  geo_3:
+    __construct: [ "48.878658", "2.341055" ]
+  geo_4:
+    __construct: [ "48.8532461", "2.3681042" ]
+  geo_5:
+    __construct: [ "48.867598", "2.362811" ]
+
+AppBundle\Entity\Address:
+  address_1:
+    addressLocality: 'Paris'
+    postalCode: '75010'
+    streetAddress: '272, rue Saint Honoré 75001 Paris 1er'
+    geo: "@geo_1"
+  address_2:
+    addressLocality: 'Paris'
+    postalCode: '75010'
+    streetAddress: '18, avenue Ledru-Rollin 75012 Paris 12ème'
+    geo: "@geo_2"
+  address_3:
+    addressLocality: 'Paris'
+    postalCode: '75010'
+    streetAddress: '17, rue Milton 75009 Paris 9ème'
+    geo: "@geo_3"
+  address_4:
+    addressLocality: 'Paris'
+    postalCode: '75010'
+    streetAddress: 'Place de la Bastille'
+    geo: "@geo_4"
+  address_5:
+    addressLocality: 'Paris'
+    postalCode: '75010'
+    streetAddress: 'Place de la République'
+    geo: "@geo_5"
+
+AppBundle\Entity\Task:
+  task_1:
+    address: "@address_4"
+    doneAfter: <identity(new \DateTime('2018-03-02 10:30:00'))>
+    doneBefore: <identity(new \DateTime('2018-03-02 11:00:00'))>
+    comments: ""
+  task_2:
+    address: "@address_2"
+    doneAfter: <identity(new \DateTime('2018-03-02 11:30:00'))>
+    doneBefore: <identity(new \DateTime('2018-03-02 12:00:00'))>
+    comments: "#bob"
+  task_3:
+    address: "@address_5"
+    doneAfter: <identity(new \DateTime('2018-03-02 12:00:00'))>
+    doneBefore: <identity(new \DateTime('2018-03-02 12:30:00'))>
+    comments: "#bob"
+    status: "DONE"
+  task_4:
+    address: "@address_1"
+    doneAfter: <identity(new \DateTime('2018-03-03 12:00:00'))>
+    doneBefore: <identity(new \DateTime('2018-03-03 12:30:00'))>
+    comments: "#bob"
+  task_5:
+    address: "@address_2"
+    doneAfter: <identity(new \DateTime('2018-03-03 13:00:00'))>
+    doneBefore: <identity(new \DateTime('2018-03-03 13:30:00'))>
+    comments: "#bob"
+    previous: "@task_4"
+  task_6:
+    address: "@address_3"
+    doneAfter: <identity(new \DateTime('2018-03-02 12:00:00'))>
+    doneBefore: <identity(new \DateTime('2018-03-02 12:30:00'))>
+    comments: "#bob"
+    status: "CANCELLED"
+  task_7:
+    address: "@address_3"
+    doneAfter: <identity(new \DateTime('2018-02-02 12:00:00'))>
+    doneBefore: <identity(new \DateTime('2018-02-02 12:30:00'))>
+    comments: "#bob"
+    status: "DONE"
+
+AppBundle\Entity\User:
+  bob:
+    __factory:
+      '@Nucleos\UserBundle\Util\UserManipulator::create':
+        - 'bob'
+        - '123456'
+        - 'bob@demo.coopcycle.org'
+        - true
+        - false
+
+AppBundle\Entity\TaskList:
+  tasklist_1:
+    courier: "@bob"
+    date: <identity(new \DateTime('2018-03-02 12:00:00'))>
+
+
+AppBundle\Entity\Tour:
+  tour_1:
+    name: "Example tour"
+    date: <identity(new \DateTime('2018-03-02 12:00:00'))>
+    tasks:
+      - '@task_1'
+      - '@task_2'
+      - '@task_3'
+  tour_2:
+    name: "Example tour"
+    date: <identity(new \DateTime('2018-03-02 12:00:00'))>
+    tasks:
+      - '@task_4'

--- a/features/fixtures/ORM/optimizer/set2.yml
+++ b/features/fixtures/ORM/optimizer/set2.yml
@@ -1,0 +1,104 @@
+AppBundle\Entity\Base\GeoCoordinates:
+  geo_1:
+    __construct: [ "48.8704288", "2.3355269" ]
+  geo_2:
+    __construct: [ "48.8669865", "2.338254" ]
+  geo_3:
+    __construct: [ "48.8655514", "2.3328735" ]
+  geo_4:
+    __construct: [ "48.8696315", "2.3026263" ]
+  geo_5:
+    __construct: [ "48.8501504", "2.3376736" ]
+  geo_6:
+    __construct: [ "48.8699566", "2.3870763" ]
+
+AppBundle\Entity\Address:
+  address_1:
+    addressLocality: 'Paris'
+    postalCode: '75000'
+    streetAddress: 'Centre de paris'
+    geo: "@geo_1"
+  address_2:
+    addressLocality: 'Paris'
+    postalCode: '75000'
+    streetAddress: 'Centre de paris'
+    geo: "@geo_2"
+  address_3:
+    addressLocality: 'Paris'
+    postalCode: '75000'
+    streetAddress: 'Centre de paris'
+    geo: "@geo_3"
+  address_4:
+    addressLocality: 'Paris'
+    postalCode: '75000'
+    streetAddress: 'Exterieur de paris'
+    geo: "@geo_4"
+  address_5:
+    addressLocality: 'Paris'
+    postalCode: '75000'
+    streetAddress: 'Exterieur de paris'
+    geo: "@geo_5"
+  address_6:
+    addressLocality: 'Paris'
+    postalCode: '75000'
+    streetAddress: 'Exterieur de paris'
+    geo: "@geo_5"
+
+AppBundle\Entity\Task:
+  task_1:
+    address: "@address_1"
+    doneAfter: <identity(new \DateTime('2018-03-02 10:30:00'))>
+    doneBefore: <identity(new \DateTime('2018-03-02 11:00:00'))>
+    comments: ""
+  task_2:
+    address: "@address_2"
+    doneAfter: <identity(new \DateTime('2018-03-02 11:30:00'))>
+    doneBefore: <identity(new \DateTime('2018-03-02 12:00:00'))>
+    comments: "#bob"
+  task_3:
+    address: "@address_3"
+    doneAfter: <identity(new \DateTime('2018-03-02 12:00:00'))>
+    doneBefore: <identity(new \DateTime('2018-03-02 12:30:00'))>
+    comments: "#bob"
+    status: "DONE"
+  task_4:
+    address: "@address_4"
+    doneAfter: <identity(new \DateTime('2018-03-03 12:00:00'))>
+    doneBefore: <identity(new \DateTime('2018-03-03 12:30:00'))>
+    comments: "#bob"
+  task_5:
+    address: "@address_5"
+    doneAfter: <identity(new \DateTime('2018-03-03 13:00:00'))>
+    doneBefore: <identity(new \DateTime('2018-03-03 13:30:00'))>
+    comments: "#bob"
+  task_6:
+    address: "@address_6"
+    doneAfter: <identity(new \DateTime('2018-03-02 12:00:00'))>
+    doneBefore: <identity(new \DateTime('2018-03-02 12:30:00'))>
+    comments: "#bob"
+    status: "CANCELLED"
+
+AppBundle\Entity\User:
+  bob:
+    __factory:
+      '@Nucleos\UserBundle\Util\UserManipulator::create':
+        - 'bob'
+        - '123456'
+        - 'bob@demo.coopcycle.org'
+        - true
+        - false
+
+AppBundle\Entity\TaskList:
+  tasklist_1:
+    courier: "@bob"
+    date: <identity(new \DateTime('2018-03-02 12:00:00'))>
+
+
+AppBundle\Entity\Tour:
+  tour_1:
+    name: "tour_1"
+    date: <identity(new \DateTime('2018-03-02 12:00:00'))>
+    tasks:
+      - '@task_1'
+      - '@task_2'
+      - '@task_3'

--- a/src/Api/Filter/TaskFilter.php
+++ b/src/Api/Filter/TaskFilter.php
@@ -50,7 +50,7 @@ final class TaskFilter extends AbstractContextAwareFilter
             return;
         }
 
-        if (!$user->hasRole('ROLE_ADMIN') && $user->hasRole('ROLE_COURIER')) {
+        if (!($user->hasRole('ROLE_ADMIN') || $user->hasRole('ROLE_DISPATCHER')) && $user->hasRole('ROLE_COURIER')) {
 
             $parameterName = $queryNameGenerator->generateParameterName('user');
             $queryBuilder

--- a/src/Entity/TaskCollection.php
+++ b/src/Entity/TaskCollection.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * A TaskCollection is the database representation of a Task\CollectionInterface.
  * It uses Doctrine's Inheritance Mapping to implement a OneToMany relationship with TaskCollectionItem.
- * There are two concrete implementations of TaskCollection: Delivery & TaskList.
+ * There are concrete implementations of TaskCollection: Tour, Delivery & TaskList.
  *
  * @see http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/reference/inheritance-mapping.html
  */

--- a/src/Entity/Tour.php
+++ b/src/Entity/Tour.php
@@ -12,6 +12,8 @@ use AppBundle\Entity\Task\CollectionInterface as TaskCollectionInterface;
 use Symfony\Component\Serializer\Annotation\Groups;
 use Symfony\Component\Serializer\Annotation\SerializedName;
 use AppBundle\Api\Filter\DateFilter;
+use AppBundle\Vroom\Job as VroomJob;
+use AppBundle\Vroom\Shipment as VroomShipment;
 
 /**
  * @ApiResource(
@@ -132,5 +134,22 @@ class Tour extends TaskCollection implements TaskCollectionInterface
         $this->date = $date;
 
         return $this;
+    }
+
+    public static function toVroomStep(Tour $tour) : VroomJob|VroomShipment
+    {
+
+        $tasks = $tour->getTasks();
+
+        if (count($tasks) > 1) {
+            $shipment = new VroomShipment();
+            $shipment->pickup = Task::toVroomJob($tasks[0]);
+            $shipment->delivery = Task::toVroomJob($tasks[count($tasks) - 1]);
+            $shipment->description = 'tour:'.$tour->getId();
+            return $shipment;
+        } else {
+            return Task::toVroomJob($tasks[0]);
+        }
+
     }
 }

--- a/src/Vroom/Shipment.php
+++ b/src/Vroom/Shipment.php
@@ -18,4 +18,9 @@ class Shipment
      * @var Job
      */
     public $delivery;
+
+    /**
+     * @var string
+     */
+    public $description;
 }


### PR DESCRIPTION
issue #4007

this modifies the routing proplem class; so the tours are isolated for the algorithm
- we create a "shipment" object with start and end of the tour
- tasks that are in the tour are reinserted in order in between tour start and end