### PR TITLE
Allow reporting zero waste incidents

### DIFF
--- a/app/DoctrineMigrations/Version20241009072602.php
+++ b/app/DoctrineMigrations/Version20241009072602.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20241009072602 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE incident ADD metadata JSON DEFAULT NULL');
+        $this->addSql('UPDATE incident SET metadata = \'[]\'');
+        $this->addSql('ALTER TABLE incident ALTER COLUMN metadata SET NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE incident DROP metadata');
+    }
+}

--- a/app/config/message_bus/task.yml
+++ b/app/config/message_bus/task.yml
@@ -191,3 +191,12 @@ services:
         subscribes_to: task:done
       - name: event_subscriber
         subscribes_to: task:failed
+
+  coopcycle.domain.task.reactor.notify_loopeat:
+    class: AppBundle\Domain\Task\Reactor\NotifyLoopeat
+    arguments:
+      - '@AppBundle\LoopEat\Client'
+      - '@monolog.logger.loopeat'
+    tags:
+      - name: event_subscriber
+        subscribes_to: task:incident-reported

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -894,6 +894,14 @@ services:
       $country: "%country_iso%"
       $locale: '%env(COOPCYCLE_LOCALE)%'
 
+  AppBundle\Incident\LoopeatFailureReasonsResolver: ~
+
+  AppBundle\Action\Task\FailureReasons:
+    public: true
+    arguments:
+      $failureReasonsResolvers:
+        - '@AppBundle\Incident\LoopeatFailureReasonsResolver'
+
   AppBundle\EventListener\RestaurantFilterConfigurator:
     tags:
       - { name: kernel.event_listener, event: kernel.request, priority: 5 }

--- a/features/tasks.feature
+++ b/features/tasks.feature
@@ -882,7 +882,11 @@ Feature: Tasks
       {
         "description": "PACKAGE WET",
         "failureReasonCode": "DAMAGED",
-        "task": "/api/tasks/2"
+        "task": "/api/tasks/2",
+        "metadata": [
+          {"foo":"bar"},
+          {"baz":"bat"}
+        ]
       }
       """
     Then the response status code should be 201
@@ -904,7 +908,11 @@ Feature: Tasks
         "createdBy":"/api/users/1",
         "createdAt":"@string@.isDateTime()",
         "updatedAt":"@string@.isDateTime()",
-        "tags":[]
+        "tags":[],
+        "metadata": [
+          {"foo": "bar"},
+          {"baz": "bat"}
+        ]
       }
       """
 

--- a/features/tasks.feature
+++ b/features/tasks.feature
@@ -882,6 +882,50 @@ Feature: Tasks
       {
         "description": "PACKAGE WET",
         "failureReasonCode": "DAMAGED",
+        "task": "/api/tasks/2"
+      }
+      """
+    Then the response status code should be 201
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context":"/api/contexts/Incident",
+        "@id":"@string@",
+        "@type":"Incident",
+        "title":"Endommagé",
+        "status":"OPEN",
+        "priority":@integer@,
+        "task":"/api/tasks/2",
+        "failureReasonCode":"DAMAGED",
+        "description":"PACKAGE WET",
+        "images":[],
+        "events":[],
+        "createdBy":"/api/users/1",
+        "createdAt":"@string@.isDateTime()",
+        "updatedAt":"@string@.isDateTime()",
+        "tags":[],
+        "metadata": []
+      }
+      """
+
+  Scenario: Report incident (with metadata)
+    Given the fixtures files are loaded:
+      | sylius_channels.yml |
+      | tasks.yml           |
+    And the courier "bob" is loaded:
+      | email     | bob@coopcycle.org |
+      | password  | 123456            |
+      | telephone | 0033612345678     |
+    And the user "bob" is authenticated
+    And the tasks with comments matching "#bob" are assigned to "bob"
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "POST" request to "/api/incidents" with body:
+      """
+      {
+        "description": "PACKAGE WET",
+        "failureReasonCode": "DAMAGED",
         "task": "/api/tasks/2",
         "metadata": [
           {"foo":"bar"},
@@ -910,8 +954,8 @@ Feature: Tasks
         "updatedAt":"@string@.isDateTime()",
         "tags":[],
         "metadata": [
-          {"foo": "bar"},
-          {"baz": "bat"}
+          {"foo":"bar"},
+          {"baz":"bat"}
         ]
       }
       """

