### PR TITLE
Associate existing users as business accounts employees

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -32,6 +32,7 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Core\Security;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -172,7 +173,8 @@ class UserController extends AbstractController
         UserManagerInterface $userManager,
         EventDispatcherInterface $eventDispatcher,
         Canonicalizer $canonicalizer,
-        BusinessAccountRegistrationFlow $businessAccountRegistrationFlow)
+        BusinessAccountRegistrationFlow $businessAccountRegistrationFlow,
+        Security $security)
     {
         $repository = $this->getDoctrine()->getRepository(Invitation::class);
 
@@ -196,8 +198,18 @@ class UserController extends AbstractController
                 return $this->loadBusinessAccountRegistrationFlow($request, $businessAccountRegistrationFlow, $user,
                     $businessAccountInvitation, $objectManager, $userManager, $eventDispatcher, $canonicalizer);
             } else {
+                $loggedInUser = $security->getUser();
+
+                if ($loggedInUser) {
+                    return $this->render('profile/associate_loggedin_user_to_business_account.html.twig', [
+                        'show_left_menu' => false,
+                        'businessAccountInvitation' => $businessAccountInvitation
+                    ]);
+                }
+
                 // The email has to be entered by the invited user in the form
                 $user->setEmail('');
+                $user->setUsername('');
             }
         }
 

--- a/templates/_partials/profile/definition_password_for_business_account.html.twig
+++ b/templates/_partials/profile/definition_password_for_business_account.html.twig
@@ -22,7 +22,8 @@
   {% if flow.getCurrentStepNumber() == 1 and form.user.username.vars.data is not empty %}
     {% include '_partials/profile/existing_user_ask_login_form.html.twig' with {
       form: form.user,
-      invitation: invitation
+      warning_message: 'business_account.registration.user_with_same_email_exists'|trans,
+      action_path: path("nucleos_user_security_check", { _target_path: path('invitation_define_password', {code: invitation.code}) })
     } %}
   {% else %}
     {{ form_start(form) }}

--- a/templates/_partials/profile/definition_password_for_classical_users.html.twig
+++ b/templates/_partials/profile/definition_password_for_classical_users.html.twig
@@ -15,14 +15,25 @@
 {% endblock %}
 
 {% block form_content %}
-  <div class="alert alert-info">
-    <i class="fa fa-info-circle"></i>
-    {% trans with {
-      '%brandName%': coopcycle_setting('brand_name'),
-      '%invitedBy%': invitationUser.customer.fullname|default(invitationUser.username)
-    } %}registration.alert.text{% endtrans %}
-  </div>
+    <div class="alert alert-info">
+      <i class="fa fa-info-circle"></i>
+      {% trans with {
+        '%brandName%': coopcycle_setting('brand_name'),
+        '%invitedBy%': invitationUser.customer.fullname|default(invitationUser.username)
+      } %}registration.alert.text{% endtrans %}
+    </div>
   {{ form_start(form) }}
-    {% include '_partials/profile/personal_information_form.html.twig' %}
+      {% include '_partials/profile/personal_information_form.html.twig' %}
   {{ form_end(form) }}
+
+  {% if businessAccountInvitation is not null %}
+    <div id="existing_user_login_form" class="hidden">
+      {% include '_partials/profile/existing_user_ask_login_form.html.twig' with {
+        form: form,
+        action_path: path('nucleos_user_security_check', { _target_path: path('associate-loggedin-user-to-business-account', {code: businessAccountInvitation.invitation.code})}),
+        warning_message: 'registration.business_account.loggin.warning_message'|trans({'%name%': businessAccountInvitation.businessAccount.name })
+      } %}
+    </div>
+  {% endif %}
+
 {% endblock %}

--- a/templates/_partials/profile/existing_user_ask_login_form.html.twig
+++ b/templates/_partials/profile/existing_user_ask_login_form.html.twig
@@ -1,10 +1,12 @@
 <div class="form-section">
