### PR TITLE
Add security token that allow a rider to use assign/unassign

### DIFF
--- a/src/Action/Task/Assign.php
+++ b/src/Action/Task/Assign.php
@@ -33,6 +33,6 @@ class Assign extends Base
             $payload = json_decode($content, true);
         }
 
-        return $this->assign($task, $payload);
+        return $this->assign($task, $payload, $request);
     }
 }

--- a/src/Action/Task/AssignTrait.php
+++ b/src/Action/Task/AssignTrait.php
@@ -4,11 +4,13 @@ namespace AppBundle\Action\Task;
 
 use ApiPlatform\Core\Exception\ItemNotFoundException;
 use AppBundle\Entity\Task;
+use AppBundle\Utils\Barcode\BarcodeUtils;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 trait AssignTrait
 {
-    protected function assign(Task $task, $payload)
+    protected function assign(Task $task, $payload, ?Request $request = null)
     {
         $user = $this->getUser();
         if (isset($payload['username'])) {
@@ -21,7 +23,12 @@ trait AssignTrait
                     $payload['username']));
             }
         }
-        if (!$this->authorization->isGranted('ROLE_DISPATCHER') && $task->isAssigned()) {
+
+
+        if (
+            $task->isAssigned() &&
+            !($this->authorization->isGranted('ROLE_DISPATCHER') || $this->isTokenActionValid($task, $request))
+        ) {
 
             throw new BadRequestHttpException(sprintf('Task #%d is already assigned to "%s"',
                 $task->getId(), $task->getAssignedCourier()->getUsername()));
@@ -39,5 +46,14 @@ trait AssignTrait
         }
 
         return $task;
+    }
+
+    private function isTokenActionValid(Task $task, ?Request $request): bool
+    {
+        if (is_null($request)) {
+            return false;
+        }
+        return $request->headers->get('X-Token-Action') ===
+            hash('xxh3', BarcodeUtils::getToken(sprintf("/api/tasks/%d", $task->getId())));
     }
 }

--- a/src/Action/Task/BulkAssign.php
+++ b/src/Action/Task/BulkAssign.php
@@ -41,7 +41,7 @@ class BulkAssign extends Base
 
         foreach($tasks as $task) {
             $taskObj = $this->iriConverter->getItemFromIri($task);
-            $tasksResults[] = $this->assign($taskObj, $payload);
+            $tasksResults[] = $this->assign($taskObj, $payload, $request);
         }
 
         $this->entityManager->flush();

--- a/src/Controller/BarcodeController.php
+++ b/src/Controller/BarcodeController.php
@@ -69,6 +69,20 @@ class BarcodeController extends AbstractController
         return $this->json([
             "ressource" => $iri,
             "client_action" => $clientAction,
+
+            /**
+             * The action_token enables temporary elevated permissions for couriers.
+             * It allows specific actions (like self-assignment) on the scanned task only.
+             *
+             * Generation:
+             * - Uses BarcodeUtils::getToken/1 to get the label's token
+             * - Hashes it with xxh3 algorithm for additional security
+             * - Uses runtime secret key to prevent token guessing
+             *
+             * Security:
+             * - Scoped to single task (token invalid for other tasks)
+             * - Cannot be forged without access to runtime secret
+             */
             "token_action" => hash('xxh3', BarcodeUtils::getToken($iri)),
             "entity" => $normalizer->normalize($task, null, [
                 'groups' => ['task', 'delivery', 'package', 'address', 'barcode']

--- a/src/Controller/BarcodeController.php
+++ b/src/Controller/BarcodeController.php
@@ -65,9 +65,11 @@ class BarcodeController extends AbstractController
         $this->taskManager->scan($task);
         $this->doctrine->getManager()->flush();
 
+        $iri = $iriConverter->getIriFromItem($task);
         return $this->json([
-            "ressource" => $iriConverter->getIriFromItem($task),
+            "ressource" => $iri,
             "client_action" => $clientAction,
+            "token_action" => hash('xxh3', BarcodeUtils::getToken($iri)),
             "entity" => $normalizer->normalize($task, null, [
                 'groups' => ['task', 'delivery', 'package', 'address', 'barcode']
             ])
@@ -105,7 +107,7 @@ class BarcodeController extends AbstractController
 
         // If the task is not assigned to the current user, we should prompt the user to self-assign
         if ($task->isAssigned()) {
-            return 'ask_to_unassign';
+            return 'ask_to_assign';
         }
 
         return null;


### PR DESCRIPTION
The action_token enables temporary elevated permissions for couriers.
It allows specific actions (like self-assignment) on the scanned task only.

Generation:
- Uses BarcodeUtils::getToken/1 to get the label's token
- Hashes it with xxh3 algorithm for additional security
- Uses runtime secret key to prevent token guessing

Security:
- Scoped to single task (token invalid for other tasks)
- Cannot be forged without access to runtime secret