--- a/src/Action/Incident/CreateIncident.php
+++ b/src/Action/Incident/CreateIncident.php
@@ -58,7 +58,8 @@ class CreateIncident
             $data->getDescription(),
             [
                 'incident_id' => $data->getId()
-            ]
+            ],
+            $data
         );
 
         return $data;

--- a/src/Action/Task/FailureReasons.php
+++ b/src/Action/Task/FailureReasons.php
@@ -16,13 +16,22 @@ class FailureReasons
 {
     public function __construct(
         private EntityManagerInterface $em,
-        private FailureReasonRegistry $failureReasonRegistry
+        private FailureReasonRegistry $failureReasonRegistry,
+        private array $failureReasonsResolvers
     )
     { }
 
     private function getDefaultReasons(Task $task): array
     {
-        return $this->failureReasonRegistry->getFailureReasons();
+        $reasons = $this->failureReasonRegistry->getFailureReasons();
+
+        foreach ($this->failureReasonsResolvers as $failureReasonsResolver) {
+            if ($failureReasonsResolver->supports($task)) {
+                $reasons = array_merge($reasons, $failureReasonsResolver->getFailureReasons($task));
+            }
+        }
+
+        return $reasons;
     }
 
     private function getFailureReasons(

--- a/src/Domain/Task/Command/Incident.php
+++ b/src/Domain/Task/Command/Incident.php
@@ -2,6 +2,7 @@
 
 namespace AppBundle\Domain\Task\Command;
 
+use AppBundle\Entity\Incident\Incident as IncidentObject;
 use AppBundle\Entity\Task;
 
 class Incident
@@ -10,7 +11,8 @@ class Incident
         private Task $task,
         private string $reason,
         private ?string $notes = null,
-        private array $data = []
+        private array $data = [],
+        private ?IncidentObject $incident = null
    )
     { }
 
@@ -32,6 +34,11 @@ class Incident
     public function getData(): array
     {
         return $this->data;
+    }
+
+    public function getIncident(): ?IncidentObject
+    {
+        return $this->incident;
     }
 }
 

--- a/src/Domain/Task/Event/TaskIncidentReported.php
+++ b/src/Domain/Task/Event/TaskIncidentReported.php
@@ -5,6 +5,7 @@ namespace AppBundle\Domain\Task\Event;
 use AppBundle\Domain\DomainEvent;
 use AppBundle\Domain\HasIconInterface;
 use AppBundle\Domain\Task\Event;
+use AppBundle\Entity\Incident\Incident;
 use AppBundle\Entity\Task;
 
 class TaskIncidentReported extends Event implements DomainEvent, HasIconInterface
@@ -14,7 +15,8 @@ class TaskIncidentReported extends Event implements DomainEvent, HasIconInterfac
         Task $task,
         private string $reason,
         private ?string $notes = null,
-        private array $data = []
+        private array $data = [],
+        private ?Incident $incident = null
     )
     {
         parent::__construct($task);
@@ -36,5 +38,15 @@ class TaskIncidentReported extends Event implements DomainEvent, HasIconInterfac
     public static function iconName()
     {
         return 'exclamation-circle';
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    public function getIncident(): ?Incident
+    {
+        return $this->incident;
     }
 }

--- a/src/Domain/Task/Handler/IncidentHandler.php
+++ b/src/Domain/Task/Handler/IncidentHandler.php
@@ -20,7 +20,8 @@ class IncidentHandler
         $reason = $command->getReason();
         $notes = $command->getNotes();
         $data = $command->getData();
+        $incident = $command->getIncident();
 
-        $this->eventRecorder->record(new Event\TaskIncidentReported($task, $reason, $notes, $data));
+        $this->eventRecorder->record(new Event\TaskIncidentReported($task, $reason, $notes, $data, $incident));
     }
 }