-  <div class="alert alert-warning">
-    <i class="fa fa-warning mr-1"></i>
-    <span>{{ 'business_account.registration.user_with_same_email_exists'|trans }}</span>
-  </div>
+  {% if warning_message is defined and warning_message is not empty %}
+    <div class="alert alert-warning">
+      <i class="fa fa-warning mr-1"></i>
+      <span>{{ warning_message }}</span>
+    </div>
+  {% endif %}
 
-  <form class="form" action="{{ path("nucleos_user_security_check", { _target_path: path('invitation_define_password', {code: invitation.code}) }) }}" method="post">
+  <form class="form" action="{{ action_path }}" method="post">
     <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}" />
     <input type="hidden" name="_username" value="{{ form.email.vars.data }}" />
     <div class="input-group">

--- a/templates/_partials/profile/personal_information_form.html.twig
+++ b/templates/_partials/profile/personal_information_form.html.twig
@@ -1,3 +1,7 @@
+{% set businessAccountEmployeeError = businessAccountInvitation is not null and not businessAccountInvitation.isInvitationForManager and
+    form.email.vars.errors|filter(e => e.message == 'nucleos_user.email.already_used'|trans({}, 'validators'))|length > 0
+%}
+
 <div class="form-section">
   <div class="header rounded-top">
     <h5>{{ 'registration.step.personal'|trans }}</h5>
@@ -5,6 +9,13 @@
   <div class="form rounded-bottom">
     {{ form_row(form.username) }}
     {{ form_row(form.email) }}
+    {% if businessAccountInvitation is not null %}
+      <div id="business_account_employee_loggin_help" class="alert alert-warning hidden">
+        <i class="fa fa-warning mr-1"></i>
+        {{ 'registration.business_account.loggin.help'|
+            trans({'%name%': businessAccountInvitation.businessAccount.name })|raw }}
+      </div>
+    {% endif %}
     <div class="row">
     <div class="col-md-6">
       {{ form_row(form.plainPassword.first) }}
@@ -47,5 +58,16 @@
 {% endblock %}
 
 {% block scripts %}
+  <script>
+    if ("{{ businessAccountEmployeeError }}") {
+      document.querySelector('#business_account_employee_loggin_help').addEventListener('click', e => {
+        e.preventDefault();
+        document.querySelector('[name="registration_form"]').remove()
+        document.querySelector('#existing_user_login_form').classList.remove('hidden')
+      })
+
+      document.querySelector('#business_account_employee_loggin_help').classList.remove('hidden')
+    }
+  </script>
   {{ encore_entry_script_tags('register') }}
 {% endblock %}

--- a/templates/profile/associate_loggedin_user_to_business_account.html.twig
+++ b/templates/profile/associate_loggedin_user_to_business_account.html.twig
@@ -1,0 +1,32 @@
+{% extends "profile.html.twig" %}
+
+{% block content %}
+  <div class="row">
+    <div class="col-md-2 col-lg-3"></div>
+    <div class="col-md-8 col-lg-6">
+      <div class="form-section mt-4">
+        <div class="alert alert-info mb-0">
+          <i class="fa fa-info mr-1"></i>
+          <span>{{ 'business_account.loggedin_employee.association.title'|trans }}</span>
+        </div>
+
+        <form class="form" action="{{ path('associate-loggedin-user-to-business-account', {code: businessAccountInvitation.invitation.code}) }}">
+          <div class="mb-4">
+            <span>
+              {{ 'business_account.loggedin_employee.association.text'|trans({
+              '%user_email%': app.user.email,
+              '%business_account_name%': businessAccountInvitation.businessAccount.name
+              })|raw }}
+            </span>
+          </div>
+          <div class="d-flex justify-content-end">
+            <a href="{{ path('homepage') }}" class="btn btn-default mr-4">{% trans %}basics.cancel{% endtrans %}</a>
+            <button type="submit" class="btn btn-primary">{% trans %}basics.continue{% endtrans %}</button>
+          </div>
+        </form>
+      </div>
+    </div>
+    <div class="col-md-2 col-lg-6"></div>
+  </div>
+
+{% endblock %}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1502,3 +1502,5 @@ business_account.registration.user_with_same_email_exists: An account with the y
 registration.business_account.loggin.help: <a href="#">Click here</a> to login and then associate your account with the company %name%.
 registration.business_account.loggin.warning_message: Login to associate your account with the company %name%.
 business_account.employee.associated: Your account has been associated successfully with the company %name%
