### PR TITLE
Get ready for Edenred implementation on the app

### DIFF
--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -865,6 +865,7 @@ services:
     public: true
     arguments:
       $cashEnabled: '%env(bool:CASH_ON_DELIVERY_ENABLED)%'
+      $edenredEnabled: '%env(bool:EDENRED_ENABLED)%'
 
   AppBundle\Action\Order\Centrifugo:
     public: true

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -1002,6 +1002,7 @@ services:
   AppBundle\Api\DataTransformer\UpdateLoopeatFormatsDataTransformer: ~
   AppBundle\Api\DataTransformer\UpdateLoopeatReturnsDataTransformer: ~
   AppBundle\Api\DataTransformer\EdenredCredentialsInputDataTransformer: ~
+  AppBundle\Api\DataTransformer\ConfigurePaymentInputDataTransformer: ~
 
   AppBundle\Api\DataTransformer\CartItemInputDataTransformer:
     arguments:

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -1000,6 +1000,7 @@ services:
   AppBundle\Api\DataTransformer\TourInputDataTransformer: ~
   AppBundle\Api\DataTransformer\UpdateLoopeatFormatsDataTransformer: ~
   AppBundle\Api\DataTransformer\UpdateLoopeatReturnsDataTransformer: ~
+  AppBundle\Api\DataTransformer\EdenredCredentialsInputDataTransformer: ~
 
   AppBundle\Api\DataTransformer\CartItemInputDataTransformer:
     arguments:

--- a/features/carts.feature
+++ b/features/carts.feature
@@ -96,7 +96,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -175,7 +176,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -254,7 +256,8 @@ Feature: Carts
         },
         "fulfillmentMethod": "delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -318,7 +321,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -385,7 +389,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -514,7 +519,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -575,7 +581,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -683,7 +690,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -791,7 +799,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -1575,7 +1584,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -1701,7 +1711,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
     When I add "Content-Type" header equal to "application/ld+json"
@@ -1978,7 +1989,8 @@ Feature: Carts
           "incident":[]
         },
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 

--- a/features/carts.feature
+++ b/features/carts.feature
@@ -1750,7 +1750,8 @@ Feature: Carts
           "total":0,
           "adjustments":@...@,
           "fulfillmentMethod":"delivery",
-          "invitation": "@string@||@null@"
+          "invitation": "@string@||@null@",
+          "hasEdenredCredentials":@boolean@
         }
       }
       """
@@ -1802,7 +1803,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
     When I add "Content-Type" header equal to "application/ld+json"
@@ -1837,7 +1839,8 @@ Feature: Carts
           "total":0,
           "adjustments":@...@,
           "fulfillmentMethod":"delivery",
-          "invitation": "@string@||@null@"
+          "invitation": "@string@||@null@",
+          "hasEdenredCredentials":@boolean@
         }
       }
       """
@@ -1889,7 +1892,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 

--- a/features/carts.feature
+++ b/features/carts.feature
@@ -2281,3 +2281,64 @@ Feature: Carts
       """
     Then the response status code should be 400
     And the response should be in JSON
+
+  Scenario: Select Edenred payment method
+    Given the fixtures files are loaded:
+      | sylius_channels.yml |
+      | payment_methods.yml |
+      | products.yml        |
+      | restaurants.yml     |
+    And the restaurant with id "1" has products:
+      | code      |
+      | PIZZA     |
+      | HAMBURGER |
+    And the user "bob" is loaded:
+      | email      | bob@coopcycle.org |
+      | password   | 123456            |
+      | telephone  | 0033612345678     |
+    Given the user "bob" has created a cart at restaurant with id "1"
+    And the user "bob" is authenticated
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "PUT" request to "/api/orders/1/payment" with body:
+      """
+      {
+        "paymentMethod": "edenred"
+      }
+      """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context": {"@*@": "@*@"},
+        "@type": "ConfigurePaymentOutput",
+        "@id": "@string@",
+        "payments": [
+          {
+            "@context": {"@*@": "@*@"},
+            "@type": "@string@",
+            "@id": "@string@",
+            "method": {
+              "@context": {"@*@": "@*@"},
+              "@type": "@string@",
+              "@id": "@string@",
+              "code": "CARD"
+            },
+            "amount": @integer@
+          },
+          {
+            "@context": {"@*@": "@*@"},
+            "@type": "@string@",
+            "@id": "@string@",
+            "method": {
+              "@context": {"@*@": "@*@"},
+              "@type": "@string@",
+              "@id": "@string@",
+              "code": "EDENRED"
+            },
+            "amount": @integer@
+          }
+        ]
+      }
+      """

--- a/features/carts.feature
+++ b/features/carts.feature
@@ -451,7 +451,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -908,7 +909,8 @@ Feature: Carts
         },
         "fulfillmentMethod":"delivery",
         "invitation": "@string@||@null@",
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -1659,7 +1661,8 @@ Feature: Carts
           "total":0,
           "adjustments":@...@,
           "fulfillmentMethod":"delivery",