--- a/src/Domain/Task/Reactor/NotifyLoopeat.php
+++ b/src/Domain/Task/Reactor/NotifyLoopeat.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace AppBundle\Domain\Task\Reactor;
+
+use AppBundle\Domain\Task\Event\TaskIncidentReported;
+use AppBundle\LoopEat\Client as LoopeatClient;
+use Psr\Log\LoggerInterface;
+
+class NotifyLoopeat
+{
+    public function __construct(
+        private LoopEatClient $loopeatClient,
+        private LoggerInterface $logger)
+    {
+    }
+
+    public function __invoke(TaskIncidentReported $event)
+    {
+        $task = $event->getTask();
+
+        if (!$task->isDropoff()) {
+            return;
+        }
+
+        $reason = $event->getReason();
+
+        if ($reason !== 'zero_waste_unexpected_returns') {
+            return;
+        }
+
+        $incident = $event->getIncident();
+
+        if (null === $incident) {
+            return;
+        }
+
+        $metadata = $incident->getMetadata();
+
+        $this->logger->info(
+            sprintf('An incident for unexpected returns was reported with metadata "%s"', json_encode($metadata))
+        );
+
+        if (array_key_exists('loopeat_returns', $metadata)) {
+            foreach ($metadata['loopeat_returns'] as $return) {
+                // TODO Check if there is a change in what has been sent to avoid useless API calls
+                $this->loopeatClient->updatePickupFormat($task->getDelivery()->getOrder(), $return['format_id'], $return['quantity']);
+            }
+        }
+    }
+}

