### PR TITLE
In the dispatch panel, show <order_number>-<delivery_position> instead of task.id

### DIFF
--- a/app/config/message_bus/task.yml
+++ b/app/config/message_bus/task.yml
@@ -43,6 +43,14 @@ services:
       - name: command_handler
         handles: AppBundle\Domain\Task\Command\Cancel
 
+  coopcycle.domain.task.handler.update:
+    class: AppBundle\Domain\Task\Handler\UpdateHandler
+    arguments:
+      - '@event_recorder'
+    tags:
+      - name: command_handler
+        handles: AppBundle\Domain\Task\Command\Update
+
   coopcycle.domain.task.handler.delete_group:
     class: AppBundle\Domain\Task\Handler\DeleteGroupHandler
     arguments:
@@ -88,6 +96,7 @@ services:
     tags:
       - name: command_handler
         handles: AppBundle\Domain\Task\Command\Incident
+
   #
   # Reactors
   #
@@ -121,6 +130,8 @@ services:
         subscribes_to: task:rescheduled
       - name: event_subscriber
         subscribes_to: task:incident-reported
+      - name: event_subscriber
+        subscribes_to: task:updated
 
   coopcycle.domain.task.reactor.send_email:
     class: AppBundle\Domain\Task\Reactor\SendEmail

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -695,7 +695,7 @@ services:
       $redis: '@snc_redis.shared'
       $service: opencage
 
- # needs to be run before TaskSubscriber as it reflects Tour.tasks changes into task.assignedTo attribute
+  # needs to be run before TaskSubscriber as it reflects Tour.tasks changes into task.assignedTo attribute
   AppBundle\Doctrine\EventSubscriber\TourSubscriber:
     tags:
       - { name: monolog.logger, channel: coopcycle.logistics }
@@ -722,6 +722,10 @@ services:
       - { name: doctrine.event_subscriber, connection: default, priority: 16 }
 
   AppBundle\Doctrine\EventSubscriber\OrganizationSubscriber:
+    tags:
+      - { name: doctrine.event_subscriber }
+
+  AppBundle\Doctrine\EventSubscriber\OrderSubscriber:
     tags:
       - { name: doctrine.event_subscriber }
 

--- a/js/app/dashboard/components/Task.js
+++ b/js/app/dashboard/components/Task.js
@@ -54,6 +54,10 @@ const TaskCaption = ({ task }) => {
             : `#${ task.id }`
           }
         </span>