-          "invitation": "@string@||@null@"
+          "invitation": "@string@||@null@",
+          "hasEdenredCredentials":@boolean@
         }
       }
       """

--- a/features/fixtures/ORM/payment_methods.yml
+++ b/features/fixtures/ORM/payment_methods.yml
@@ -4,3 +4,8 @@ Sylius\Component\Payment\Model\PaymentMethod:
     currentLocale: fr
     name: Card
     enabled: true
+  payment_method_edenred:
+    code: EDENRED
+    currentLocale: fr
+    name: Edenred
+    enabled: true

--- a/features/foodtech.feature
+++ b/features/foodtech.feature
@@ -93,7 +93,8 @@ Feature: Food Tech
             "hasReceipt":@boolean@,
             "invitation": "@string@||@null@",
             "events":@array@,
-            "paymentGateway":@string@
+            "paymentGateway":@string@,
+            "hasEdenredCredentials":@boolean@
           }
         ],
         "hydra:totalItems":1,

--- a/features/orders.feature
+++ b/features/orders.feature
@@ -1419,9 +1419,7 @@ Feature: Orders
       """
       {
         "@context":{
-          "@vocab":@string@,
-          "hydra":"http://www.w3.org/ns/hydra/core#",
-          "stripeAccount":@string@
+          "@*@":"@*@"
         },
         "@type":"PaymentDetailsOutput",
         "@id":@string@,
@@ -1560,9 +1558,7 @@ Feature: Orders
       """
       {
         "@context":{
-          "@vocab":@string@,
-          "hydra":"http://www.w3.org/ns/hydra/core#",
-          "stripeAccount":@string@
+          "@*@":"@*@"
         },
         "@type":"PaymentDetailsOutput",
         "@id":@string@,

--- a/features/orders.feature
+++ b/features/orders.feature
@@ -236,7 +236,8 @@ Feature: Orders
       "assignedTo":null,
       "invitation":null,
       "events":@array@,
-      "paymentGateway":@string@
+      "paymentGateway":@string@,
+      "hasEdenredCredentials":@boolean@
     }
     """
 
@@ -406,7 +407,8 @@ Feature: Orders
       "assignedTo":null,
       "invitation":null,
       "events":@array@,
-      "paymentGateway":@string@
+      "paymentGateway":@string@,
+      "hasEdenredCredentials":@boolean@
     }
     """
 
@@ -699,7 +701,8 @@ Feature: Orders
       "assignedTo":null,
       "invitation":null,
       "events":@array@,
-      "paymentGateway":@string@
+      "paymentGateway":@string@,
+      "hasEdenredCredentials":@boolean@
     }
     """
 
@@ -856,7 +859,8 @@ Feature: Orders
         "hasReceipt":@boolean@,
         "invitation":null,
         "events":@array@,
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -1008,7 +1012,8 @@ Feature: Orders
       "assignedTo":null,
       "invitation":null,
       "events":@array@,
-      "paymentGateway":@string@
+      "paymentGateway":@string@,
+      "hasEdenredCredentials":@boolean@
     }
     """
 
@@ -1234,7 +1239,8 @@ Feature: Orders
         "assignedTo":null,
         "invitation":null,
         "events":@array@,
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
       """
 
@@ -1419,7 +1425,8 @@ Feature: Orders
         },
         "@type":"PaymentDetailsOutput",
         "@id":@string@,
-        "stripeAccount":null
+        "stripeAccount":null,
+        "payments":@array@
       }
       """
 
@@ -1559,7 +1566,8 @@ Feature: Orders
         },
         "@type":"PaymentDetailsOutput",
         "@id":@string@,
-        "stripeAccount":null
+        "stripeAccount":null,
+        "payments":@array@
       }
       """
 

--- a/features/orders_adhoc.feature
+++ b/features/orders_adhoc.feature
@@ -156,7 +156,8 @@ Feature: Orders Adhoc
         },
         "invitation": "@string@||@null@",
         "events":@array@,
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
     """
 
@@ -283,7 +284,8 @@ Feature: Orders Adhoc
         },
         "invitation": "@string@||@null@",
         "events":@array@,
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
     """
     When the user "bob" is loaded:
@@ -408,6 +410,7 @@ Feature: Orders Adhoc
         },
         "invitation": "@string@||@null@",
         "events":@array@,