+business_account.loggedin_employee.association.text: You are logged in with the email <strong>%user_email%</strong>. Do you want to associate your account with the company <strong>%business_account_name%</strong>?
+business_account.loggedin_employee.association.title: Invitation to associate your account with a Business Acccount

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1182,7 +1182,7 @@ adminDashboard.hubs.help: Hubs allow to group together shops sharing the same pi
 adminDashboard.business_accounts.title: Business accounts
 adminDashboard.business_accounts.createNew: Create a new business account
 form.business_account.businessRestaurantGroup.label: Business restaurant group
-form.business_account.businessRestaurantGroup.placeholder: Choose a business restaurant group`
+form.business_account.businessRestaurantGroup.placeholder: Choose a business restaurant group
 form.business_account.employees.label: List of employees
 form.business_account.restaurants.add: Add a restaurant
 form.business_account.employees.add: Add an employee

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1499,3 +1499,6 @@ restaurants.edenred.added_list.actions: Actions
 business_restaurant_group.form.fill_all_pages: "Please, fill out all three settings pages."
 business_account.registration.user_with_same_email_exists: An account with the your email already
   exists. Please log in to continue with your business account configuration.
+registration.business_account.loggin.help: <a href="#">Click here</a> to login and then associate your account with the company %name%.
+registration.business_account.loggin.warning_message: Login to associate your account with the company %name%.
+business_account.employee.associated: Your account has been associated successfully with the company %name%

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -1438,3 +1438,5 @@ business_account.registration.user_with_same_email_exists: Ya existe una cuenta 
 registration.business_account.loggin.help: <a href="#">Haga click aquí</a> para iniciar sesión y asociar su cuenta con la empresa %name%.
 registration.business_account.loggin.warning_message: Inicie sesión para luego asociar su cuenta con la empresa %name%.
 business_account.employee.associated: Su cuenta ha sido asociada con éxito a la empresa %name%
+business_account.loggedin_employee.association.text: Tenés una sesión iniciada con el email <strong>%user_email%</strong>, deseas asociar tu cuenta a la de la empresa <strong>%business_account_name%</strong>?
+business_account.loggedin_employee.association.title: Invitación para asociar su cuenta a una cuenta de empresa

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -1435,3 +1435,6 @@ restaurants.edenred.added_list.actions: Acciones
 business_restaurant_group.form.fill_all_pages: "Por favor, completar toda la configuración requerida en las tres páginas."
 business_account.registration.user_with_same_email_exists: Ya existe una cuenta con su correo
   electrónico. Por favor, inicie sesión para continuar con la configuración de su cuenta de empresa.
+registration.business_account.loggin.help: <a href="#">Haga click aquí</a> para iniciar sesión y asociar su cuenta con la empresa %name%.
+registration.business_account.loggin.warning_message: Inicie sesión para luego asociar su cuenta con la empresa %name%.
+business_account.employee.associated: Su cuenta ha sido asociada con éxito a la empresa %name%


### PR DESCRIPTION
With these changes now an existing user should be able to accept the invitation to associate its account to a Business Account (https://github.com/coopcycle/coopcycle-web/issues/4251).

**An existing user opens the link of the invitation while they are not logged in to the platform**

https://github.com/coopcycle/coopcycle-web/assets/4819244/c2ab6d5b-1a25-46d8-83c7-4329a83ba635

**An existing and logged in user opens the link of the invitation**

https://github.com/coopcycle/coopcycle-web/assets/4819244/fce861b8-9da6-41d4-8635-ed3e017bec37


