### PR TITLE
Invitation link moved to confirmed registration screen

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -266,6 +266,7 @@ twig:
         group_orders_enabled: '%group_orders_enabled%'
         business_account_enabled: '%env(bool:BUSINESS_ACCOUNT_ENABLED)%'
         odoo_url: '%env(ODOO_URL)%'
+        invitation_link_provider: '@AppBundle\Service\InvitationLinkProviderService'
 
     exception_controller: null
 

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -1062,6 +1062,8 @@ services:
     arguments:
       $country: "%country_iso%"
 
+  AppBundle\Service\InvitationLinkProviderService: ~
+
   AppBundle\Domain\Order\Workflow\Guard:
     public: true
 

--- a/src/Form/BusinessAccountRegistration.php
+++ b/src/Form/BusinessAccountRegistration.php
@@ -21,17 +21,11 @@ class BusinessAccountRegistration
 	/**
 	 * @Assert\Valid
 	 */
-	public $invitationLink;
-
-	/**
-	 * @Assert\Valid
-	 */
 	public $code;
 
-    public function __construct(User $user, BusinessAccount $businessAccount, $invitationLink = null, $code = null) {
+    public function __construct(User $user, BusinessAccount $businessAccount, $code = null) {
 		$this->user = $user;
 		$this->businessAccount = $businessAccount;
-		$this->invitationLink = $invitationLink;
 		$this->code = $code;
 	}
 }

--- a/src/Form/BusinessAccountRegistrationFlow.php
+++ b/src/Form/BusinessAccountRegistrationFlow.php
@@ -34,10 +34,6 @@ class BusinessAccountRegistrationFlow extends FormFlow
 				'label' => 'registration.step.company',
 				'form_type' => $formType,
 			],
-			[
-				'label' => 'registration.step.invitation',
-				'form_type' => $formType,
-			],
 		];
     }
 

--- a/src/Form/BusinessAccountRegistrationForm.php
+++ b/src/Form/BusinessAccountRegistrationForm.php
@@ -51,16 +51,14 @@ class BusinessAccountRegistrationForm extends AbstractType
                     'label' => false,
                     'business_account_registration' => true
                 ]);
-				break;
-            case 3:
+
                 $code = $this->tokenGenerator->generateToken();
                 $invitationLink = $this->urlGenerator->generate('invitation_define_password', [
                     'code' => $code
                 ], UrlGeneratorInterface::ABSOLUTE_URL);
 
                 $builder
-                    ->add('invitationLink', UrlType::class, [
-                        'label' => 'registration.step.invitation.copy.link',
+                    ->add('invitationLink', HiddenType::class, [
                         'data' => $invitationLink
                     ])
                     ->add('code', HiddenType::class, [

--- a/src/Form/BusinessAccountRegistrationForm.php
+++ b/src/Form/BusinessAccountRegistrationForm.php
@@ -4,27 +4,11 @@ namespace AppBundle\Form;
 
 use Nucleos\ProfileBundle\Form\Type\RegistrationFormType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\HiddenType;
-use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormEvent;
-use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Security\Csrf\TokenGenerator\TokenGeneratorInterface;
 
 class BusinessAccountRegistrationForm extends AbstractType
 {
-    private $urlGenerator;
-    private $tokenGenerator;
-
-    public function __construct(
-        UrlGeneratorInterface $urlGenerator,
-        TokenGeneratorInterface $tokenGenerator)
-    {
-        $this->urlGenerator = $urlGenerator;
-        $this->tokenGenerator = $tokenGenerator;
-    }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
@@ -51,20 +35,6 @@ class BusinessAccountRegistrationForm extends AbstractType
                     'label' => false,
                     'business_account_registration' => true
                 ]);
-
-                $code = $this->tokenGenerator->generateToken();
-                $invitationLink = $this->urlGenerator->generate('invitation_define_password', [
-                    'code' => $code
-                ], UrlGeneratorInterface::ABSOLUTE_URL);
-
-                $builder
-                    ->add('invitationLink', HiddenType::class, [
-                        'data' => $invitationLink
-                    ])
-                    ->add('code', HiddenType::class, [
-                        'required' => false,
-                        'data' => $code
-                    ]);
 
                 break;
         }

--- a/src/Form/BusinessAccountType.php
+++ b/src/Form/BusinessAccountType.php
@@ -12,12 +12,10 @@ use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Validator\Constraints as Assert;
 
@@ -25,16 +23,13 @@ class BusinessAccountType extends AbstractType
 {
     private $authorizationChecker;
     private $objectManager;
-    private $urlGenerator;
 
     public function __construct(
         AuthorizationCheckerInterface $authorizationChecker,
-        EntityManagerInterface $objectManager,
-        UrlGeneratorInterface $urlGenerator)
+        EntityManagerInterface $objectManager)
     {
         $this->authorizationChecker = $authorizationChecker;
         $this->objectManager = $objectManager;
-        $this->urlGenerator = $urlGenerator;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)

--- a/src/Form/BusinessAccountType.php
+++ b/src/Form/BusinessAccountType.php
@@ -101,17 +101,6 @@ class BusinessAccountType extends AbstractType
                                 'data' => $businessAccountInvitation->getId()
                             ]);
                     }