-        "paymentGateway":@string@
+        "paymentGateway":@string@,
+        "hasEdenredCredentials":@boolean@
       }
     """

--- a/src/Action/Order/ConfigurePayment.php
+++ b/src/Action/Order/ConfigurePayment.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace AppBundle\Action\Order;
+
+use AppBundle\Api\Dto\ConfigurePaymentOutput;
+
+class ConfigurePayment
+{
+    public function __invoke($data)
+    {
+        return new ConfigurePaymentOutput($data);
+    }
+}

--- a/src/Action/Order/PaymentDetails.php
+++ b/src/Action/Order/PaymentDetails.php
@@ -3,7 +3,6 @@
 namespace AppBundle\Action\Order;
 
 use AppBundle\Api\Dto\PaymentDetailsOutput;
-use AppBundle\Edenred\Client as EdenredClient;
 use AppBundle\Service\StripeManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Component\Payment\Model\PaymentInterface;
@@ -13,14 +12,11 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 class PaymentDetails
 {
     private $stripeManager;
-    private $edenredClient;
 
     public function __construct(
-        StripeManager $stripeManager,
-        EdenredClient $edenredClient)
+        StripeManager $stripeManager)
     {
         $this->stripeManager = $stripeManager;
-        $this->edenredClient = $edenredClient;
     }
 
     public function __invoke($data, Request $request)
@@ -36,10 +32,6 @@ class PaymentDetails
         $this->stripeManager->configurePayment($payment);
 
         $output->stripeAccount = $payment->getStripeUserId();
-
-        if ($payment->isEdenredWithCard()) {
-            $output->breakdown = $this->edenredClient->splitAmounts($data);
-        }
 
         return $output;
     }

--- a/src/Action/Order/PaymentDetails.php
+++ b/src/Action/Order/PaymentDetails.php
@@ -3,6 +3,7 @@
 namespace AppBundle\Action\Order;
 
 use AppBundle\Api\Dto\PaymentDetailsOutput;
+use AppBundle\Edenred\Client as EdenredClient;
 use AppBundle\Service\StripeManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Component\Payment\Model\PaymentInterface;
@@ -12,11 +13,14 @@ use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 class PaymentDetails
 {
     private $stripeManager;
+    private $edenredClient;
 
     public function __construct(
-        StripeManager $stripeManager)
+        StripeManager $stripeManager,
+        EdenredClient $edenredClient)
     {
         $this->stripeManager = $stripeManager;
+        $this->edenredClient = $edenredClient;
     }
 
     public function __invoke($data, Request $request)
@@ -32,6 +36,10 @@ class PaymentDetails
         $this->stripeManager->configurePayment($payment);
 
         $output->stripeAccount = $payment->getStripeUserId();
+
+        if ($payment->isEdenredWithCard()) {
+            $output->breakdown = $this->edenredClient->splitAmounts($data);
+        }
 
         return $output;
     }

--- a/src/Action/Order/PaymentDetails.php
+++ b/src/Action/Order/PaymentDetails.php
@@ -3,22 +3,12 @@
 namespace AppBundle\Action\Order;
 
 use AppBundle\Api\Dto\PaymentDetailsOutput;
-use AppBundle\Service\StripeManager;
-use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Component\Payment\Model\PaymentInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 class PaymentDetails
 {
-    private $stripeManager;
-
-    public function __construct(
-        StripeManager $stripeManager)
-    {
-        $this->stripeManager = $stripeManager;
-    }
-
     public function __invoke($data, Request $request)
     {
         $output = new PaymentDetailsOutput();

--- a/src/Action/Order/PaymentMethods.php
+++ b/src/Action/Order/PaymentMethods.php
@@ -37,6 +37,7 @@ class PaymentMethods
         }
 
         if ($this->edenredEnabled || $data->supportsEdenred()) {
+            // TODO Also check if balance is > 0
             $output->addMethod('edenred+card');
         }
 

--- a/src/Action/Order/PaymentMethods.php
+++ b/src/Action/Order/PaymentMethods.php
@@ -12,13 +12,16 @@ class PaymentMethods
 {
     private $settingsManager;
     private $cashEnabled;
+    private $edenredEnabled;
 
     public function __construct(
         SettingsManager $settingsManager,
-        bool $cashEnabled)
+        bool $cashEnabled,
+        bool $edenredEnabled)
     {
         $this->settingsManager = $settingsManager;
         $this->cashEnabled = $cashEnabled;
+        $this->edenredEnabled = $edenredEnabled;
     }
 
     public function __invoke($data): PaymentMethodsOutput
@@ -31,6 +34,10 @@ class PaymentMethods
 
         if ($this->cashEnabled || $data->supportsCashOnDelivery()) {
             $output->addMethod('cash_on_delivery');
+        }
+
+        if ($this->edenredEnabled || $data->supportsEdenred()) {
+            $output->addMethod('edenred+card');
         }
 
         return $output;

--- a/src/Action/Order/PaymentMethods.php
+++ b/src/Action/Order/PaymentMethods.php
@@ -38,7 +38,7 @@ class PaymentMethods
 
         if ($this->edenredEnabled || $data->supportsEdenred()) {
             // TODO Also check if balance is > 0
-            $output->addMethod('edenred+card');
+            $output->addMethod('edenred');
         }
 
         return $output;

--- a/src/Api/DataTransformer/ConfigurePaymentInputDataTransformer.php
+++ b/src/Api/DataTransformer/ConfigurePaymentInputDataTransformer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace AppBundle\Api\DataTransformer;
+
+use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
+use ApiPlatform\Core\Serializer\AbstractItemNormalizer;
+use AppBundle\Api\Dto\ConfigurePaymentInput;
+use AppBundle\Edenred\Client as EdenredClient;
+use AppBundle\Entity\Sylius\Order;
+use Sylius\Component\Payment\Model\PaymentInterface;
+use Sylius\Component\Payment\Repository\PaymentMethodRepositoryInterface;
+
+/**
+ * @see https://api-platform.com/docs/v2.6/core/dto/#updating-a-resource-with-a-custom-input
+ */
+class ConfigurePaymentInputDataTransformer implements DataTransformerInterface
+{
+    public function __construct(
+        private PaymentMethodRepositoryInterface $paymentMethodRepository,
+        private EdenredClient $edenredClient)
+    {}
+
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($data, string $to, array $context = [])
+    {
+        $order = $context[AbstractItemNormalizer::OBJECT_TO_POPULATE];
+
+        $code = strtoupper($data->paymentMethod);
+
+        $paymentMethod = $this->paymentMethodRepository->findOneByCode($code);
+        if (null === $paymentMethod) {
+            throw new \Exception(sprintf('Payment method "%s" not found', $code));
+        }
+
+        $payment = $order->getLastPayment(PaymentInterface::STATE_CART);
+        $payment->setMethod($paymentMethod);
+
+        switch ($code) {
+            case 'EDENRED+CARD':
+            case 'EDENRED':
+                $breakdown = $this->edenredClient->splitAmounts($order);
+                $payment->setAmountBreakdown($breakdown['edenred'], $breakdown['card']);
+                break;
+            default:
+                $payment->clearAmountBreakdown();
+                break;
+        }
+
+        return $order;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsTransformation($data, string $to, array $context = []): bool
+    {
+        if ($data instanceof Order) {
+            return false;
+        }
+
+        return $to === Order::class && ($context['input']['class'] ?? null) === ConfigurePaymentInput::class;
+    }
+}

--- a/src/Api/DataTransformer/ConfigurePaymentInputDataTransformer.php
+++ b/src/Api/DataTransformer/ConfigurePaymentInputDataTransformer.php
@@ -7,6 +7,7 @@ use ApiPlatform\Core\Serializer\AbstractItemNormalizer;
 use AppBundle\Api\Dto\ConfigurePaymentInput;
 use AppBundle\Entity\Sylius\Order;
 use AppBundle\Sylius\Payment\Context as PaymentContext;
+use Doctrine\ORM\EntityManagerInterface;
 use Sylius\Component\Order\Processor\OrderProcessorInterface;
 use Sylius\Component\Payment\Model\PaymentInterface;
 use Sylius\Component\Payment\Repository\PaymentMethodRepositoryInterface;
@@ -19,7 +20,8 @@ class ConfigurePaymentInputDataTransformer implements DataTransformerInterface
     public function __construct(
         private PaymentMethodRepositoryInterface $paymentMethodRepository,
         private PaymentContext $paymentContext,
-        private OrderProcessorInterface $orderPaymentProcessor)
+        private OrderProcessorInterface $orderPaymentProcessor,
+        private EntityManagerInterface $entityManager)
     {}
 
     /**
@@ -39,6 +41,8 @@ class ConfigurePaymentInputDataTransformer implements DataTransformerInterface
         $this->paymentContext->setMethod($code);
 
         $this->orderPaymentProcessor->process($order);
+
+        $this->entityManager->flush();
 
         return $order;
     }

--- a/src/Api/DataTransformer/ConfigurePaymentInputDataTransformer.php
+++ b/src/Api/DataTransformer/ConfigurePaymentInputDataTransformer.php
@@ -38,10 +38,13 @@ class ConfigurePaymentInputDataTransformer implements DataTransformerInterface
         $payment->setMethod($paymentMethod);
 
         switch ($code) {
+            // At this step, the customer may not have connected the Edenred account yet
             case 'EDENRED+CARD':
             case 'EDENRED':
-                $breakdown = $this->edenredClient->splitAmounts($order);
-                $payment->setAmountBreakdown($breakdown['edenred'], $breakdown['card']);
+                if ($order->getCustomer()->hasEdenredCredentials()) {
+                    $breakdown = $this->edenredClient->splitAmounts($order);
+                    $payment->setAmountBreakdown($breakdown['edenred'], $breakdown['card']);
+                }
                 break;
             default:
                 $payment->clearAmountBreakdown();

--- a/src/Api/DataTransformer/EdenredCredentialsInputDataTransformer.php
+++ b/src/Api/DataTransformer/EdenredCredentialsInputDataTransformer.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace AppBundle\Api\DataTransformer;
+
+use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
+use ApiPlatform\Core\Serializer\AbstractItemNormalizer;
+use AppBundle\Api\Dto\EdenredCredentialsInput;
+use AppBundle\Entity\Sylius\Order;
+
+/**
+ * @see https://api-platform.com/docs/v2.6/core/dto/#updating-a-resource-with-a-custom-input
+ */
+class EdenredCredentialsInputDataTransformer implements DataTransformerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function transform($data, string $to, array $context = [])
+    {
+        $order = $context[AbstractItemNormalizer::OBJECT_TO_POPULATE];
+
+        $customer = $order->getCustomer();
+
+        $customer->setEdenredAccessToken($data->accessToken);
+        $customer->setEdenredRefreshToken($data->refreshToken);
+
+        return $order;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsTransformation($data, string $to, array $context = []): bool
+    {
+        if ($data instanceof Order) {
+            return false;
+        }
+
+        return $to === Order::class && ($context['input']['class'] ?? null) === EdenredCredentialsInput::class;
+    }
+}

--- a/src/Api/DataTransformer/EdenredCredentialsInputDataTransformer.php
+++ b/src/Api/DataTransformer/EdenredCredentialsInputDataTransformer.php
@@ -5,18 +5,13 @@ namespace AppBundle\Api\DataTransformer;
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
 use ApiPlatform\Core\Serializer\AbstractItemNormalizer;
 use AppBundle\Api\Dto\EdenredCredentialsInput;
-use AppBundle\Edenred\Client as EdenredClient;
 use AppBundle\Entity\Sylius\Order;
-use Sylius\Component\Payment\Model\PaymentInterface;
 
 /**
  * @see https://api-platform.com/docs/v2.6/core/dto/#updating-a-resource-with-a-custom-input
  */
 class EdenredCredentialsInputDataTransformer implements DataTransformerInterface
 {
-    public function __construct(private EdenredClient $edenredClient)
-    {}
-
     /**
      * {@inheritdoc}
      */
@@ -28,14 +23,6 @@ class EdenredCredentialsInputDataTransformer implements DataTransformerInterface
 
         $customer->setEdenredAccessToken($data->accessToken);
         $customer->setEdenredRefreshToken($data->refreshToken);
-
-        // If the current order needs to be paid with Edenred,
-        // we setup the amount breakdown
-        $payment = $order->getLastPayment(PaymentInterface::STATE_CART);
-        if ($payment->isEdenredWithCard()) {
-            $breakdown = $this->edenredClient->splitAmounts($order);
-            $payment->setAmountBreakdown($breakdown['edenred'], $breakdown['card']);
-        }
 
         return $order;
     }

--- a/src/Api/DataTransformer/EdenredCredentialsInputDataTransformer.php
+++ b/src/Api/DataTransformer/EdenredCredentialsInputDataTransformer.php
@@ -5,13 +5,18 @@ namespace AppBundle\Api\DataTransformer;
 use ApiPlatform\Core\DataTransformer\DataTransformerInterface;
 use ApiPlatform\Core\Serializer\AbstractItemNormalizer;
 use AppBundle\Api\Dto\EdenredCredentialsInput;
+use AppBundle\Edenred\Client as EdenredClient;
 use AppBundle\Entity\Sylius\Order;
+use Sylius\Component\Payment\Model\PaymentInterface;
 
 /**
  * @see https://api-platform.com/docs/v2.6/core/dto/#updating-a-resource-with-a-custom-input
  */
 class EdenredCredentialsInputDataTransformer implements DataTransformerInterface
 {
+    public function __construct(private EdenredClient $edenredClient)
+    {}
+
     /**
      * {@inheritdoc}
      */
@@ -23,6 +28,14 @@ class EdenredCredentialsInputDataTransformer implements DataTransformerInterface
 
         $customer->setEdenredAccessToken($data->accessToken);
         $customer->setEdenredRefreshToken($data->refreshToken);
+
+        // If the current order needs to be paid with Edenred,
+        // we setup the amount breakdown
+        $payment = $order->getLastPayment(PaymentInterface::STATE_CART);
+        if ($payment->isEdenredWithCard()) {
+            $breakdown = $this->edenredClient->splitAmounts($order);
+            $payment->setAmountBreakdown($breakdown['edenred'], $breakdown['card']);
+        }
 
         return $order;
     }

--- a/src/Api/Dto/ConfigurePaymentInput.php
+++ b/src/Api/Dto/ConfigurePaymentInput.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace AppBundle\Api\Dto;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+final class ConfigurePaymentInput
+{
+    /**
+     * @var string
+     * @Groups({"order_configure_payment"})
+     */
+    public string $paymentMethod;
+}
+

--- a/src/Api/Dto/ConfigurePaymentOutput.php
+++ b/src/Api/Dto/ConfigurePaymentOutput.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AppBundle\Api\Dto;
+
+use ApiPlatform\Core\Annotation\ApiProperty;
+use AppBundle\Sylius\Order\OrderInterface;
+use Sylius\Component\Payment\Model\PaymentInterface;
+use Doctrine\Common\Collections\Collection;
+use Symfony\Component\Serializer\Annotation\Groups;
+
+final class ConfigurePaymentOutput
+{
+    /**
+     * @ApiProperty
+     * @Groups({"order_configure_payment"})
+     * @var Collection
+     */
+    public $payments;
+
+    public function __construct(OrderInterface $order)
+    {
+        $this->payments = $order->getPayments();
+    }
+}

--- a/src/Api/Dto/EdenredCredentialsInput.php
+++ b/src/Api/Dto/EdenredCredentialsInput.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AppBundle\Api\Dto;
+
+use Symfony\Component\Serializer\Annotation\Groups;
+
+final class EdenredCredentialsInput
+{
+    /**
+     * @var string
+     * @Groups({"update_edenred_credentials"})
+     */
+    public string $accessToken;
+
+    /**
+     * @var string
+     * @Groups({"update_edenred_credentials"})
+     */
+    public string $refreshToken;
+}

--- a/src/Api/Dto/PaymentDetailsOutput.php
+++ b/src/Api/Dto/PaymentDetailsOutput.php
@@ -3,14 +3,20 @@
 namespace AppBundle\Api\Dto;
 
 use ApiPlatform\Core\Annotation\ApiProperty;
-use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 final class PaymentDetailsOutput
 {
     /**
      * @var string|null
-     * @Groups({"order"})
+     * @Groups({"payment_details"})
      */
     public $stripeAccount;
+
+    /**
+     * @var Collection
+     * @Groups({"payment_details"})
+     */
+    public $payments;
 }

--- a/src/Api/Dto/PaymentDetailsOutput.php
+++ b/src/Api/Dto/PaymentDetailsOutput.php
@@ -2,6 +2,8 @@
 
 namespace AppBundle\Api\Dto;
 
+use ApiPlatform\Core\Annotation\ApiProperty;
+use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Component\Serializer\Annotation\Groups;
 
 final class PaymentDetailsOutput
@@ -11,4 +13,10 @@ final class PaymentDetailsOutput
      * @Groups({"order"})
      */
     public $stripeAccount;
+
+    /**
+     * @var array|null
+     * @Groups({"order"})
+     */
+    public $breakdown;
 }

--- a/src/Api/Dto/PaymentDetailsOutput.php
+++ b/src/Api/Dto/PaymentDetailsOutput.php
@@ -13,10 +13,4 @@ final class PaymentDetailsOutput
      * @Groups({"order"})
      */
     public $stripeAccount;
-
-    /**
-     * @var array|null
-     * @Groups({"order"})
-     */
-    public $breakdown;
 }

--- a/src/Controller/EdenredController.php
+++ b/src/Controller/EdenredController.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Lexik\Bundle\JWTAuthenticationBundle\Exception\JWTDecodeFailureException;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Annotation\Route;
@@ -95,5 +96,27 @@ class EdenredController extends AbstractController
             // TODO Redirect depending on context
             return $this->redirectToRoute('profile_edit');
         }
+    }
+
+    /**
+     * Proxies authorization_code requests to Edenred server, to avoid exposing the client secret.
+     * This is used on the app.
+     *
+     * @Route("/edenred/connect/token", name="edenred_connect_token")
+     */
+    public function connectTokenAction(Request $request)
+    {
+        $response = new JsonResponse();
+
+        // TODO Make sure client_id matches & grant_type == authorization_code
+
+        try {
+            $data = $this->authentication->authorizationCode($request->get('code'), $request->get('redirect_uri'));
+            $response->setData($data);
+        } catch (HttpExceptionInterface $e) {
+            $response->setJson($e->getResponse()->getContent());
+        }
+
+        return $response;
     }
 }

--- a/src/Edenred/Client.php
+++ b/src/Edenred/Client.php
@@ -49,6 +49,11 @@ class Client
 
     public function getBalance(Customer $customer): int
     {
+        if (!$customer->hasEdenredCredentials()) {
+
+            return 0;
+        }
+
         try {
 
             $userInfo = $this->authentication->userInfo($customer);

--- a/src/Entity/Sylius/Order.php
+++ b/src/Entity/Sylius/Order.php
@@ -1807,6 +1807,7 @@ class Order extends BaseOrder implements OrderInterface
     }
 
     /**
+<<<<<<< HEAD
      * To get bookmarks that current user has access to use OrderManager::hasBookmark instead
      * @return Collection all bookmarks set by different users
      */
@@ -1833,6 +1834,23 @@ class Order extends BaseOrder implements OrderInterface
     public function setSubscription(?RecurrenceRule $subscription): void
     {
         $this->subscription = $subscription;
+
+    }
+
+    /**
+     * @SerializedName("hasEdenredCredentials")
+     * @Groups({"order", "order_update", "cart"})
+     */
+    public function hasEdenredCredentials(): bool
+    {
+        /** @var \AppBundle\Sylius\Customer\CustomerInterface|null */
+        $customer = $this->getCustomer();
+
+        if (null === $customer) {
+            return false;
+        }
+
+        return $customer->hasEdenredCredentials();
     }
 
     /**

--- a/src/Entity/Sylius/Order.php
+++ b/src/Entity/Sylius/Order.php
@@ -129,7 +129,7 @@ use Webmozart\Assert\Assert as WMAssert;
  *       "method"="GET",
  *       "path"="/orders/{id}/payment",
  *       "controller"=PaymentDetailsController::class,
- *       "normalization_context"={"api_sub_level"=true},
+ *       "normalization_context"={"api_sub_level"=true, "groups"={"payment_details"}},
  *       "security"="is_granted('edit', object)",
  *       "openapi_context"={
  *         "summary"="Get payment details for a Order resource."

--- a/src/Entity/Sylius/Order.php
+++ b/src/Entity/Sylius/Order.php
@@ -37,6 +37,7 @@ use AppBundle\Api\Dto\PaymentMethodsOutput;
 use AppBundle\Api\Dto\StripePaymentMethodOutput;
 use AppBundle\Api\Dto\LoopeatFormats as LoopeatFormatsOutput;
 use AppBundle\Api\Dto\LoopeatReturns;
+use AppBundle\Api\Dto\EdenredCredentialsInput;
 use AppBundle\DataType\TsRange;
 use AppBundle\Entity\Address;
 use AppBundle\Entity\BusinessAccount;
@@ -422,6 +423,18 @@ use Webmozart\Assert\Assert as WMAssert;
  *       "denormalization_context"={"groups"={"update_loopeat_returns"}},
  *       "openapi_context"={
  *         "summary"="Update Loopeat returns for an order"
+ *       }
+ *     },
+ *     "update_edenred_credentials"={
+ *       "method"="PUT",
+ *       "path"="/orders/{id}/edenred_credentials",
+ *       "security"="is_granted('edit', object)",
+ *       "input"=EdenredCredentialsInput::class,
+ *       "validate"=false,
+ *       "normalization_context"={"groups"={"cart"}},
+ *       "denormalization_context"={"groups"={"update_edenred_credentials"}},
+ *       "openapi_context"={
+ *         "summary"="Update Edenred credentials for an order"
  *       }
  *     },
  *   },

--- a/src/Entity/Sylius/Order.php
+++ b/src/Entity/Sylius/Order.php
@@ -16,6 +16,7 @@ use AppBundle\Action\Order\StartPreparing as OrderStartPreparing;
 use AppBundle\Action\Order\FinishPreparing as OrderFinishPreparing;
 use AppBundle\Action\Order\Centrifugo as CentrifugoController;
 use AppBundle\Action\Order\CloneStripePayment;
+use AppBundle\Action\Order\ConfigurePayment as ConfigurePaymentController;
 use AppBundle\Action\Order\CreateInvitation as CreateInvitationController;
 use AppBundle\Action\Order\CreateSetupIntentOrAttachPM;
 use AppBundle\Action\Order\Delay as OrderDelay;
@@ -34,6 +35,7 @@ use AppBundle\Action\Order\UpdateLoopeatFormats as UpdateLoopeatFormatsControlle
 use AppBundle\Action\Order\UpdateLoopeatReturns as UpdateLoopeatReturnsController;
 use AppBundle\Api\Dto\CartItemInput;
 use AppBundle\Api\Dto\ConfigurePaymentInput;
+use AppBundle\Api\Dto\ConfigurePaymentOutput;
 use AppBundle\Api\Dto\PaymentMethodsOutput;
 use AppBundle\Api\Dto\StripePaymentMethodOutput;
 use AppBundle\Api\Dto\LoopeatFormats as LoopeatFormatsOutput;
@@ -444,7 +446,11 @@ use Webmozart\Assert\Assert as WMAssert;
  *       "path"="/orders/{id}/payment",
  *       "security"="is_granted('edit', object)",
  *       "input"=ConfigurePaymentInput::class,
+ *       "controller"=ConfigurePaymentController::class,
+ *       "output"=ConfigurePaymentOutput::class,
+ *       "validate"=false,
  *       "denormalization_context"={"groups"={"order_configure_payment"}},
+ *       "normalization_context"={"api_sub_level"=true, "groups"={"order_configure_payment"}},
  *       "openapi_context"={
  *         "summary"="Configure payment for a Order resource."
  *       }
@@ -1832,7 +1838,6 @@ class Order extends BaseOrder implements OrderInterface
     }
 
     /**
-<<<<<<< HEAD
      * To get bookmarks that current user has access to use OrderManager::hasBookmark instead
      * @return Collection all bookmarks set by different users
      */

--- a/src/Entity/Sylius/Order.php
+++ b/src/Entity/Sylius/Order.php
@@ -33,6 +33,7 @@ use AppBundle\Action\Order\Tip as OrderTip;
 use AppBundle\Action\Order\UpdateLoopeatFormats as UpdateLoopeatFormatsController;
 use AppBundle\Action\Order\UpdateLoopeatReturns as UpdateLoopeatReturnsController;
 use AppBundle\Api\Dto\CartItemInput;
+use AppBundle\Api\Dto\ConfigurePaymentInput;
 use AppBundle\Api\Dto\PaymentMethodsOutput;
 use AppBundle\Api\Dto\StripePaymentMethodOutput;
 use AppBundle\Api\Dto\LoopeatFormats as LoopeatFormatsOutput;
@@ -126,6 +127,7 @@ use Webmozart\Assert\Assert as WMAssert;
  *       "method"="GET",
  *       "path"="/orders/{id}/payment",
  *       "controller"=PaymentDetailsController::class,
+ *       "normalization_context"={"api_sub_level"=true},
  *       "security"="is_granted('edit', object)",
  *       "openapi_context"={
  *         "summary"="Get payment details for a Order resource."
@@ -435,6 +437,16 @@ use Webmozart\Assert\Assert as WMAssert;
  *       "denormalization_context"={"groups"={"update_edenred_credentials"}},
  *       "openapi_context"={
  *         "summary"="Update Edenred credentials for an order"
+ *       }
+ *     },
+ *     "configure_payment"={
+ *       "method"="PUT",
+ *       "path"="/orders/{id}/payment",
+ *       "security"="is_granted('edit', object)",
+ *       "input"=ConfigurePaymentInput::class,
+ *       "denormalization_context"={"groups"={"order_configure_payment"}},
+ *       "openapi_context"={
+ *         "summary"="Configure payment for a Order resource."
  *       }
  *     },
  *   },

--- a/src/Resources/config/serialization.yml
+++ b/src/Resources/config/serialization.yml
@@ -214,11 +214,11 @@ AppBundle\Entity\Delivery\FailureReason:
 Sylius\Component\Payment\Model\Payment:
   attributes:
     amount:
-      groups: ['payment']
+      groups: ['payment', 'order_configure_payment']
     method:
-      groups: ['payment']
+      groups: ['payment', 'order_configure_payment']
 
 Sylius\Component\Payment\Model\PaymentMethod:
   attributes:
     code:
-      groups: ['payment']
+      groups: ['payment', 'order_configure_payment']

--- a/src/Resources/config/serialization.yml
+++ b/src/Resources/config/serialization.yml
@@ -102,6 +102,8 @@ Sylius\Component\Order\Model\Order:
       groups: ['order']
     paymentMethod:
       groups: ['order', 'order_update', 'order_minimal']
+    hasEdenredCredentials:
+      groups: ['cart', 'order', 'order_update']
 
 Sylius\Component\Order\Model\OrderItem:
   attributes:

--- a/src/Resources/config/serialization.yml
+++ b/src/Resources/config/serialization.yml
@@ -214,11 +214,11 @@ AppBundle\Entity\Delivery\FailureReason:
 Sylius\Component\Payment\Model\Payment:
   attributes:
     amount:
-      groups: ['payment', 'order_configure_payment']
+      groups: ['payment', 'order_configure_payment', 'payment_details']
     method:
-      groups: ['payment', 'order_configure_payment']
+      groups: ['payment', 'order_configure_payment', 'payment_details']
 
 Sylius\Component\Payment\Model\PaymentMethod:
   attributes:
     code:
-      groups: ['payment', 'order_configure_payment']
+      groups: ['payment', 'order_configure_payment', 'payment_details']

--- a/src/Serializer/JsonLd/OrderNormalizer.php
+++ b/src/Serializer/JsonLd/OrderNormalizer.php
@@ -4,6 +4,7 @@ namespace AppBundle\Serializer\JsonLd;
 
 use ApiPlatform\Core\Api\IriConverterInterface;
 use ApiPlatform\Core\JsonLd\Serializer\ItemNormalizer;
+use AppBundle\Edenred\Client as EdenredClient;
 use AppBundle\Entity\Sylius\Order;
 use AppBundle\LoopEat\Client as LoopeatClient;
 use AppBundle\LoopEat\Context as LoopeatContext;
@@ -46,7 +47,8 @@ class OrderNormalizer implements NormalizerInterface, DenormalizerInterface
         private TranslatorInterface $translator,
         private LoopeatClient $loopeatClient,
         private LoopeatContextInitializer $loopeatContextInitializer,
-        private GatewayResolver $paymentGatewayResolver)
+        private GatewayResolver $paymentGatewayResolver,
+        private EdenredClient $edenredClient)
     {}
 
     public function normalize($object, $format = null, array $context = array())
@@ -172,6 +174,11 @@ class OrderNormalizer implements NormalizerInterface, DenormalizerInterface
         }
 
         $data['paymentGateway'] = $this->paymentGatewayResolver->resolveForOrder($object);
+
+        // Make sure the customer has *VALID* Edenred credentials
+        if (array_key_exists('hasEdenredCredentials', $data) && true === $data['hasEdenredCredentials']) {
+            $data['hasEdenredCredentials'] = $this->edenredClient->hasValidCredentials($object->getCustomer());
+        }
 
         return $data;
     }


### PR DESCRIPTION
This pull requests adds 2 new endpoints: 
- `PUT /orders/{id}/edenred_credentials` to update the Edenred credentials of the customer of an order
- `PUT /orders/{id}/payment` to configure the payment method of an order, i.e for Edenred it will calculate the amount breakdown (customers can spend a maximum of 25€ per day with Edenred). 

It also adds a proxy to obtain an access token from Edenred without exposing the client secret. 