--- a/src/Entity/Incident/Incident.php
+++ b/src/Entity/Incident/Incident.php
@@ -110,6 +110,10 @@ class Incident implements TaggableInterface {
      */
     protected ?User $createdBy = null;
 
+    /**
+     * @Groups({"incident"})
+     */
+    protected array $metadata = [];
 
     /**
      * @Groups({"incident"})
@@ -218,6 +222,16 @@ class Incident implements TaggableInterface {
     public function setCreatedBy(?User $created_by): self {
         $this->createdBy = $created_by;
         return $this;
+    }
+
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+
+    public function setMetadata(array $metadata)
+    {
+        $this->metadata = $metadata;
     }
 
     public function getCreatedAt(): mixed {

--- a/src/Entity/Sylius/Order.php
+++ b/src/Entity/Sylius/Order.php
@@ -47,6 +47,7 @@ use AppBundle\Entity\BusinessAccount;
 use AppBundle\Entity\Delivery;
 use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\LoopEat\OrderCredentials;
+use AppBundle\Entity\ReusablePackaging;
 use AppBundle\Entity\Task\RecurrenceRule;
 use AppBundle\Entity\Vendor;
 use AppBundle\Filter\OrderDateFilter;
@@ -1921,5 +1922,21 @@ class Order extends BaseOrder implements OrderInterface
         }
 
         return false;
+    }
+
+    public function getLoopeatFormatById(int $formatId): ?array
+    {
+        $reusablePackagings = $this->getRestaurant()->getReusablePackagings();
+
+        foreach ($reusablePackagings as $reusablePackaging) {
+            if (ReusablePackaging::TYPE_LOOPEAT === $reusablePackaging->getType()) {
+                $data = $reusablePackaging->getData();
+                if ($data['id'] === $formatId) {
+                    return $data;
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Incident/FailureReasonsResolverInterface.php
+++ b/src/Incident/FailureReasonsResolverInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AppBundle\Incident;
+
+use AppBundle\Entity\Task;
+
+interface FailureReasonsResolverInterface
+{
+    public function supports(Task $task): bool;
+
+    public function getFailureReasons(Task $task): array;
+}

--- a/src/Incident/LoopeatFailureReasonsResolver.php
+++ b/src/Incident/LoopeatFailureReasonsResolver.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace AppBundle\Incident;
+
+use AppBundle\Entity\Task;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+class LoopeatFailureReasonsResolver implements FailureReasonsResolverInterface
+{
+    public function __construct(private TranslatorInterface $translator)
+    {}
+
+    public function supports(Task $task): bool
+    {
+        if ($task->isDropoff()) {
+            if (null !== $delivery = $task->getDelivery()) {
+                if (null !== $order = $delivery->getOrder()) {
+
+                    return $order->hasLoopeatReturns();
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public function getFailureReasons(Task $task): array
+    {
+        $order = $task->getDelivery()->getOrder();
+
+        $metadata = [];
+        foreach ($order->getLoopeatReturns() as $i => $return) {
+            $format = $order->getLoopeatFormatById($return['format_id']);
+            if ($format) {
+                $metadata[] = [
+                    'type' => 'hidden',
+                    'name' => "loopeat_returns[{$i}][format_id]",
+                    'value' => $return['format_id'],
+                ];
+                $metadata[] = [
+                    'type' => 'number',
+                    'name' => "loopeat_returns[{$i}][quantity]",
+                    'value' => $return['quantity'],
+                    'label' => $format['title'],
+                ];
+            }
+        }
+
+        return [
+            [
+                'code' => 'zero_waste_unexpected_returns',
+                'description' => $this->translator->trans('loopeat.incident.unexpected_returns'),
+                'metadata' => $metadata,
+            ]
+        ];
+    }
+}

--- a/src/LoopEat/Client.php
+++ b/src/LoopEat/Client.php
@@ -420,7 +420,7 @@ class Client
 
     public function updateDeliverFormats(OrderInterface $order)
     {
-        $this->logger->info(sprintf('Updating formats for order "%s", with id "%s"', $order->getNumber(), $order->getLoopeatOrderId()));
+        $this->logger->info(sprintf('Updating "deliver" formats for order "%s", with id "%s"', $order->getNumber(), $order->getLoopeatOrderId()));
 
         $response = $this->client->request('GET', sprintf('/api/v1/partners/orders/%s/formats', $order->getLoopeatOrderId()), [
             'headers' => [
@@ -446,7 +446,7 @@ class Client
 
                 try {
 
-                    $this->logger->info(sprintf('Updating formats for order "%s", setting format "%s" quantity to "%s"',
+                    $this->logger->info(sprintf('Updating "deliver" formats for order "%s", setting format "%s" quantity to "%s"',
                         $order->getNumber(), $format['format_id'], $format['quantity']));
 
                     $restaurant = $order->getRestaurant();
@@ -495,6 +495,53 @@ class Client
         } catch (RequestException $e) {
             $this->logger->error($e->getMessage());
             return false;
+        }
+    }
+
+    public function updatePickupFormat(OrderInterface $order, $formatId, $quantity)
+    {
+        $this->logger->info(sprintf('Updating "pickup" formats for order "%s", with id "%s"', $order->getNumber(), $order->getLoopeatOrderId()));
+
+        $response = $this->client->request('GET', sprintf('/api/v1/partners/orders/%s/formats', $order->getLoopeatOrderId()), [
+            'headers' => [
+                'Authorization' => sprintf('Basic %s', $this->getPartnerToken())
+            ],
+        ]);
+
+        $res = json_decode((string) $response->getBody(), true);
+
+        $orderFormats = $res['data'];
+
+        $getOrderFormatId = function($formatId) use ($orderFormats) {
+            foreach ($orderFormats as $orderFormat) {
+                if ($orderFormat['act'] === 'pickup' && (int) $orderFormat['details']['id'] === (int) $formatId) {
+                    return $orderFormat['id'];
+                }
+            }
+        };
+
+        try {
+
+            $this->logger->info(sprintf('Updating "pickup" formats for order "%s", setting format "%s" quantity to "%s"',
+                $order->getNumber(), $formatId, $quantity));
+
+            $url = sprintf('/api/v1/partners/orders/%s/formats/%s', $order->getLoopeatOrderId(), $getOrderFormatId($formatId));
+
+            $response = $this->client->request('PATCH', $url, [
+                'headers' => [
+                    'Authorization' => sprintf('Basic %s', $this->getPartnerToken())
+                ],
+                'json' => [
+                    'order_format' => [
+                        'quantity' => $quantity,
+                    ]
+                ],
+            ]);
+
+            $res = json_decode((string) $response->getBody(), true);
+
+        } catch (RequestException $e) {
+            $this->logger->error($e->getMessage());
         }
     }
 }

--- a/src/Resources/config/doctrine/Incident.Incident.orm.xml
+++ b/src/Resources/config/doctrine/Incident.Incident.orm.xml
@@ -9,6 +9,7 @@
     <field name="priority" type="integer" column="priority" />
     <field name="failureReasonCode" type="string" column="failure_reason_code" length="32" nullable="true" />
     <field name="description" type="string" column="description" length="65535" nullable="true" />
+    <field name="metadata" type="json" column="metadata"/>
     <field name="createdAt" type="datetime" column="created_at">
       <gedmo:timestampable on="create"/>
       </field>

--- a/src/Service/TaskManager.php
+++ b/src/Service/TaskManager.php
@@ -6,13 +6,14 @@ use AppBundle\Domain\Task\Command\AddToGroup;
 use AppBundle\Domain\Task\Command\Cancel;
 use AppBundle\Domain\Task\Command\Update;
 use AppBundle\Domain\Task\Command\DeleteGroup;
-use AppBundle\Domain\Task\Command\Incident;
+use AppBundle\Domain\Task\Command\Incident as IncidentCommand;
 use AppBundle\Domain\Task\Command\MarkAsDone;
 use AppBundle\Domain\Task\Command\MarkAsFailed;
 use AppBundle\Domain\Task\Command\RemoveFromGroup;
 use AppBundle\Domain\Task\Command\Reschedule;
 use AppBundle\Domain\Task\Command\Restore;
 use AppBundle\Domain\Task\Command\Start;
+use AppBundle\Entity\Incident\Incident;
 use AppBundle\Entity\Task;
 use AppBundle\Entity\Task\Group as TaskGroup;
 use SimpleBus\SymfonyBridge\Bus\CommandBus;
@@ -75,8 +76,8 @@ class TaskManager
         $this->commandBus->handle(new Reschedule($task, $rescheduledAfter, $rescheduledBefore));
     }
 
-    public function incident(Task $task, string $reason, ?string $notes = null, array $data = []): void
+    public function incident(Task $task, string $reason, ?string $notes = null, array $data = [], Incident $incident = null): void
     {
-        $this->commandBus->handle(new Incident($task, $reason, $notes, $data));
+        $this->commandBus->handle(new IncidentCommand($task, $reason, $notes, $data, $incident));
     }
 }

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1624,3 +1624,4 @@ order.export.heading.applied_billing: Applied billing
 deliveries.import_upload_error: The file couldn't be uploaded. Please try again later.
 organizations.breadcrumb: Organizations
 organizations.new: New organization
+loopeat.incident.unexpected_returns: Unexpected number of zero waste returns


### PR DESCRIPTION
This pull request introduces a way to add dynamic failure reasons (via classes implementing `FailureReasonsResolverInterface`). 

Also, it uses the `metadata` property of a `FailureReason` to describe additional form fields that should be attached to an incident. In this case, the form fields will allow describing how many zero waste containers have been returned by the customer. 

Finally, it adds a `metadata` property to the `Incident` class, to allow storing the form data. 