### PR TITLE
Fix busines account for existing users

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -265,7 +265,7 @@ class UserController extends AbstractController
         return $this->render('_partials/profile/definition_password_for_business_account.html.twig', [
             'form' => $form->createView(),
             'flow' => $businessAccountRegistrationFlow,
-            'invitationUser' => $businessAccountInvitation->getInvitation()->getUser(),
+            'invitation' => $businessAccountInvitation->getInvitation(),
         ]);
     }
 

--- a/src/Entity/BusinessAccountInvitation.php
+++ b/src/Entity/BusinessAccountInvitation.php
@@ -8,6 +8,11 @@ class BusinessAccountInvitation
     private $businessAccount;
     private $invitation;
 
+    public function getId()
+    {
+        return $this->id;
+    }
+
     public function getBusinessAccount()
     {
         return $this->businessAccount;

--- a/src/EventListener/AuthenticationWebSuccessHandler.php
+++ b/src/EventListener/AuthenticationWebSuccessHandler.php
@@ -54,6 +54,11 @@ class AuthenticationWebSuccessHandler implements AuthenticationSuccessHandlerInt
         // This is the URL (if any) the user visited that forced them to login
         $targetPath = $this->getTargetPath($request->getSession(), $this->providerKey);
 
+        // Check if there is a target path in request params
+        if (!$targetPath) {
+            $targetPath = $request->get('_target_path');
+        }
+
         // If there is no target path, redirect depending on role
         if (!$targetPath) {
 

--- a/src/Form/BusinessAccountType.php
+++ b/src/Form/BusinessAccountType.php
@@ -10,6 +10,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -85,14 +86,20 @@ class BusinessAccountType extends AbstractType
                     ]);
                 if (null !== $businessAccountInvitation) {
                     if ($this->authorizationChecker->isGranted('ROLE_ADMIN') && !$options['business_account_registration']) {
-                        $form->add('managerEmail', EmailType::class, [
-                            'label' => 'form.business_account.manager.email.label',
-                            'help' => 'form.business_account.manager.email_sent.help',
-                            'disabled' => true,
-                            'required'=> false,
-                            'mapped'=> false,
-                            'data' => $businessAccountInvitation->getInvitation()->getEmail(),
-                        ]);
+                        $form
+                            ->add('managerEmail', EmailType::class, [
+                                'label' => 'form.business_account.manager.email.label',
+                                'help' => 'form.business_account.manager.email_sent.help',
+                                'help_html' => true,
+                                'disabled' => true,
+                                'required'=> false,
+                                'mapped'=> false,
+                                'data' => $businessAccountInvitation->getInvitation()->getEmail(),
+                            ])
+                            ->add('invitationId', HiddenType::class, [
+                                'mapped' => false,
+                                'data' => $businessAccountInvitation->getId()
+                            ]);
                     }
 
                     if ($this->authorizationChecker->isGranted('ROLE_BUSINESS_ACCOUNT')) {

--- a/src/Resources/config/routing/admin.yml
+++ b/src/Resources/config/routing/admin.yml
@@ -123,6 +123,12 @@ admin_business_account:
     defaults:
         _controller: AppBundle\Controller\AdminController::businessAccountAction
 
+admin_business_account_resend_registration_email:
+    path: /admin/restaurants/business-account-resend-registration-email
+    defaults:
+        _controller: AppBundle\Controller\AdminController::businessAccountResendRegistrationEmailAction
+    methods: [ POST ]
+
 admin_business_restaurant_group_new:
     path: /admin/restaurants/business-restaurant-groups/new
     defaults:

--- a/templates/_partials/profile/definition_password_for_business_account.html.twig
+++ b/templates/_partials/profile/definition_password_for_business_account.html.twig
@@ -19,7 +19,13 @@
       '%brandName%': coopcycle_setting('brand_name'),
     } %}registration.alert.business.account.text{% endtrans %}
   </div>
-  {{ form_start(form) }}
+  {% if flow.getCurrentStepNumber() == 1 and form.user.username is not null %}
+    {% include '_partials/profile/existing_user_ask_login_form.html.twig' with {
+      form: form.user,
+      invitation: invitation
+    } %}
+  {% else %}
+    {{ form_start(form) }}
     {% if flow.getCurrentStepNumber() == 1 %}
       {% include '_partials/profile/personal_information_form.html.twig' with {
         form: form.user
@@ -33,7 +39,8 @@
     {% if flow.getCurrentStepNumber() == 3 %}
       {% include '_partials/profile/business_account_invitation_form.html.twig' %}
     {% endif %}
-  {{ form_end(form) }}
+    {{ form_end(form) }}
+  {% endif %}
 {% endblock %}
 
 {% block scripts %}

--- a/templates/_partials/profile/definition_password_for_business_account.html.twig
+++ b/templates/_partials/profile/definition_password_for_business_account.html.twig
@@ -19,7 +19,7 @@
       '%brandName%': coopcycle_setting('brand_name'),
     } %}registration.alert.business.account.text{% endtrans %}
   </div>