+        {/* keep the task ID displayed for the web dispatcher while migrating the client code as the rider sees the task ID in the app */}
+        <span className='text-muted ml-1'>
+          {`#${ task.id }`}
+        </span>
       </span>
       { (task.orgName && !_.isEmpty(task.orgName)) && (
         <span>

--- a/js/app/dashboard/components/Task.js
+++ b/js/app/dashboard/components/Task.js
@@ -44,7 +44,13 @@ const TaskCaption = ({ task }) => {
       <span className="mr-1">
         <span className="text-monospace font-weight-bold">
           { task.metadata?.order_number ?
-            task.metadata.order_number
+            <>
+              {
+                task.metadata?.delivery_position ?
+                <>{task.metadata.order_number}-{task.metadata.delivery_position}</>
+                : task.metadata.order_number
+              }
+            </>
             : `#${ task.id }`
           }
         </span>

--- a/js/app/dashboard/redux/middlewares.js
+++ b/js/app/dashboard/redux/middlewares.js
@@ -64,6 +64,7 @@ export const socketIO = ({ dispatch, getState }) => {
         case 'task:created':
         case 'task:rescheduled':
         case 'task:incident-reported':
+        case 'task:updated':
           dispatch(updateTask(event.data.task))
           break
         case 'task:assigned':

--- a/src/Doctrine/EventSubscriber/OrderSubscriber.php
+++ b/src/Doctrine/EventSubscriber/OrderSubscriber.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace AppBundle\Doctrine\EventSubscriber;
+
+use AppBundle\Entity\Sylius\Order;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Events;
+
+use function PHPUnit\Framework\isNull;
+
+class OrderSubscriber implements EventSubscriber
+{
+    public function getSubscribedEvents()
+    {
+        return array(
+            Events::onFlush,
+        );
+    }
+
+    public function onFlush(OnFlushEventArgs $args)
+    {
+        $em = $args->getEntityManager();
+        $uow = $em->getUnitOfWork();
+
+        $isOrder = function ($entity) {
+            return $entity instanceof Order;
+        };
+
+        $updatedOrders = array_filter($uow->getScheduledEntityUpdates(), $isOrder);
+
+        foreach ($updatedOrders as $order) {
+            $entityChangeSet = $uow->getEntityChangeSet($order);
+            [ $oldValue, $newValue ] = $entityChangeSet['number'];
+            $delivery = $order->getDelivery();
+
+            if (is_null($oldValue) && !is_null($newValue) && !is_null($delivery)) {
+                foreach($delivery->getTasks() as $task) {
+                    $task->setMetadata('order_number', $newValue);
+                }
+            }
+        }
+
+        $uow->computeChangeSets();
+    }
+}

--- a/src/Doctrine/EventSubscriber/OrderSubscriber.php
+++ b/src/Doctrine/EventSubscriber/OrderSubscriber.php
@@ -6,11 +6,18 @@ use AppBundle\Entity\Sylius\Order;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Events;
-
-use function PHPUnit\Framework\isNull;
+use AppBundle\Service\TaskManager;
+use SimpleBus\Message\Recorder\RecordsMessages;
+use SimpleBus\SymfonyBridge\Bus\CommandBus;
 
 class OrderSubscriber implements EventSubscriber
 {
+    public function __construct(
+        protected RecordsMessages $eventRecorder,
+        protected CommandBus $commandBus,
+        protected TaskManager $taskManager)
+    {}
+
     public function getSubscribedEvents()
     {
         return array(
@@ -37,6 +44,7 @@ class OrderSubscriber implements EventSubscriber
             if (is_null($oldValue) && !is_null($newValue) && !is_null($delivery)) {
                 foreach($delivery->getTasks() as $task) {
                     $task->setMetadata('order_number', $newValue);
+                    $this->taskManager->update($task);
                 }
             }
         }

--- a/src/Doctrine/EventSubscriber/OrderSubscriber.php
+++ b/src/Doctrine/EventSubscriber/OrderSubscriber.php
@@ -38,6 +38,7 @@ class OrderSubscriber implements EventSubscriber
         };
 
         $updatedOrders = array_filter($uow->getScheduledEntityUpdates(), $isOrder);
+        $needsRecompute = false;
 
         foreach ($updatedOrders as $order) {
             $entityChangeSet = $uow->getEntityChangeSet($order);
@@ -55,10 +56,13 @@ class OrderSubscriber implements EventSubscriber
                 foreach($delivery->getTasks() as $task) {
                     $task->setMetadata('order_number', $newValue);
                     $this->taskManager->update($task);
+                    $needsRecompute = true;
                 }
             }
         }
 
-        $uow->computeChangeSets();
+        if ($needsRecompute) {
+            $uow->computeChangeSets();
+        }
     }
 }

--- a/src/Doctrine/EventSubscriber/OrderSubscriber.php
+++ b/src/Doctrine/EventSubscriber/OrderSubscriber.php
@@ -38,6 +38,11 @@ class OrderSubscriber implements EventSubscriber
 
         foreach ($updatedOrders as $order) {
             $entityChangeSet = $uow->getEntityChangeSet($order);
+
+            if (!array_key_exists('number', $entityChangeSet)) {
+                continue;
+            }
+
             [ $oldValue, $newValue ] = $entityChangeSet['number'];
             $delivery = $order->getDelivery();
 

--- a/src/Doctrine/EventSubscriber/OrderSubscriber.php
+++ b/src/Doctrine/EventSubscriber/OrderSubscriber.php
@@ -25,6 +25,9 @@ class OrderSubscriber implements EventSubscriber
         );
     }
 
+    /**
+     * Save the order number in task.metadata.order_number for non-foodtech orders
+     */
     public function onFlush(OnFlushEventArgs $args)
     {
         $em = $args->getEntityManager();
@@ -44,6 +47,8 @@ class OrderSubscriber implements EventSubscriber
             }
 
             [ $oldValue, $newValue ] = $entityChangeSet['number'];
+
+            // for foodtech orders the delivery is not created when we assign the number, it is created when the order is accepted
             $delivery = $order->getDelivery();
 
             if (is_null($oldValue) && !is_null($newValue) && !is_null($delivery)) {

--- a/src/Domain/Task/Command/Update.php
+++ b/src/Domain/Task/Command/Update.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace AppBundle\Domain\Task\Command;
+
+use AppBundle\Entity\Task;
+
+class Update
+{
+    private $task;
+
+    public function __construct(Task $task)
+    {
+        $this->task = $task;
+    }
+
+    public function getTask()
+    {
+        return $this->task;
+    }
+}

--- a/src/Domain/Task/Event/TaskUpdated.php
+++ b/src/Domain/Task/Event/TaskUpdated.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AppBundle\Domain\Task\Event;
+
+use AppBundle\Domain\DomainEvent;
+use AppBundle\Domain\SilentEventInterface;
+use AppBundle\Domain\Task\Event;
+use AppBundle\Entity\Task;
+
+class TaskUpdated extends Event implements DomainEvent, SilentEventInterface
+{
+    public function __construct(
+        Task $task,
+    )
+    {
+        parent::__construct($task);
+    }
+
+    public static function messageName(): string
+    {
+        return 'task:updated';
+    }
+}

--- a/src/Domain/Task/Handler/UpdateHandler.php
+++ b/src/Domain/Task/Handler/UpdateHandler.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace AppBundle\Domain\Task\Handler;
+
+use AppBundle\Domain\Task\Command\Update;
+use AppBundle\Domain\Task\Event;
+use SimpleBus\Message\Recorder\RecordsMessages;
+
+class UpdateHandler
+{
+    private $eventRecorder;
+
+    public function __construct(RecordsMessages $eventRecorder)
+    {
+        $this->eventRecorder = $eventRecorder;
+    }
+
+    public function __invoke(Update $command)
+    {
+        $task = $command->getTask();
+
+        $this->eventRecorder->record(new Event\TaskUpdated($task));
+
+    }
+}

--- a/src/Domain/Task/Reactor/NotifyUrbantz.php
+++ b/src/Domain/Task/Reactor/NotifyUrbantz.php
@@ -24,7 +24,7 @@ class NotifyUrbantz
 
     public function __construct(
         HttpClientInterface $urbantzClient,
-        EntityManagerInterface $entityManager,
+        private EntityManagerInterface $entityManager,
         string $secret,
         LoggerInterface $logger = null)
     {

--- a/src/Domain/Task/Reactor/TriggerWebhook.php
+++ b/src/Domain/Task/Reactor/TriggerWebhook.php
@@ -12,18 +12,11 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 class TriggerWebhook
 {
-    private $messageBus;
-    private $iriConverter;
-
     public function __construct(
-        MessageBusInterface $messageBus,
-        IriConverterInterface $iriConverter,
-        EntityManagerInterface $entityManager)
-    {
-        $this->messageBus = $messageBus;
-        $this->iriConverter = $iriConverter;
-        $this->entityManager = $entityManager;
-    }
+        private MessageBusInterface $messageBus,
+        private IriConverterInterface $iriConverter,
+        private EntityManagerInterface $entityManager)
+    {}
 
     public function __invoke(Event $event)
     {
@@ -100,4 +93,3 @@ class TriggerWebhook
         return '';
     }
 }
-

--- a/src/Entity/Delivery.php
+++ b/src/Entity/Delivery.php
@@ -188,8 +188,12 @@ class Delivery extends TaskCollection implements TaskCollectionInterface, Packag
     public function addTask(Task $task, $position = null)
     {
         $task->setDelivery($this);
+        $taskCollection = parent::addTask($task, $position);
 
-        return parent::addTask($task, $position);
+        $deliveryPosition = $taskCollection->findTaskPosition($task);
+        $task->setMetadata('delivery_position', $deliveryPosition);
+
+        return $taskCollection;
     }
 
 

--- a/src/Entity/Delivery.php
+++ b/src/Entity/Delivery.php
@@ -191,7 +191,7 @@ class Delivery extends TaskCollection implements TaskCollectionInterface, Packag
         $taskCollection = parent::addTask($task, $position);
 
         $deliveryPosition = $taskCollection->findTaskPosition($task);
-        $task->setMetadata('delivery_position', $deliveryPosition);
+        $task->setMetadata('delivery_position', $deliveryPosition + 1); // we prefer it to be 1-indexed for user display
 
         return $taskCollection;
     }

--- a/src/Entity/TaskCollection.php
+++ b/src/Entity/TaskCollection.php
@@ -207,6 +207,17 @@ abstract class TaskCollection
         }
     }
 
