### PR TITLE
fixed: avoid calling `sync()` action twice

### DIFF
--- a/js/app/restaurant/components/Order/index.js
+++ b/js/app/restaurant/components/Order/index.js
@@ -4,28 +4,21 @@ import Sticky from 'react-stickynode'
 import classNames from 'classnames'
 
 import { sync } from '../../redux/actions'
-import {
-  selectIsMobileCartVisible,
-} from '../../redux/selectors'
+import { selectIsMobileCartVisible } from '../../redux/selectors'
 import FulfillmentDetails from './FulfillmentDetails'
 import MobileOrderHeading from './MobileOrderHeading'
 import CartWrapper from './CartWrapper'
+import { createPortal } from 'react-dom'
 
 // mobile (and small tablets)
-export function OrderOverlay() {
+function OrderOverlay() {
   const isMobileCartVisible = useSelector(selectIsMobileCartVisible)
 
-  const dispatch = useDispatch()
-
-  useEffect(() => {
-    dispatch(sync())
-  }, [])
-
   return (
-    <div className={ classNames('order-overlay', {
-      'order-overlay--show': isMobileCartVisible,
-    }) }>
-
+    <div
+      className={classNames('order-overlay', {
+        'order-overlay--show': isMobileCartVisible,
+      })}>
       <MobileOrderHeading />
 
       <div className="order-overlay__content">
@@ -37,16 +30,9 @@ export function OrderOverlay() {
   )
 }
 
-
 // desktop (and larger tablets)
-export function StickyOrder() {
-  const [ menuNavHeight, setMenuNavHeight ] = useState(0)
-
-  const dispatch = useDispatch()
-
-  useEffect(() => {
-    dispatch(sync())
-  }, [])
+function StickyOrder() {
+  const [menuNavHeight, setMenuNavHeight] = useState(0)
 
   const el = document.getElementById('restaurant-menu-nav')
 
@@ -54,14 +40,39 @@ export function StickyOrder() {
     if (el) {
       const height = el.clientHeight
 
-      document.documentElement.style.setProperty('--restaurant-menu-nav-height',
-        `${ height }px`)
+      document.documentElement.style.setProperty(
+        '--restaurant-menu-nav-height',
+        `${height}px`,
+      )
       setMenuNavHeight(height)
     }
-  }, [ el ])
+  }, [el])
 
   return (
-    <Sticky top={ menuNavHeight } bottomBoundary=".content">
+    <Sticky top={menuNavHeight} bottomBoundary=".content">
       <CartWrapper />
-    </Sticky>)
+    </Sticky>
+  )
+}
+
+// desktop only
+const fulfilmentDetailsContainer = document.getElementById(
+  'restaurant__fulfilment-details__container',
+)
+
+export function OrderLayout() {
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    console.log('OrderLayout; sync')
+    dispatch(sync())
+  }, [])
+
+  return (
+    <>
+      {createPortal(<FulfillmentDetails />, fulfilmentDetailsContainer)}
+      <StickyOrder />
+      <OrderOverlay />
+    </>
+  )
 }

--- a/js/app/restaurant/item.js
+++ b/js/app/restaurant/item.js
@@ -1,6 +1,5 @@
-import React from 'react'
-import { createRoot } from 'react-dom/client';
-import { createPortal } from 'react-dom'
+import React, { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 import { I18nextProvider } from 'react-i18next'
 import Modal from 'react-modal'
@@ -25,28 +24,20 @@ import './menu.scss'
 import './components/Order/index.scss'
 import '../components/order/index.scss'
 
-import ProductOptionsModal
-  from './components/ProductDetails/ProductOptionsModal'
+import ProductOptionsModal from './components/ProductDetails/ProductOptionsModal'
 import ChangeRestaurantOnAddProductModal from './components/ChangeRestaurantOnAddProductModal'
 import InvitePeopleToOrderModal from './components/InvitePeopleToOrderModal'
 import SetGuestCustomerEmailModal from './components/SetGuestCustomerEmailModal'
 import LoopeatModal from './components/LoopeatModal'
-import FulfillmentDetails from './components/Order/FulfillmentDetails'
-import { OrderOverlay, StickyOrder } from './components/Order'
+import { OrderLayout } from './components/Order'
 import {
   selectCanAddToExistingCart,
   selectCartShippingTimeRange,
   selectCartTiming,
 } from './redux/selectors'
-import {
-  checkTimeRange,
-} from '../utils/order/helpers'
-import {
-  timeRangeSlice,
-} from '../components/order/timeRange/reduxSlice'
-import {
-  accountSlice,
-} from '../entities/account/reduxSlice'
+import { checkTimeRange } from '../utils/order/helpers'
+import { timeRangeSlice } from '../components/order/timeRange/reduxSlice'
+import { accountSlice } from '../entities/account/reduxSlice'
 import { buildGuestInitialState } from '../entities/guest/utils'
 import { guestSlice } from '../entities/guest/reduxSlice'
 import { orderSlice } from '../entities/order/reduxSlice'
@@ -68,7 +59,6 @@ function setMenuLoading(isLoading) {
 }
 
 function init() {
-
   const container = document.getElementById('cart')
 
   if (!container) {
@@ -191,16 +181,12 @@ function init() {
 
   Modal.setAppElement(container)
 
-  // desktop only
-  const fulfilmentDetailsContainer = document.getElementById('restaurant__fulfilment-details__container')
-
-  const root = createRoot(container);
+  const root = createRoot(container)
   root.render(
-      <Provider store={ store }>
-        <I18nextProvider i18n={ i18n }>
-          {createPortal(<FulfillmentDetails />, fulfilmentDetailsContainer)}
-          <StickyOrder />
-          <OrderOverlay />
+    <StrictMode>
+      <Provider store={store}>
+        <I18nextProvider i18n={i18n}>
+          <OrderLayout />
           <ProductOptionsModal />
           <ChangeRestaurantOnAddProductModal />
           <InvitePeopleToOrderModal />
@@ -208,6 +194,7 @@ function init() {
           <LoopeatModal />
         </I18nextProvider>
       </Provider>
+    </StrictMode>,
   )
 }
 


### PR DESCRIPTION
fixed: avoid calling sync() action twice on loading a restaurant page: http://*/en/restaurant/3-burger-bar

Which leads to a double POST`/*/restaurant/*/cart` requests with in turn leads to a creation of double adjustments (delivery fees)

![Screenshot 2024-08-09 at 12 12 50](https://github.com/user-attachments/assets/22bb759e-1265-4bf9-a22a-30ff56023567)

❗️you will probably see double POST requests in the development environment, that due to the `StrictMode`