-  {% if flow.getCurrentStepNumber() == 1 and form.user.username is not null %}
+  {% if flow.getCurrentStepNumber() == 1 and form.user.username.vars.data is not empty %}
     {% include '_partials/profile/existing_user_ask_login_form.html.twig' with {
       form: form.user,
       invitation: invitation

--- a/templates/_partials/profile/existing_user_ask_login_form.html.twig
+++ b/templates/_partials/profile/existing_user_ask_login_form.html.twig
@@ -1,0 +1,24 @@
+<div class="form-section">
+  <div class="alert alert-warning">
+    <i class="fa fa-warning mr-1"></i>
+    <span>{{ 'business_account.registration.user_with_same_email_exists'|trans }}</span>
+  </div>
+
+  <form class="form" action="{{ path("nucleos_user_security_check", { _target_path: path('invitation_define_password', {code: invitation.code}) }) }}" method="post">
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}" />
+    <input type="hidden" name="_username" value="{{ form.email.vars.data }}" />
+    <div class="input-group">
+      <input type="password" name="_password"
+        class="form-control" id="guest-checkout-password"
+        placeholder="{{ 'security.login.password'|trans({}, 'NucleosUserBundle') }}">
+      <span class="input-group-btn">
+        <button type="submit" class="btn btn-primary">
+          {{ 'security.login.submit'|trans({}, 'NucleosUserBundle') }}
+        </button>
+      </span>
+    </div>
+    <a class="help-block mb-0" href="{{ path('nucleos_user_resetting_request') }}">
+      {% trans from 'messages' %}authentication.forgot_password{% endtrans %}
+    </a>
+  </form>
+</div>

--- a/templates/admin/business_account.html.twig
+++ b/templates/admin/business_account.html.twig
@@ -109,9 +109,12 @@
   </button>
 {{ form_end(form) }}
 
-<form id="resend_registration_email_form" method="post" action="{{ path('admin_business_account_resend_registration_email') }}" >
-  <input type="hidden" name="invitationId" value="{{ form.invitationId.vars.data }}">
-</form>
+{% if form.invitationId is defined %}
+  <form id="resend_registration_email_form" method="post" action="{{ path('admin_business_account_resend_registration_email') }}" >
+    <input type="hidden" name="invitationId" value="{{ form.invitationId.vars.data }}">
+  </form>
+{% endif %}
+
 {% endblock %}
 
 {% block scripts %}

--- a/templates/admin/business_account.html.twig
+++ b/templates/admin/business_account.html.twig
@@ -108,4 +108,17 @@
     {% endif %}
   </button>
 {{ form_end(form) }}
+
+<form id="resend_registration_email_form" method="post" action="{{ path('admin_business_account_resend_registration_email') }}" >
+  <input type="hidden" name="invitationId" value="{{ form.invitationId.vars.data }}">
+</form>
+{% endblock %}
+
+{% block scripts %}
+  <script>
+    $('#company_managerEmail_help').find('a').on('click', (e) => {
+      e.preventDefault;
+      $('#resend_registration_email_form').submit();
+    });
+  </script>
 {% endblock %}

--- a/templates/emails/business_account_send_invitation.mjml.twig
+++ b/templates/emails/business_account_send_invitation.mjml.twig
@@ -3,10 +3,10 @@
 {% block content %}
 <mj-column>
   <mj-text align="left" line-height="20px">
-    {{ 'business_account.send_invitation.body' | trans({'%name%': account.name}, 'emails') | raw }}
+    {{ 'business_account.send_invitation.body' | trans({'%name%': account.name }, 'emails') | raw }}
   </mj-text>
   <mj-button font-family="Raleway, Arial, sans-serif" background-color="#10ac84" color="white" href="{{ url('invitation_define_password', {'code': invitation.code}) }}">
-  	{{ 'admin.send_invitation.create_password' | trans({}, 'emails') }}
+  	{{ 'business_account.send_invitation.cta' | trans({}, 'emails') }}
   </mj-button>
 </mj-column>
 {% endblock %}

--- a/translations/emails.en.yml
+++ b/translations/emails.en.yml
@@ -160,3 +160,4 @@ business_account.send_invitation.body: |
   Hello %name%,
   <br>
   This is an invitation to configure the business account in CoopCycle, to continue with the activation please click on the following link.
+business_account.send_invitation.cta: Continue to activate

--- a/translations/emails.es.yml
+++ b/translations/emails.es.yml
@@ -88,6 +88,8 @@ order.adhoc.body: |
   Se ha creado un nuevo pedido para usted.
   <br>
   Para finalizar su pedido, haga clic en el siguiente enlace para especificar su dirección, elegir una franja de entrega y pagar con tarjeta de crédito.
-business_account.send_invitation.body: "Hola %name%,\n<br>\nEste correo es una invitación\
-  \ a tu espacio CoopCycle, para terminar la creación de su cuenta, por favor haga\
-  \ un clic en el siguiente enlace.\n"
+business_account.send_invitation.body: |
+  Hola %name%,
+  <br>
+  Ésta es una invitación para configurar su cuenta de empresa en Coopcycle, por favor haga click en el siguiente enlace para continuar con la activación.
+business_account.send_invitation.cta: Continuar activación

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1188,9 +1188,11 @@ form.business_account.restaurants.add: Add a restaurant
 form.business_account.employees.add: Add an employee
 form.business_account.manager.email.label: Account manager email
 form.business_account.manager.email.help: An invitation email to Coopcycle will be sent
-form.business_account.manager.email_sent.help: Invitation email to Coopcycle has been sent
+form.business_account.manager.email_sent.help: Invitation email to Coopcycle has been sent. <a href="#">Click here</a> to resend the email.
 form.business_account.save_and_send_invitation.label: Save and send invitation
 form.business_acount.send_invitation.confirm: Invitation email to Coopcycle has been sent
+form.business_acount.resend_invitation.confirm: Invitation email to Coopcycle has been resent
+form.business_acount.resend_invitation.failed: There has been an error trying to resend the Business Account registration email
 adminDashboard.business_restaurant_group_list.title: Business restaurant group list
 adminDashboard.business_restaurant_group.title: Business restaurant group
 adminDashboard.business_restaurant_group.createNew: Create a new business restaurant group

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1495,3 +1495,5 @@ restaurants.edenred.refresh.no_updates: "The restaurant '%restaurant_name%' does
 restaurants.edenred.refresh.has_updates: "The restaurant '%restaurant_name%' has had an update from Edenred servers."
 restaurants.edenred.added_list.actions: Actions
 business_restaurant_group.form.fill_all_pages: "Please, fill out all three settings pages."
+business_account.registration.user_with_same_email_exists: An account with the your email already
+  exists. Please log in to continue with your business account configuration.

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -1224,9 +1224,11 @@ form.business_account.restaurants.add: Agregar un restaurante
 form.business_account.employees.add: Agregar un empleado
 form.business_account.manager.email.label: Email del administrador de la cuenta
 form.business_account.manager.email.help: Se enviará un link de invitación a Coopcycle
-form.business_account.manager.email_sent.help: Link de invitación a Coopcycle enviado
+form.business_account.manager.email_sent.help: Link de invitación a Coopcycle enviado. <a href="#">Haga click aquí</a> para reenviar el email.
 form.business_account.save_and_send_invitation.label: Guardar y enviar invitación
 form.business_acount.send_invitation.confirm: El email de invitación a Coopcycle ha sido enviado
+form.business_acount.resend_invitation.confirm: El email de invitación a Coopcycle ha sido reenviado
+form.business_acount.resend_invitation.failed: Ha ocurrido un error al intentar reenviar el email de registración de la cuenta de empresa
 adminDashboard.business_restaurant_group_list.title: Listado de grupos de restaurantes para empresas
 adminDashboard.business_restaurant_group.title: Group de restaurantes para empresas
 adminDashboard.business_restaurant_group.createNew: Crear un nuevo grupo de restaurantes para empresas

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -1431,3 +1431,5 @@ restaurants.edenred.refresh.no_updates: "El restaurante '%restaurant_name%' hast
 restaurants.edenred.refresh.has_updates: "El restaurante '%restaurant_name%' ha tenido actualizaciones de los servidores de Edenred."
 restaurants.edenred.added_list.actions: Acciones
 business_restaurant_group.form.fill_all_pages: "Por favor, completar toda la configuración requerida en las tres páginas."
+business_account.registration.user_with_same_email_exists: Ya existe una cuenta con su correo
+  electrónico. Por favor, inicie sesión para continuar con la configuración de su cuenta de empresa.


### PR DESCRIPTION
With these changes now an existing user should be able to accept the invitation to configure their business account (https://github.com/coopcycle/coopcycle-web/issues/4217).

**Existing user clicks on invitation but is not logged in in the app**
Now we ask for login first, and then we skip the step 1 (personal account creation) and send the user to the 2nd step when should complete the info of the company.

https://github.com/coopcycle/coopcycle-web/assets/4819244/b3a1ada0-847c-4c25-99c7-868a0ff6eebb

**Existing user opens the invitation while is already logged in in the app **
After click in the invitation we skip the step 1 (personal account creation) and send the user to the 2nd step when should complete the info of the company.

https://github.com/coopcycle/coopcycle-web/assets/4819244/b6b7aa06-4d17-4cca-bec3-88dd143163c6

**Resend invitation email**
New resend invitation email action for cases when the invitation email is not received

https://github.com/coopcycle/coopcycle-web/assets/4819244/caaeeb64-a40c-4166-9f53-b19cf4c026cd