+    /**
+     * Find task position in the collection
+     */
+    public function findTaskPosition(Task $task) {
+        foreach ($this->getItems() as $item) {
+            if ($item->getTask() === $task) {
+                return $item->getPosition();
+            }
+        }
+    }
+
     public function getTasksByType(string $type)
     {
         return $this->getItems()

--- a/src/Service/ActivityManager.php
+++ b/src/Service/ActivityManager.php
@@ -5,8 +5,6 @@ namespace AppBundle\Service;
 use AppBundle\Domain\HasIconInterface;
 use AppBundle\Domain\Order\Event as OrderEvents;
 use AppBundle\Domain\Task\Event as TaskEvents;
-use AppBundle\Entity\TaskEvent;
-use AppBundle\Entity\Sylius\OrderEvent;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Type;
@@ -25,6 +23,7 @@ class ActivityManager
         OrderEvents\OrderDropped::class,
         OrderEvents\OrderFulfilled::class,
         TaskEvents\TaskCreated::class,
+        TaskEvents\TaskUpdated::class,
         TaskEvents\TaskAssigned::class,
         TaskEvents\TaskUnassigned::class,
         TaskEvents\TaskStarted::class,

--- a/src/Service/TaskManager.php
+++ b/src/Service/TaskManager.php
@@ -4,6 +4,7 @@ namespace AppBundle\Service;
 
 use AppBundle\Domain\Task\Command\AddToGroup;
 use AppBundle\Domain\Task\Command\Cancel;
+use AppBundle\Domain\Task\Command\Update;
 use AppBundle\Domain\Task\Command\DeleteGroup;
 use AppBundle\Domain\Task\Command\Incident;
 use AppBundle\Domain\Task\Command\MarkAsDone;
@@ -58,6 +59,11 @@ class TaskManager
     public function start(Task $task)
     {
         $this->commandBus->handle(new Start($task));
+    }
+
+    public function update(Task $task)
+    {
+        $this->commandBus->handle(new Update($task));
     }
 
     public function restore(Task $task)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b6f433d1-9a26-45a3-a601-3dea2ecd02a8)

I added the `TaskUpdated` event before I needed to update the task data in the dispatch when the order number was finally set (the task is added before on `TaskCreated` event)