### PR TITLE
Orders screen for business account managers

### DIFF
--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -660,14 +660,15 @@ class ProfileController extends AbstractController
             );
         }
 
-        return $this->render('profile/orders.html.twig', [
+        $form = $this->createForm(BusinessAccountType::class, $businessAccount);
+
+        return $this->render('profile/business_account_orders.html.twig', [
             'orders' => $orders,
             'routes' => [
                 'restaurant' => 'restaurant',
-                'order_receipt' => 'profile_order_receipt',
-                'order_receipt_generate' => 'profile_order_receipt_generate',
                 'order' => 'profile_order'
-            ]
+            ],
+            'form' => $form->createView()
         ]);
     }
 }

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -660,15 +660,12 @@ class ProfileController extends AbstractController
             );
         }
 
-        $form = $this->createForm(BusinessAccountType::class, $businessAccount);
-
         return $this->render('profile/business_account_orders.html.twig', [
             'orders' => $orders,
             'routes' => [
                 'restaurant' => 'restaurant',
                 'order' => 'profile_order'
-            ],
-            'form' => $form->createView()
+            ]
         ]);
     }
 }

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -642,6 +642,8 @@ class ProfileController extends AbstractController
         $orders = [];
 
         if (null !== $businessAccount->getId()) {
+            Assert::isInstanceOf($this->orderRepository, EntityRepository::class);
+
             $qb = $this->orderRepository
                 ->createQueryBuilder('o')
                 ->andWhere('o.businessAccount = :business_account')

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -661,6 +661,12 @@ class ProfileController extends AbstractController
 
         return $this->render('profile/orders.html.twig', [
             'orders' => $orders,
+            'routes' => [
+                'restaurant' => 'restaurant',
+                'order_receipt' => 'profile_order_receipt',
+                'order_receipt_generate' => 'profile_order_receipt_generate',
+                'order' => 'profile_order'
+            ]
         ]);
     }
 }

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -642,19 +642,20 @@ class ProfileController extends AbstractController
         $orders = [];
 
         if (null !== $businessAccount->getId()) {
-            $qb = $objectManager->getRepository(Order::class)->createQueryBuilder('o');
-            $qb
+            $qb = $this->orderRepository
+                ->createQueryBuilder('o')
                 ->andWhere('o.businessAccount = :business_account')
-                ->setParameter('business_account', $businessAccount);
+                ->andWhere('o.state != :state')
+                ->orderBy('LOWER(o.shippingTimeRange)', 'DESC')
+                ->setParameter('business_account', $businessAccount)
+                ->setParameter('state', OrderInterface::STATE_CART);
 
             $orders = $paginator->paginate(
                 $qb,
                 $request->query->getInt('page', 1),
                 self::ITEMS_PER_PAGE,
                 [
-                    PaginatorInterface::DEFAULT_SORT_FIELD_NAME => 'o.createdAt',
-                    PaginatorInterface::DEFAULT_SORT_DIRECTION => 'desc',
-                    PaginatorInterface::SORT_FIELD_ALLOW_LIST => ['o.createdAt'],
+                    PaginatorInterface::DISTINCT => false,
                 ]
             );
         }

--- a/templates/_partials/order/list.html.twig
+++ b/templates/_partials/order/list.html.twig
@@ -11,7 +11,9 @@
     <th class="text-right">{% trans %}basics.platform_fees{% endtrans %}</th>
     {% endif %}
     <th class="text-right">{% trans %}order.total_including_tax{% endtrans %}</th>
+    {% if with_receipt ?? true %}
     <th class="text-center">{% trans %}order.list.receipt{% endtrans %}</th>
+    {% endif %}
     <th class="text-right">{% trans %}order.list.shippedAt{% endtrans %}</th>
     {% if with_reorder ?? false %}
     <th></th>
@@ -21,12 +23,22 @@
   {% for order in orders %}
   <tr>
     <td width="5%">
+      {% if is_granted('ROLE_ADMIN') or (order.customer is not null and order.customer == app.user.customer) %}
       <a href="{{ path(routes.order, { id: order.id }) }}" class="text-monospace">
         {% if order.number is not null %}
         {{ order.number }}
         {% else %}
         #{{ order.id }}
         {% endif %}
+      {% else %}
+        <span>
+          {% if order.number is not null %}
+          {{ order.number }}
+          {% else %}
+          #{{ order.id }}
+          {% endif %}
+        </span>
+      {% endif %}
       </a>
     </td>
     {% if is_granted('ROLE_ADMIN') and (with_extras ?? true) %}
@@ -47,6 +59,7 @@
     <td class="text-right">
       <span>{{ order.total|price_format }}</span>
     </td>