-
-                    if ($this->authorizationChecker->isGranted('ROLE_BUSINESS_ACCOUNT')) {
-                        $invitationLink = $this->urlGenerator->generate('invitation_define_password', [
-                            'code' => $businessAccountInvitation->getInvitation()->getCode()
-                        ], UrlGeneratorInterface::ABSOLUTE_URL);
-                        $form->add('invitationLink', UrlType::class, [
-                            'mapped' => false,
-                            'label' => 'registration.step.invitation.copy.link',
-                            'data' => $invitationLink
-                        ]);
-                    }
                 }
             } else {
                 if ($this->authorizationChecker->isGranted('ROLE_ADMIN')) {

--- a/src/Service/InvitationLinkProviderService.php
+++ b/src/Service/InvitationLinkProviderService.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace AppBundle\Service;
+
+use AppBundle\Action\Utils\TokenStorageTrait;
+use AppBundle\Entity\BusinessAccountInvitation;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+
+class InvitationLinkProviderService
+{
+    use TokenStorageTrait;
+
+    private $urlGenerator;
+    private $objectManager;
+
+    public function __construct(
+        TokenStorageInterface $tokenStorage,
+        UrlGeneratorInterface $urlGenerator,
+        EntityManagerInterface $objectManager)
+    {
+        $this->tokenStorage = $tokenStorage;
+        $this->urlGenerator = $urlGenerator;
+        $this->objectManager = $objectManager;
+    }
+
+    public function getInvitationLink()
+    {
+        $user = $this->getUser();
+
+        $businessAccountInvitation = $this->objectManager->getRepository(BusinessAccountInvitation::class)
+            ->findOneBy([
+                'businessAccount' => $user->getBusinessAccount(),
+            ]);
+
+        return $this->urlGenerator->generate('invitation_define_password', [
+            'code' => $businessAccountInvitation->getInvitation()->getCode()
+        ], UrlGeneratorInterface::ABSOLUTE_URL);
+    }
+
+}

--- a/templates/_partials/profile/business_account_invitation_form.html.twig
+++ b/templates/_partials/profile/business_account_invitation_form.html.twig
@@ -1,6 +1,0 @@
-<div class="form-section">
-  <div class="header rounded-top">
-    <h5>{{ flow.currentStepLabel|trans }}</h5>
-  </div>
-  {% include '_partials/profile/invitation_link.html.twig' %}
-</div>

--- a/templates/_partials/profile/definition_password_for_business_account.html.twig
+++ b/templates/_partials/profile/definition_password_for_business_account.html.twig
@@ -37,9 +37,6 @@
         form: form.businessAccount
       } %}
     {% endif %}
-    {% if flow.getCurrentStepNumber() == 3 %}
-      {% include '_partials/profile/business_account_invitation_form.html.twig' %}
-    {% endif %}
     {{ form_end(form) }}
   {% endif %}
 {% endblock %}

--- a/templates/_partials/profile/invitation_link.html.twig
+++ b/templates/_partials/profile/invitation_link.html.twig
@@ -1,39 +1,23 @@
+{% set invitationLink = invitation_link_provider.getInvitationLink() %}
+
 <div class="form rounded-bottom">
   {% if title is defined %}
     <h5>{{ title|trans }}</h5>
   {% endif %}
-  {% if form is defined %}
-    <div class="form-group">
-      <label class="control-label">{{ field_label(form.invitationLink) }}</label>
-      <div class="input-group" data-toggle="copy" data-clipboard-text="{{ field_value(form.invitationLink) }}">
-        <span class="input-group-addon bg-primary"><i class="fa fa-link fa-rotate-90 text-white"></i></span>
-        {{ form_widget(form.invitationLink) }}
-      </div>
-      <div class="d-flex justify-content-end mt-3">
-      <button id="copy-button" type="button" class="btn btn-primary" data-toggle="copy" data-clipboard-text="{{ field_value(form.invitationLink) }}">
-        <i class="fa fa-copy mr-2"></i>
-        {{ 'registration.step.invitation.copy.button'|trans }}
-        </button>
-      </div>
+
+  <div class="form-group">
+    <label class="control-label">{{ 'registration.step.invitation.copy.link'|trans }}</label>
+    <div class="input-group" data-toggle="copy" data-clipboard-text="{{ invitationLink }}">
+      <span class="input-group-addon bg-primary"><i class="fa fa-link fa-rotate-90 text-white"></i></span>
+      <input type="text" class="form-control" value="{{ invitationLink }}">
     </div>
