### PR TITLE
Support multi points in time based pricing functions 

### DIFF
--- a/app/DoctrineMigrations/Version20240617121101.php
+++ b/app/DoctrineMigrations/Version20240617121101.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240617121101 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $stmt = $this->connection->prepare('SELECT id, expression FROM pricing_rule');
+
+        $result = $stmt->execute();
+
+        while ($pricingRule = $result->fetchAssociative()) {
+
+            $expression = $pricingRule['expression'];
+
+            if (str_contains($expression, 'diff_days')
+            ||  str_contains($expression, 'diff_hours')
+            ||  str_contains($expression, 'time_range_length')) {
+
+                $expression = preg_replace('/(?<func>diff_(hours|days))\(pickup\) (?<expression>([<>]|==|in) [0-9]+(\.\.)*[0-9]*)/', '${1}(pickup, \'${3}\')', $expression);
+
+                $expression = preg_replace('/time_range_length\((?<type>(pickup|dropoff)), \'hours\'\) (?<expression>([<>]|==|in) [0-9]+(\.\.)*[0-9]*)/', 'time_range_length(${1}, \'hours\', \'${3}\')', $expression);
+
+                $this->addSql('UPDATE pricing_rule SET expression = :expression WHERE id = :id', [
+                    'expression' => $expression,
+                    'id' => $pricingRule['id'],
+                ]);
+            }
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/js/app/components/RulePicker.js
+++ b/js/app/components/RulePicker.js
@@ -38,6 +38,14 @@ const lineToString = state => {
     return `diff_hours(pickup, '${state.operator} ${convertToRange(state.right)}')`
   }
 
+  if (state.left === `time_range_length(pickup, 'hours')`) {
+    return `time_range_length(pickup, 'hours', '${state.operator} ${convertToRange(state.right)}')`
+  }
+
+  if (state.left === `time_range_length(dropoff, 'hours')`) {
+    return `time_range_length(dropoff, 'hours', '${state.operator} ${convertToRange(state.right)}')`
+  }
+
   if (state.operator === 'in' && Array.isArray(state.right) && state.right.length === 2) {
     return `${state.left} in ${state.right[0]}..${state.right[1]}`
   }

--- a/js/app/components/RulePicker.js
+++ b/js/app/components/RulePicker.js
@@ -16,11 +16,27 @@ export const numericTypes = [
 
 export const isNum = (type) => _.includes(numericTypes, type)
 
+const convertToRange = (value) => {
+  if (Array.isArray(value) && value.length === 2) {
+    return `${value[0]}..${value[1]}`
+  }
+
+  return value
+}
+
 const lineToString = state => {
   /*
   Build the expression line from the user's input stored in state.
   Returns nothing if we can't build the line.
   */
+
+  if (state.left === 'diff_days(pickup)') {
+    return `diff_days(pickup, '${state.operator} ${convertToRange(state.right)}')`
+  }
+
+  if (state.left === 'diff_hours(pickup)') {
+    return `diff_hours(pickup, '${state.operator} ${convertToRange(state.right)}')`
+  }
 
   if (state.operator === 'in' && Array.isArray(state.right) && state.right.length === 2) {
     return `${state.left} in ${state.right[0]}..${state.right[1]}`
@@ -28,10 +44,6 @@ const lineToString = state => {
 
   if (state.left === 'packages' && state.operator === 'containsAtLeastOne') {
     return `packages.containsAtLeastOne("${state.right}")`
-  }
-
-  if (state.left === 'diff_days(pickup)') {
-    return `diff_days(pickup) ${state.operator} ${state.right}`
   }
 
   switch (state.operator) {

--- a/js/app/delivery/pricing-rule-parser.js
+++ b/js/app/delivery/pricing-rule-parser.js
@@ -114,6 +114,19 @@ const traverseNode = (node, accumulator) => {
         operator: node.attributes.name,
         right:    node.nodes.arguments.nodes[1].attributes.value,
       })
+    } else if (node.attributes.name === 'diff_hours' || node.attributes.name === 'diff_days') {
+
+      let [ cmpSign, cmpValue ] = node.nodes.arguments.nodes[1].attributes.value.split(' ')
+      if (cmpSign === 'in') {
+        cmpValue = cmpValue.split('..')
+      }
+
+      accumulator.push({
+        left:     `${node.attributes.name}(${node.nodes.arguments.nodes[0].attributes.name})`,
+        operator: cmpSign,
+        right:    cmpValue,
+      })
+
     } else {
       if (node.nodes.left.nodes.node?.attributes.name === 'dropoff' && node.nodes.left.nodes.attribute?.attributes.value === 'doorstep') {
         accumulator.push({

--- a/js/app/delivery/pricing-rule-parser.js
+++ b/js/app/delivery/pricing-rule-parser.js
@@ -127,6 +127,19 @@ const traverseNode = (node, accumulator) => {
         right:    cmpValue,
       })
 
+    } else if (node.attributes.name === 'time_range_length') {
+
+      let [ cmpSign, cmpValue ] = node.nodes.arguments.nodes[2].attributes.value.split(' ')
+      if (cmpSign === 'in') {
+        cmpValue = cmpValue.split('..')
+      }
+
+      accumulator.push({
+        left:     `time_range_length(${node.nodes.arguments.nodes[0].attributes.name}, 'hours')`,
+        operator: cmpSign,
+        right:    cmpValue,
+      })
+
     } else {
       if (node.nodes.left.nodes.node?.attributes.name === 'dropoff' && node.nodes.left.nodes.attribute?.attributes.value === 'doorstep') {
         accumulator.push({

--- a/src/Entity/Task.php
+++ b/src/Entity/Task.php
@@ -1094,6 +1094,7 @@ class Task implements TaggableInterface, OrganizationAwareInterface, PackagesAwa
     {
         $taskObject = new \stdClass();
 
+        $taskObject->type = $this->getType();
         $taskObject->address = $this->getAddress();
         $taskObject->createdAt = $this->getCreatedAt();
         $taskObject->after = $this->getAfter();
@@ -1114,14 +1115,14 @@ class Task implements TaggableInterface, OrganizationAwareInterface, PackagesAwa
         $emptyObject->before = null;
         $emptyObject->doorstep = false;
 
+        $thisObj = $this->toExpressionLanguageObject();
+
         $values['distance'] = -1;
         $values['weight'] = $this->getWeight();
-        $values['pickup'] = $this->isPickup() ? $this->toExpressionLanguageObject() : $emptyObject;
-        $values['dropoff'] = $this->isDropoff() ? $this->toExpressionLanguageObject() : $emptyObject;
+        $values['pickup'] = $this->isPickup() ? $thisObj : $emptyObject;
+        $values['dropoff'] = $this->isDropoff() ? $thisObj : $emptyObject;
         $values['packages'] = new PackagesResolver($this);
 
-        $thisObj = new \stdClass();
-        $thisObj->type = $this->getType();
         $values['task'] = $thisObj;
 
         return $values;

--- a/src/ExpressionLanguage/PickupExpressionLanguageProvider.php
+++ b/src/ExpressionLanguage/PickupExpressionLanguageProvider.php
@@ -7,6 +7,7 @@ use Carbon\Carbon;
 use Doctrine\ORM\EntityRepository;
 use Symfony\Component\ExpressionLanguage\ExpressionFunction;
 use Symfony\Component\ExpressionLanguage\ExpressionFunctionProviderInterface;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
 class PickupExpressionLanguageProvider implements ExpressionFunctionProviderInterface
 {
@@ -16,18 +17,20 @@ class PickupExpressionLanguageProvider implements ExpressionFunctionProviderInte
             // FIXME Need to test compilation
         };
 
-        $daysEvaluator = function ($arguments, $task) {
+        $daysEvaluator = function ($arguments, $task, $expression = null) {
+
+            if (null === $expression) {
+                @trigger_error('Not passing an expression as the 2nd argument is deprecated', E_USER_DEPRECATED);
+            }
 
             $now = Carbon::now();
 
-            if (isset($task->createdAt) && null !== $task->createdAt) {
-                $now = Carbon::instance($task->createdAt);
+            if (isset($arguments['task']) && $arguments['task']->type !== '' && $arguments['task'] !== $task) {
+                return false;
             }
 
-            // May happen for multiple points
-            // FIXME Won't work as expected when using "less than", i.e diff_days(pickup) < 3
-            if (null === $task->before) {
-                return -1;
+            if (isset($task->createdAt) && null !== $task->createdAt) {
+                $now = Carbon::instance($task->createdAt);
             }
 
             $before = Carbon::instance($task->before);
@@ -37,30 +40,49 @@ class PickupExpressionLanguageProvider implements ExpressionFunctionProviderInte
                 $diff = $before->isSameDay($now) ? 0 : 1;
             }
 
-            return $diff;
+            if (null === $expression) {
+                return $diff;
+            }
+
+            $el = new ExpressionLanguage();
+
+            return $el->evaluate("{$diff} {$expression}");
         };
 
         $hoursCompiler = function (Address $address, $zoneName) {
             // FIXME Need to test compilation
         };
 
-        $hoursEvaluator = function ($arguments, $task) {
+        $hoursEvaluator = function ($arguments, $task, $expression = null) {
+
+            if (null === $expression) {
+                @trigger_error('Not passing an expression as the 2nd argument is deprecated', E_USER_DEPRECATED);
+            }
 
             $now = Carbon::now();
+
+            if (isset($arguments['task']) && $arguments['task']->type !== '' && $arguments['task'] !== $task) {
+                return false;
+            }
+
+            if (null === $task->before) {
+                return false;
+            }
 
             if (isset($task->createdAt) && null !== $task->createdAt) {
                 $now = Carbon::instance($task->createdAt);
             }
 
-            // May happen for multiple points
-            // FIXME Won't work as expected when using "less than", i.e diff_days(pickup) < 3
-            if (null === $task->before) {
-                return -1;
+            $before = Carbon::instance($task->before);
+            $diff = $before->floatDiffInHours($now);
+
+            if (null === $expression) {
+                return $diff;
             }
 
-            $before = Carbon::instance($task->before);
+            $el = new ExpressionLanguage();
 
-            return $before->floatDiffInHours($now);
+            return $el->evaluate("{$diff} {$expression}");
         };
 
         $timeRangeLengthCompiler = function ($task, $unit) {

--- a/src/ExpressionLanguage/PickupExpressionLanguageProvider.php
+++ b/src/ExpressionLanguage/PickupExpressionLanguageProvider.php
@@ -89,18 +89,28 @@ class PickupExpressionLanguageProvider implements ExpressionFunctionProviderInte
             // FIXME Need to test compilation
         };
 
-        $timeRangeLengthEvaluator = function ($arguments, $task, $unit) {
+        $timeRangeLengthEvaluator = function ($arguments, $task, $unit, $expression = null) {
 
-            // May happen for multiple points
-            // FIXME Won't work as expected when using "less than", i.e time_range_length(pickup) < 3
+            if (isset($arguments['task']) && $arguments['task']->type !== '' && $arguments['task'] !== $task) {
+                return null === $expression ? -1 : false;
+            }
+
             if (null === $task->after || null === $task->before) {
-                return -1;
+                return null === $expression ? -1 : false;
             }
 
             $after = Carbon::instance($task->after);
             $before = Carbon::instance($task->before);
 
-            return $before->floatDiffInHours($after);
+            $diff = $before->floatDiffInHours($after);
+
+            if (null === $expression) {
+                return $diff;
+            }
+
+            $el = new ExpressionLanguage();
+
+            return $el->evaluate("{$diff} {$expression}");
         };
 
         return array(

--- a/src/ExpressionLanguage/PickupExpressionLanguageProvider.php
+++ b/src/ExpressionLanguage/PickupExpressionLanguageProvider.php
@@ -17,7 +17,7 @@ class PickupExpressionLanguageProvider implements ExpressionFunctionProviderInte
             // FIXME Need to test compilation
         };
 
-        $daysEvaluator = function ($arguments, $task, $expression = null) {
+        $daysEvaluator = function ($arguments, $task, ?string $expression = null): int|float|bool {
 
             if (null === $expression) {
                 @trigger_error('Not passing an expression as the 2nd argument is deprecated', E_USER_DEPRECATED);
@@ -26,7 +26,7 @@ class PickupExpressionLanguageProvider implements ExpressionFunctionProviderInte
             $now = Carbon::now();
 
             if (isset($arguments['task']) && $arguments['task']->type !== '' && $arguments['task'] !== $task) {
-                return false;
+                return null === $expression ? -1 : false;
             }
 
             if (isset($task->createdAt) && null !== $task->createdAt) {
@@ -53,7 +53,7 @@ class PickupExpressionLanguageProvider implements ExpressionFunctionProviderInte
             // FIXME Need to test compilation
         };
 
-        $hoursEvaluator = function ($arguments, $task, $expression = null) {
+        $hoursEvaluator = function ($arguments, $task, ?string $expression = null): float|bool {
 
             if (null === $expression) {
                 @trigger_error('Not passing an expression as the 2nd argument is deprecated', E_USER_DEPRECATED);
@@ -62,11 +62,11 @@ class PickupExpressionLanguageProvider implements ExpressionFunctionProviderInte
             $now = Carbon::now();
 
             if (isset($arguments['task']) && $arguments['task']->type !== '' && $arguments['task'] !== $task) {
-                return false;
+                return null === $expression ? -1 : false;
             }
 
             if (null === $task->before) {
-                return false;
+                return null === $expression ? -1 : false;
             }
 
             if (isset($task->createdAt) && null !== $task->createdAt) {

--- a/tests/AppBundle/ExpressionLanguage/PickupExpressionLanguageProviderTest.php
+++ b/tests/AppBundle/ExpressionLanguage/PickupExpressionLanguageProviderTest.php
@@ -207,6 +207,13 @@ class PickupExpressionLanguageProviderTest extends TestCase
 
         $this->assertIsNumeric($value);
         $this->assertEquals($expectedValue, $value);
+
+        $value = $this->language->evaluate(sprintf('time_range_length(pickup, "hours", "== %s")', $expectedValue), [
+            'pickup' => $pickup,
+        ]);
+
+        $this->assertThat($value, $this->isType('boolean'));
+        $this->assertTrue($value);
     }
 
     public function timeRangeLengthProviderIn()

--- a/tests/AppBundle/ExpressionLanguage/PickupExpressionLanguageProviderTest.php
+++ b/tests/AppBundle/ExpressionLanguage/PickupExpressionLanguageProviderTest.php
@@ -50,7 +50,7 @@ class PickupExpressionLanguageProviderTest extends TestCase
             'pickup' => $pickup,
         ]);
 
-        $this->assertThat($value, $this->isType('int'));
+        $this->assertIsNumeric($value);
         $this->assertEquals($expectedValue, $value);
     }
 

--- a/tests/AppBundle/ExpressionLanguage/PickupExpressionLanguageProviderTest.php
+++ b/tests/AppBundle/ExpressionLanguage/PickupExpressionLanguageProviderTest.php
@@ -62,6 +62,11 @@ class PickupExpressionLanguageProviderTest extends TestCase
             [ '2019-08-19 09:00:00', '2019-08-22 12:00:00', 'diff_days(pickup) >= 3', true ],
             [ '2019-08-19 23:59:59', '2019-08-20 12:00:00', 'diff_days(pickup) in 0..1', true ],
             [ '2019-08-19 09:00:00', '2019-08-19 16:00:00', 'diff_days(pickup) > 0', false ],
+            [ '2019-08-19 09:00:00', '2019-08-20 12:00:00', 'diff_days(pickup, "== 1")', true ],
+            [ '2019-08-19 09:00:00', '2019-08-21 12:00:00', 'diff_days(pickup, "> 1")', true ],
+            [ '2019-08-19 09:00:00', '2019-08-22 12:00:00', 'diff_days(pickup, ">= 3")', true ],
+            [ '2019-08-19 23:59:59', '2019-08-20 12:00:00', 'diff_days(pickup, "in 0..1")', true ],
+            [ '2019-08-19 09:00:00', '2019-08-19 16:00:00', 'diff_days(pickup, "> 0")', false ],
         ];
     }
 
@@ -120,6 +125,9 @@ class PickupExpressionLanguageProviderTest extends TestCase
             [ '2019-08-19 09:00:00', '2019-08-19 12:00:00', 'diff_hours(pickup) == 3', true ],
             [ '2019-08-19 09:00:00', '2019-08-19 12:00:00', 'diff_hours(pickup) >= 3', true ],
             [ '2019-08-19 09:00:00', '2019-08-19 10:30:00', 'diff_hours(pickup) > 1',  true ],
+            [ '2019-08-19 09:00:00', '2019-08-19 12:00:00', 'diff_hours(pickup, "== 3")', true ],
+            [ '2019-08-19 09:00:00', '2019-08-19 12:00:00', 'diff_hours(pickup, ">= 3")', true ],
+            [ '2019-08-19 09:00:00', '2019-08-19 10:30:00', 'diff_hours(pickup, "> 1")',  true ],
         ];
     }
 


### PR DESCRIPTION
Fixes #3977

Since 0437ce115b9b970306e5a1343bf3de7c697af467, it's possible to define time-based functions in pricing rules, i.e: 
- `diff_days(pickup)`
- `diff_hours(pickup)`
- `time_range_length(pickup, 'hours')`

As those functions were first designed to work at **delivery** level (i.e 2 tasks, pickup & dropoff), to make them work at **task** level while not breaking everything, [we inject a fake/empty task in the expression language context](https://github.com/coopcycle/coopcycle-web/blob/b493c7a30ee43439e0e7231d6f6f9c641ac7ea96/src/Entity/Task.php#L1106-L1127), and we return `-1` when we encounter this fake/empty task, as a way to "skip" the rule matching. 

It [works well for distance evaluation](https://github.com/coopcycle/coopcycle-web/blob/b493c7a30ee43439e0e7231d6f6f9c641ac7ea96/src/Entity/Task.php#L1117), but not for time. 
Because a pricing rule could contains this: 

```
diff_hours(pickup) < 3
```

 If we return `-1`, it matches. 
 
 --- 
 
This pull request allows passing an additional parameter to those functions, so that they return a **boolean** instead of a numeric value. Not passing this argument is still supported, but deprecated. 
 
| BEFORE | AFTER |
| -------- | ------- |
| `diff_days(pickup) < 3` | `diff_days(pickup, '< 3')` |
| `diff_hours(pickup) < 3` | `diff_hours(pickup, '< 3')` |
| `time_range_length(pickup, 'hours') < 3` | `time_range_length(pickup, , 'hours', '< 3')` |