+    {% if with_receipt ?? true %}
     <td width="10%" class="text-center">
       {% if order.hasReceipt() %}
       <a target="_blank" href="{{ path(routes.order_receipt, { orderNumber: order.number }) }}">
@@ -58,6 +71,7 @@
           data-action="{{ path(routes.order_receipt_generate, { orderNumber: order.number }) }}">{{ 'order.list.generate_receipt'|trans }}</button>
       {% endif %}
     </td>
+    {% endif %}
     <td class="text-right">{{ order.shippingTimeRange|time_range_for_humans_short }}</td>
     {% if with_reorder ?? false %}
     <td class="text-right">

--- a/templates/profile.html.twig
+++ b/templates/profile.html.twig
@@ -70,13 +70,30 @@
         </li>
         {% endif %}
         {% if business_account_enabled and is_granted('ROLE_BUSINESS_ACCOUNT') %}
-          <li
-            class="{{ app.request.attributes.get('_route') == 'profile_business_account' ? 'active' : '' }}">
-            <a href="{{ path('profile_business_account') }}">
-              <i class="fa fa-gear mr-1"></i>
-              <span>{% trans %}profile.businessAccount{% endtrans %}</span>
-            </a>
-          </li>
+        <li>
+          <a role="button" data-toggle="collapse" data-target="#business-account" aria-expanded="true" aria-controls="business-account">
+            <i class="fa fa-users mr-1"></i>
+            <span>{% trans %}profile.businessAccount{% endtrans %}</span>
+          </a>
+        </li>
+        <div class="collapse in" id="business-account">
+          <ul class="nav nav-pills nav-stacked">
+            <li
+              class="{{ app.request.attributes.get('_route') == 'profile_business_account' ? 'active' : '' }}">
+              <a class="ml-4" href="{{ path('profile_business_account') }}">
+                <i class="fa fa-gear mr-1"></i>
+                <span>{% trans %}profile.configuration{% endtrans %}</span>
+              </a>
+            </li>
+            <li
+              class="{{ app.request.attributes.get('_route') == 'profile_business_account_orders' ? 'active' : '' }}">
+              <a class="ml-4" href="{{ path('profile_business_account_orders') }}">
+                <i class="fa fa-cube mr-1"></i>
+                <span>{% trans %}profile.orders{% endtrans %}</span>
+              </a>
+            </li>
+          </ul>
+        </div>
         {% endif %}
       </ul>
     </div>

--- a/templates/profile/business_account_orders.html.twig
+++ b/templates/profile/business_account_orders.html.twig
@@ -1,0 +1,23 @@
+{% extends "profile.html.twig" %}
+
+{% block content %}
+
+  {% if orders is empty %}
+    <div class="alert alert-warning">
+      {%  trans %}profile.orders.empty{%  endtrans %}
+    </div>
+  {% else %}
+    {% include "_partials/order/list.html.twig" with { with_extras: false, with_reorder: false, with_receipt: false } %}
+    <div class="text-center">
+      {{ knp_pagination_render(orders, '@KnpPaginator/Pagination/twitter_bootstrap_v3_pagination.html.twig') }}
+    </div>
+  {% endif %}
+
+  <div class="d-flex justify-content-end">
+    <div class="link-section form-section">
+      {% include '_partials/profile/invitation_link.html.twig' with {
+        title: 'business.account.settings.link'|trans
+      } %}
+    </div>
+  </div>
+{% endblock %}

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -308,6 +308,8 @@ profile.managedStores: Stores managed by user
 profile.managedRestaurants: Restaurants managed by user
 profile.accountType: Account type
 profile.businessAccount: Business account
+profile.orders: Orders
+profile.configuration: Configuration
 order.cart.title: Cart
 order.items.products_with_count: Products (%count%)
 order.summary.heading: Order %number% (#%id%)

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -208,6 +208,8 @@ profile.managedStores: Tiendas gestionadas por el usuario
 profile.managedRestaurants: Restaurantes gestionados por el usuario
 profile.accountType: Tipo de cuenta
 profile.businessAccount: Cuenta de empresa
+profile.orders: Pedidos
+profile.configuration: Configuración
 order.cart.title: Cesta
 order.items.products_with_count: Productos (%count%)
 order.summary.heading: Pedido %number% (#%id%)


### PR DESCRIPTION
New screen where Business Account managers can see the orders made by users/employees on behalf of the company.
![business_account_orders](https://github.com/coopcycle/coopcycle-web/assets/4819244/9d6d28da-2277-4b38-898c-facc76705c77)

With this screen the menu section for Business Accounts has changed. Now it has a sub menu section to access to the configuration of Company information and another for the orders:

https://github.com/coopcycle/coopcycle-web/assets/4819244/5148efb0-3033-4bd4-a86f-48c2d8aeba7c