-  {% else %}
-    <div class="form-group">
-      <label class="control-label">{{ 'registration.step.invitation.copy.link'|trans }}</label>
-      <div class="input-group" data-toggle="copy" data-clipboard-text="{{ invitationLink }}">
-        <span class="input-group-addon bg-primary"><i class="fa fa-link fa-rotate-90 text-white"></i></span>
-        <input type="text" class="form-control" value="{{ invitationLink }}">
-      </div>
-      <div class="d-flex justify-content-end mt-3">
-      <button id="copy-button" type="button" class="btn btn-primary" data-toggle="copy" data-clipboard-text="{{ invitationLink }}">
-        <i class="fa fa-copy mr-2"></i>
-        {{ 'registration.step.invitation.copy.button'|trans }}
-        </button>
-      </div>
+    <div class="d-flex justify-content-end mt-3">
+    <button id="copy-button" type="button" class="btn btn-primary" data-toggle="copy" data-clipboard-text="{{ invitationLink }}">
+      <i class="fa fa-copy mr-2"></i>
+      {{ 'registration.step.invitation.copy.button'|trans }}
+      </button>
     </div>
-  {% endif %}
-  {% if flow is defined %}
-    {% include '_partials/profile/flow_buttons.html.twig' %}
-  {% endif %}
+  </div>
 </div>
 
 {% block scripts %}

--- a/templates/_partials/profile/invitation_link.html.twig
+++ b/templates/_partials/profile/invitation_link.html.twig
@@ -1,20 +1,36 @@
 <div class="form rounded-bottom">
   {% if title is defined %}
-    <h5>{{ title }}</h5>
+    <h5>{{ title|trans }}</h5>
   {% endif %}
-  <div class="form-group">
-    <label class="control-label">{{ field_label(form.invitationLink) }}</label>
-    <div class="input-group" data-toggle="copy" data-clipboard-text="{{ field_value(form.invitationLink) }}">
-      <span class="input-group-addon bg-primary"><i class="fa fa-link fa-rotate-90 text-white"></i></span>
-      {{ form_widget(form.invitationLink) }}
+  {% if form is defined %}
+    <div class="form-group">
+      <label class="control-label">{{ field_label(form.invitationLink) }}</label>
+      <div class="input-group" data-toggle="copy" data-clipboard-text="{{ field_value(form.invitationLink) }}">
+        <span class="input-group-addon bg-primary"><i class="fa fa-link fa-rotate-90 text-white"></i></span>
+        {{ form_widget(form.invitationLink) }}
+      </div>
+      <div class="d-flex justify-content-end mt-3">
+      <button id="copy-button" type="button" class="btn btn-primary" data-toggle="copy" data-clipboard-text="{{ field_value(form.invitationLink) }}">
+        <i class="fa fa-copy mr-2"></i>
+        {{ 'registration.step.invitation.copy.button'|trans }}
+        </button>
+      </div>
     </div>
-    <div class="d-flex justify-content-end mt-3">
-    <button id="copy-button" type="button" class="btn btn-primary" data-toggle="copy" data-clipboard-text="{{ field_value(form.invitationLink) }}">
-      <i class="fa fa-copy mr-2"></i>
-      {{ 'registration.step.invitation.copy.button'|trans }}
-      </button>
+  {% else %}
+    <div class="form-group">
+      <label class="control-label">{{ 'registration.step.invitation.copy.link'|trans }}</label>
+      <div class="input-group" data-toggle="copy" data-clipboard-text="{{ invitationLink }}">
+        <span class="input-group-addon bg-primary"><i class="fa fa-link fa-rotate-90 text-white"></i></span>
+        <input type="text" class="form-control" value="{{ invitationLink }}">
+      </div>
+      <div class="d-flex justify-content-end mt-3">
+      <button id="copy-button" type="button" class="btn btn-primary" data-toggle="copy" data-clipboard-text="{{ invitationLink }}">
+        <i class="fa fa-copy mr-2"></i>
+        {{ 'registration.step.invitation.copy.button'|trans }}
+        </button>
+      </div>
     </div>
-  </div>
+  {% endif %}
   {% if flow is defined %}
     {% include '_partials/profile/flow_buttons.html.twig' %}
   {% endif %}

