### PR TITLE
Allow search saved addresses in delivery form

### DIFF
--- a/js/app/components/AddressAutosuggest.js
+++ b/js/app/components/AddressAutosuggest.js
@@ -531,6 +531,13 @@ class AddressAutosuggest extends Component {
     })
   }
 
+  componentDidUpdate(prevProps) {
+    if ((!prevProps.address && this.props.address) ||
+      (_.isObject(prevProps.address) && _.isObject(this.props.address) && prevProps.address["@id"] !== this.props.address["@id"])) {
+        this.setState({ value: this.props.address.streetAddress })
+      }
+  }
+
   onSuggestionsClearRequested() {
 
     let suggestions = []

--- a/js/app/delivery/AddressBook.js
+++ b/js/app/delivery/AddressBook.js
@@ -413,7 +413,7 @@ export default function(el, options) {
 
   render(
     <AddressBook
-      allowSearchSavedAddresses={ allowSearchSavedAddresses }
+      allowSearchSavedAddresses={ Boolean(allowSearchSavedAddresses) }
       addresses={ addresses }
       initialAddress={ address }
       details={ details }

--- a/js/app/delivery/AddressBook.js
+++ b/js/app/delivery/AddressBook.js
@@ -12,6 +12,7 @@ import AddressAutosuggest from '../components/AddressAutosuggest'
 import { getCountry } from '../i18n'
 
 import './AddressBook.scss'
+import { SavedAddressesBox } from './SavedAddressBox'
 
 const AddressPopoverIcon = ({ prop }) => {
   switch (prop) {
@@ -150,12 +151,14 @@ const AddressBook = ({
   onDuplicateAddress,
   onClear,
   details,
+  allowSearchSavedAddresses,
   ...otherProps
 }) => {
 
   const { t } = useTranslation()
   const [ address, setAddress ] = useState(initialAddress)
   const [ isModalOpen, setModalOpen ] = useState(false)
+  const [ searchSavedAddresses, setSearchSavedAddresses ] = useState(false)
 
   const onAddressPropChange = (address, prop, value) => {
 
@@ -176,6 +179,19 @@ const AddressBook = ({
 
   return (
     <div>
+       {allowSearchSavedAddresses &&
+        <div>
+          <a className="help-block" role="button" onClick={() => setSearchSavedAddresses(!searchSavedAddresses)} aria-expanded="false">
+            <small><i className="fa fa-plus"></i> { t('TASK_FORM_SEARCH_SAVED_ADDRESS_BY_NAME') }</small>
+          </a>
+          {searchSavedAddresses &&
+            <SavedAddressesBox addresses={addresses} address={address} onSelected={(selected) => {
+              setAddress(selected)
+              onAddressSelected(selected.streetAddress, selected)
+            }}/>
+          }
+        </div>
+       }
       <div>
         <AddressAutosuggest
           addresses={ addresses }
@@ -255,6 +271,7 @@ export default function(el, options) {
     newAddressControl,
     isNewAddressControl,
     duplicateAddressControl,
+    allowSearchSavedAddresses,
   } = options
 
   Modal.setAppElement(el)
@@ -393,6 +410,7 @@ export default function(el, options) {
 
   render(
     <AddressBook
+      allowSearchSavedAddresses={ allowSearchSavedAddresses }
       addresses={ addresses }
       initialAddress={ address }
       details={ details }

--- a/js/app/delivery/AddressBook.js
+++ b/js/app/delivery/AddressBook.js
@@ -182,7 +182,10 @@ const AddressBook = ({
        {allowSearchSavedAddresses &&
         <div>
           <a className="help-block" role="button" onClick={() => setSearchSavedAddresses(!searchSavedAddresses)} aria-expanded="false">
-            <small><i className="fa fa-plus"></i> { t('TASK_FORM_SEARCH_SAVED_ADDRESS_BY_NAME') }</small>
+            <small>
+              <i className={`fa ${searchSavedAddresses ? 'fa-chevron-down' : 'fa-chevron-right'}`}></i>
+               { t('TASK_FORM_SEARCH_SAVED_ADDRESS_BY_NAME') }
+            </small>
           </a>
           {searchSavedAddresses &&
             <SavedAddressesBox addresses={addresses} address={address} onSelected={(selected) => {

--- a/js/app/delivery/AddressBook.scss
+++ b/js/app/delivery/AddressBook.scss
@@ -1,3 +1,5 @@
+@import "../../../assets/css/vars.scss";
+
 .ReactModal__Overlay--addressProp {
   // To make sure the overlay is *ABOVE* the Leaflet map
   z-index: 1001;
@@ -5,4 +7,16 @@
 
 .ReactModal__Content--addressProp {
   max-width: 50%;
+}
+
+.SavedAddressesBox__Results {
+  max-height: 160px;
+  overflow: auto;
+
+  li {
+    &:hover,
+      &:focus {
+        background-color: $light-gray;
+      }
+  }
 }

--- a/js/app/delivery/SavedAddressBox.js
+++ b/js/app/delivery/SavedAddressBox.js
@@ -1,0 +1,62 @@
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useCombobox } from 'downshift'
+
+function getAddressesFilter(inputValue) {
+  const lowerCasedInputValue = inputValue.toLowerCase()
+
+  return function addressesFilter(address) {
+    return (
+      !inputValue ||
+      address.name.toLowerCase().includes(lowerCasedInputValue)
+    )
+  }
+}
+
+export const SavedAddressesBox = ({ addresses, address, onSelected }) => {
+  const [items, setItems] = useState([])
+  const { t } = useTranslation()
+  const {
+    isOpen,
+    getMenuProps,
+    getInputProps,
+    getItemProps,
+  } = useCombobox({
+    onInputValueChange({ inputValue }) {
+      setItems(addresses.filter(getAddressesFilter(inputValue)))
+    },
+    items,
+    itemToString(item) {
+      return item ? `${item.name} - ${item.streetAddress}` : ''
+    },
+    onSelectedItemChange({ selectedItem }) {
+      onSelected(selectedItem)
+    }
+  })
+
+  return (
+    <div className="mb-2">
+      <div className="form-group-search">
+        <input
+          placeholder={t('TASK_FORM_SEARCH_ADDRESS_NAME_PLACEHOLDER')}
+          className="form-control"
+          {...getInputProps()} />
+      </div>
+      <ul
+        className={`SavedAddressesBox__Results list-unstyled bg-white shadow-md ${!isOpen && 'hidden'}`}
+        {...getMenuProps()}
+      >
+        {isOpen &&
+          items.map((item, index) => (
+            <li
+              className={`py-2 px-3 shadow-sm ${(address && address["@id"] === item["@id"]) && 'font-weight-bold'}`}
+              key={item['@id']}
+              {...getItemProps({ item, index })}
+            >
+              <span>{item.name} - {item.streetAddress}</span>
+            </li>
+          ))}
+      </ul>
+    </div>
+  )
+}

--- a/js/app/delivery/SavedAddressBox.js
+++ b/js/app/delivery/SavedAddressBox.js
@@ -8,7 +8,7 @@ function getAddressesFilter(inputValue) {
   return function addressesFilter(address) {
     return (
       !inputValue ||
-      address.name.toLowerCase().includes(lowerCasedInputValue)
+      address.name?.toLowerCase().includes(lowerCasedInputValue)
     )
   }
 }

--- a/js/app/forms/delivery.js
+++ b/js/app/forms/delivery.js
@@ -50,20 +50,21 @@ function toPackages(name) {
 function hideRememberAddress(name, type) {
   const rememberAddr = document.querySelector(`#${name}_${type}_address_rememberAddress`)
   if (rememberAddr) {
-    rememberAddr.closest('.checkbox').classList.add('invisible')
+    rememberAddr.closest('.checkbox').classList.add('hidden')
   }
 }
 
 function showRememberAddress(name, type) {
   const rememberAddr = document.querySelector(`#${name}_${type}_address_rememberAddress`)
   if (rememberAddr) {
-    rememberAddr.closest('.checkbox').classList.remove('invisible')
+    rememberAddr.closest('.checkbox').classList.remove('hidden')
   }
 }
 
 function createAddressWidget(name, type, cb) {
 
   new AddressBook(document.querySelector(`#${name}_${type}_address`), {
+    allowSearchSavedAddresses: true,
     existingAddressControl: document.querySelector(`#${name}_${type}_address_existingAddress`),
     newAddressControl: document.querySelector(`#${name}_${type}_address_newAddress_streetAddress`),
     isNewAddressControl: document.querySelector(`#${name}_${type}_address_isNewAddress`),

--- a/js/app/i18n/locales/en.json
+++ b/js/app/i18n/locales/en.json
@@ -417,6 +417,8 @@
         "RESTAURANT_STOCK_PHOTOS_SELECT": "Select this image",
         "PRESS_ENTER_TO_SEARCH": "Press Enter to search « {{query}} »",
         "SHOW_MORE_RESULTS": "Show more results for « {{query}} »",
-        "ADMIN_DASHBOARD_ORDERS_RESTORE": "Restore"
+        "ADMIN_DASHBOARD_ORDERS_RESTORE": "Restore",
+        "TASK_FORM_SEARCH_SAVED_ADDRESS_BY_NAME": "Search a saved address",
+        "TASK_FORM_SEARCH_ADDRESS_NAME_PLACEHOLDER": "Address name..."
     }
 }

--- a/js/app/i18n/locales/es.json
+++ b/js/app/i18n/locales/es.json
@@ -369,6 +369,8 @@
         "SEE_ALL": "Ver todo",
         "ORDER_DELAYED_NOTIFICATION": "Orden {{orderNumber}} atrasada. Nuevo rango horario de entrega: {{shippingTimeRange}}",
         "DELETE_ALL": "Eliminar todo",
-        "ADMIN_RECURRENCE_RULE_NAME_PLACEHOLDER": "Nombre de la regla"
+        "ADMIN_RECURRENCE_RULE_NAME_PLACEHOLDER": "Nombre de la regla",
+        "TASK_FORM_SEARCH_SAVED_ADDRESS_BY_NAME": "Buscar una dirección guardada",
+        "TASK_FORM_SEARCH_ADDRESS_NAME_PLACEHOLDER": "Nombre de la dirección..."
     }
 }

--- a/src/Form/AddressType.php
+++ b/src/Form/AddressType.php
@@ -83,7 +83,7 @@ class AddressType extends AbstractType
         if (true === $options['with_name']) {
             $builder
                 ->add('name', TextType::class, [
-                    'required' => false,
+                    'required' => true,
                     'label' => 'form.address.name.label',
                     'attr' => ['placeholder' => 'form.address.name.placeholder']
                 ]);

--- a/templates/form/address_book.html.twig
+++ b/templates/form/address_book.html.twig
@@ -12,9 +12,7 @@
     {{ form_widget(form.existingAddress,          { attr: { 'class': (isNewAddress ? 'd-none' : '') } }) }}
     {{ form_widget(form.newAddress.streetAddress, { attr: { 'class': (isNewAddress ? '' : 'd-none') } }) }}
 
-    {% if form.rememberAddress is defined %}
-      {{ form_widget(form.rememberAddress) }}
-    {% endif %}
+    
 
     {{ form_widget(form.newAddress.postalCode, { attr: { 'data-address-prop': 'postalCode' } }) }}
     {{ form_widget(form.newAddress.addressLocality, { attr: { 'data-address-prop': 'addressLocality' } }) }}
@@ -37,4 +35,8 @@
     {{ form_widget(form.duplicateAddress, { attr: { 'class': 'd-none' } }) }}
 
   </div>
+
+  {% if form.rememberAddress is defined %}
+      {{ form_widget(form.rememberAddress) }}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
Closes #3825

This change allows to dispatchers and shop owners searching saved addresses by its name in the delivery form.
Note that Autosuggest component already show saved addresses but is limited only to 5 addresses. This new search component will search for all the saved address.


https://github.com/coopcycle/coopcycle-web/assets/4819244/9d70aa87-36d1-4ea1-bf9f-bf10ae834f4f