--- a/templates/bundles/NucleosProfileBundle/Registration/confirmed.html.twig
+++ b/templates/bundles/NucleosProfileBundle/Registration/confirmed.html.twig
@@ -50,8 +50,7 @@
           <div class="d-flex justify-content-end">
             <div class="info-section rounded mt-0 mr-0">
               {% include '_partials/profile/invitation_link.html.twig' with {
-                'title': 'registration.confirm.invitation.link.title',
-                'invitationLink': invitation_link_provider.getInvitationLink()
+                'title': 'registration.confirm.invitation.link.title'
               } %}
             </div>
           </div>

--- a/templates/bundles/NucleosProfileBundle/Registration/confirmed.html.twig
+++ b/templates/bundles/NucleosProfileBundle/Registration/confirmed.html.twig
@@ -16,8 +16,16 @@
             <img src="{{ asset('img/registration-congrats.svg') }}">
             <h5>{{ 'registration.congratulations'|trans }}</h5>
             <strong>{% trans with { '%username%': user.username } %}registration.confirmed{% endtrans %}</strong>
+            {% set businessAccountManager = is_granted('ROLE_BUSINESS_ACCOUNT') and user.businessAccount is not null %}
             {% set cart = cart_provider.getCart() %}
-            {% if cart is not empty and cart.restaurant is not empty and cart.state == 'cart' %}
+            {% if businessAccountManager %}
+              <div class="text-center">
+                <a href="{{ path('profile_business_account') }}" class="btn btn-md bg-primary mt-3">
+                  <i class="fa fa-gear mr-1" aria-hidden="true"></i>
+                  {{ 'topbar.action.admin_business_account'|trans({}, 'messages') }}
+                </a>
+              </div>
+            {% elseif cart is not empty and cart.restaurant is not empty and cart.state == 'cart' %}
               <div class="text-center">
                 <a href="{{ path('order') }}" class="btn btn-md bg-primary mt-3">
                   {{ 'registration.after_confirmation_continue_order'|trans }}
@@ -38,7 +46,7 @@
             {% endif %}
           </div>
         </div>
-        {% if is_granted('ROLE_BUSINESS') and user.businessAccount is not null %}
+        {% if businessAccountManager %}
           <div class="d-flex justify-content-end">
             <div class="info-section rounded mt-0 mr-0">
               {% include '_partials/profile/invitation_link.html.twig' with {

--- a/templates/bundles/NucleosProfileBundle/Registration/confirmed.html.twig
+++ b/templates/bundles/NucleosProfileBundle/Registration/confirmed.html.twig
@@ -38,6 +38,16 @@
             {% endif %}
           </div>
         </div>
+        {% if is_granted('ROLE_BUSINESS') and user.businessAccount is not null %}
+          <div class="d-flex justify-content-end">
+            <div class="info-section rounded mt-0 mr-0">
+              {% include '_partials/profile/invitation_link.html.twig' with {
+                'title': 'registration.confirm.invitation.link.title',
+                'invitationLink': invitation_link_provider.getInvitationLink()
+              } %}
+            </div>
+          </div>
+        {% endif %}
         <div class="d-flex">
           <img src="{{ asset('img/registration-image.svg') }}">
         </div>

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1466,6 +1466,7 @@ registration.step.company.name: "Name of the company"
 registration.step.invitation.copy.link: "Copy the link below and send it to your colleagues"
 registration.step.invitation.copy.button: "Copy the link"
 registration.step.invitation.link.copied: "Copied"
+registration.confirm.invitation.link.title: "Use this link below to invite colleagues to join"
 error.404: Page not found.
 error.502: The server is over capacity. Please try again later.
 error.504: The server took too much time to respond.

--- a/translations/messages.es.yml
+++ b/translations/messages.es.yml
@@ -1402,6 +1402,7 @@ registration.company.address.different.for.billing: "Usar una dirección diferen
 registration.company.billing.address: "Dirección de facturación"
 registration.step.company.name: "Nombre de la empresa"
 registration.step.invitation.copy.link: "Copia el siguiente enlace y envíalo a tus colegas"
+registration.confirm.invitation.link.title: "Usa el siguiente enlace para invitar a tus colegas de trabajo a unirse"
 registration.step.invitation.copy.button: "Copiar el enlace"
 registration.step.invitation.link.copied: "Copiado"
 deliveries.imports: Ficheros importados


### PR DESCRIPTION
#4311  The idea is to not display the invitation link until the registration process has been completed. Now the Business Account registration flow has 2 steps instead of 3 and in the 'confirmed registration' screen now we are showing the invitation link section.


https://github.com/coopcycle/coopcycle-web/assets/4819244/73345850-17e8-4927-a72e-c69a9bb5614f

