### PR TITLE
Serialize labels as part of task packages

### DIFF
--- a/features/deliveries.feature
+++ b/features/deliveries.feature
@@ -144,7 +144,7 @@ Feature: Deliveries
           "@type":"Task",
           "id":@integer@,
           "status":"TODO",
-          "type": "DROPOFF",
+          "type":"DROPOFF",
           "address":{
             "@id":"@string@.startsWith('/api/addresses')",
             "@type":"http://schema.org/Place",

--- a/features/deliveries.feature
+++ b/features/deliveries.feature
@@ -169,7 +169,6 @@ Feature: Deliveries
           "barcode":{"@*@":"@*@"},
           "createdAt":"@string@.isDateTime()"
         },
-        "tasks": @array@,
         "trackingUrl": @string@
       }
       """
@@ -419,7 +418,6 @@ Feature: Deliveries
           "barcode": {"@*@":"@*@"},
           "createdAt":"@string@.isDateTime()"
         },
-        "tasks": @array@,
         "trackingUrl": @string@
       }
       """

--- a/features/deliveries.feature
+++ b/features/deliveries.feature
@@ -144,7 +144,7 @@ Feature: Deliveries
           "@type":"Task",
           "id":@integer@,
           "status":"TODO",
-          "type":"DROPOFF",
+          "type": "DROPOFF",
           "address":{
             "@id":"@string@.startsWith('/api/addresses')",
             "@type":"http://schema.org/Place",
@@ -169,6 +169,7 @@ Feature: Deliveries
           "barcode":{"@*@":"@*@"},
           "createdAt":"@string@.isDateTime()"
         },
+        "tasks": @array@,
         "trackingUrl": @string@
       }
       """
@@ -372,7 +373,8 @@ Feature: Deliveries
               "name": "XL",
               "quantity": 2,
               "volume_per_package": 3,
-              "short_code": "AB"
+              "short_code": "AB",
+              "labels": @array@
             }
           ],
           "barcode": {"@*@":"@*@"},
@@ -410,12 +412,14 @@ Feature: Deliveries
               "name": "XL",
               "quantity": 2,
               "volume_per_package": 3,
-              "short_code": "AB"
+              "short_code": "AB",
+              "labels": @array@
             }
           ],
           "barcode": {"@*@":"@*@"},
           "createdAt":"@string@.isDateTime()"
         },
+        "tasks": @array@,
         "trackingUrl": @string@
       }
       """

--- a/features/deliveries_multi.feature
+++ b/features/deliveries_multi.feature
@@ -186,7 +186,8 @@ Feature: Multi-step deliveries
               "name":"XL",
               "quantity":4,
               "volume_per_package": 3,
-              "short_code": "AB"
+              "short_code": "AB",
+              "labels":@array@
             }
           ],
           "barcode": @array@,
@@ -224,7 +225,8 @@ Feature: Multi-step deliveries
               "name":"XL",
               "quantity":2,
               "volume_per_package": 3,
-              "short_code": "AB"
+              "short_code": "AB",
+              "labels":@array@
             }
           ],
           "barcode": @array@,
@@ -313,7 +315,8 @@ Feature: Multi-step deliveries
               "name":"XL",
               "quantity":2,
               "volume_per_package": 3,
-              "short_code": "AB"
+              "short_code": "AB",
+              "labels":@array@
             }
           ],
           "barcode": @array@,
@@ -351,7 +354,8 @@ Feature: Multi-step deliveries
               "name":"XL",
               "quantity":2,
               "volume_per_package": 3,
-              "short_code": "AB"
+              "short_code": "AB",
+              "labels":@array@
             }
           ],
           "barcode": @array@,
@@ -438,7 +442,8 @@ Feature: Multi-step deliveries
               "name":"XL",
               "quantity":2,
               "volume_per_package": 3,
-              "short_code": "AB"
+              "short_code": "AB",
+              "labels":@array@
             }
           ],
           "barcode": @array@,
@@ -476,7 +481,8 @@ Feature: Multi-step deliveries
               "name":"XL",
               "quantity":2,
               "volume_per_package": 3,
-              "short_code": "AB"
+              "short_code": "AB",
+              "labels":@array@
             }
           ],
           "barcode": @array@,

--- a/features/dispatch.feature
+++ b/features/dispatch.feature
@@ -169,7 +169,8 @@ Feature: Dispatch
         "orgName": @string@,
         "images": @array@,
         "hasIncidents": @boolean@,
-        "barcode": @array@
+        "barcode": @array@,
+        "packages": @array@
       }
       """
 

--- a/features/tasks.feature
+++ b/features/tasks.feature
@@ -2405,11 +2405,12 @@ Feature: Tasks
       {
          "packages":[
             {
-               "type":"SMALL",
-               "name":"SMALL",
-               "quantity":4,
-               "volume_per_package": 1,
-               "short_code": "AB"
+              "type":"SMALL",
+              "name":"SMALL",
+              "quantity":4,
+              "volume_per_package": 1,
+              "short_code": "AB",
+              "labels":@array@
             }
          ],
          "@*@": "@*@"

--- a/src/Action/Task/Collection.php
+++ b/src/Action/Task/Collection.php
@@ -16,9 +16,9 @@ class Collection extends Base
                 case
                     WHEN t_outer.delivery_id is not null and t_outer.type = 'PICKUP' THEN
                         (select json_agg(json_build_object(
-                            'name', packages_rows.name, 'type', packages_rows.name, 'quantity', packages_rows.quantity, 'volume_per_package', packages_rows.volume_units, 'short_code', packages_rows.short_code))
+                            'id', 'name', packages_rows.name, 'type', packages_rows.name, 'quantity', packages_rows.quantity, 'volume_per_package', packages_rows.volume_units, 'short_code', packages_rows.short_code))
                             FROM
-                                (select p.name AS name, p.average_volume_units AS volume_units, p.short_code as short_code, sum(tp.quantity) AS quantity
+                                (select p.id, p.name AS name, p.average_volume_units AS volume_units, p.short_code as short_code, sum(tp.quantity) AS quantity
                                     from task t inner join task_package tp on tp.task_id = t.id
                                     inner join package p on tp.package_id = p.id
                                     where t.delivery_id = t_outer.delivery_id
@@ -26,9 +26,9 @@ class Collection extends Base
                                 ) packages_rows)
                     WHEN t_outer.type = 'DROPOFF' THEN
                         (select json_agg(json_build_object(
-                            'name', packages_rows.name, 'type', packages_rows.name, 'quantity', packages_rows.quantity, 'volume_per_package', packages_rows.volume_units, 'short_code', packages_rows.short_code))
+                            'id', 'name', packages_rows.name, 'type', packages_rows.name, 'quantity', packages_rows.quantity, 'volume_per_package', packages_rows.volume_units, 'short_code', packages_rows.short_code))
                             FROM
-                                (select p.name AS name, p.average_volume_units AS volume_units, p.short_code as short_code, sum(tp.quantity) AS quantity
+                                (select p.id, p.name AS name, p.average_volume_units AS volume_units, p.short_code as short_code, sum(tp.quantity) AS quantity
                                     from task t inner join task_package tp on tp.task_id = t.id
                                     inner join package p on tp.package_id = p.id
                                     where t.id = t_outer.id

--- a/src/Serializer/TaskNormalizer.php
+++ b/src/Serializer/TaskNormalizer.php
@@ -105,7 +105,7 @@ class TaskNormalizer implements NormalizerInterface, DenormalizerInterface
                     ->createQueryBuilder('t');
 
                 $query = $qb
-                    ->select('p.name AS name', 'p.name AS type', 'sum(tp.quantity) AS quantity', 'p.averageVolumeUnits AS volume_per_package', 'p.shortCode AS short_code')
+                    ->select('p.id', 'p.name AS name', 'p.name AS type', 'sum(tp.quantity) AS quantity', 'p.averageVolumeUnits AS volume_per_package', 'p.shortCode AS short_code')
                     ->join('t.packages', 'tp', 'WITH', 'tp.task = t.id')
                     ->join('tp.package', 'p', 'WITH', 'tp.package = p.id')
                     ->join('t.delivery', 'd', 'WITH', 'd.id = :deliveryId')
@@ -128,18 +128,38 @@ class TaskNormalizer implements NormalizerInterface, DenormalizerInterface
                     ->getResult()[0]["1"];
             }
         } else {
+
             $qb =  $this->entityManager
                 ->getRepository(Task::class)
                 ->createQueryBuilder('t');
 
             $data['packages'] = $qb
-                ->select('p.name AS name', 'p.name AS type', 'tp.quantity AS quantity', 'p.averageVolumeUnits AS volume_per_package', 'p.shortCode AS short_code')
+                ->select('p.id', 'p.name AS name', 'p.name AS type', 'tp.quantity AS quantity', 'p.averageVolumeUnits AS volume_per_package', 'p.shortCode AS short_code')
                 ->join('t.packages', 'tp', 'WITH', 'tp.task = t.id')
                 ->join('tp.package', 'p', 'WITH', 'tp.package = p.id')
                 ->andWhere('t.id = :taskId')
                 ->setParameter('taskId', $object->getId())
                 ->getQuery()
                 ->getResult();
+        }
+
+        // Add labels
+
+        foreach ($data['packages'] as $i => $p) {
+
+            $data['packages'][$i]['labels'] = [];
+
+            $barcodes = BarcodeUtils::getBarcodesFromTaskAndPackageIds($object->getId(), $p['id'], $p['quantity']);
+            foreach ($barcodes as $barcode) {
+                $labelUrl = $this->urlGenerator->generate(
+                    'task_label_pdf',
+                    ['code' => $barcode, 'token' => BarcodeUtils::getToken($barcode)],
+                    UrlGeneratorInterface::ABSOLUTE_URL
+                );
+                $data['packages'][$i]['labels'][] = $labelUrl;
+            }
+
+            unset($data['packages'][$i]['id']);
         }
 
         return $data;

--- a/src/Serializer/TaskNormalizer.php
+++ b/src/Serializer/TaskNormalizer.php
@@ -91,7 +91,6 @@ class TaskNormalizer implements NormalizerInterface, DenormalizerInterface
         ];
 
         $data['packages'] = [];
-        $data['weight'] = null;
 
         if (!is_null($object->getPrefetchedPackagesAndWeight())) {
             $data['packages'] = !is_null($object->getPrefetchedPackagesAndWeight()['packages']) ? $object->getPrefetchedPackagesAndWeight()['packages'] : [];

--- a/src/Serializer/TaskNormalizer.php
+++ b/src/Serializer/TaskNormalizer.php
@@ -90,10 +90,13 @@ class TaskNormalizer implements NormalizerInterface, DenormalizerInterface
             ]
         ];
 
+        $data['packages'] = [];
+        $data['weight'] = null;
+
         if (!is_null($object->getPrefetchedPackagesAndWeight())) {
             $data['packages'] = !is_null($object->getPrefetchedPackagesAndWeight()['packages']) ? $object->getPrefetchedPackagesAndWeight()['packages'] : [];
             $data['weight'] = $object->getPrefetchedPackagesAndWeight()['weight'];
-        } else if ($object->isPickup()) {
+        } elseif ($object->isPickup()) {
             // for a pickup in a delivery, the serialized weight is the sum of the dropoff weight and the packages are the "sum" of the dropoffs packages
             $delivery = $object->getDelivery();
 

--- a/src/Utils/Barcode/BarcodeUtils.php
+++ b/src/Utils/Barcode/BarcodeUtils.php
@@ -76,17 +76,7 @@ class BarcodeUtils {
         $taskId = $package->getTask()->getId();
         $packageId = $package->getId();
 
-        return array_map(
-            fn(int $index) => self::parse(sprintf(
-                self::WITH_PACKAGE,
-                1, // TODO: Dynamic instance
-                Barcode::TYPE_TASK,
-                $taskId,
-                $packageId,
-                $index + $start + 1
-            )),
-            range(0, $quantity - 1)
-        );
+        return self::getBarcodesFromTaskAndPackageIds($taskId, $packageId, $quantity, $start);
     }
 
 

--- a/src/Utils/Barcode/BarcodeUtils.php
+++ b/src/Utils/Barcode/BarcodeUtils.php
@@ -102,4 +102,24 @@ class BarcodeUtils {
 
         return hash('xxh3', sprintf("%s%s%s", self::$appName, self::$salt, $barcode));
     }
+
+    /**
+     * Returns a list of barcodes for a package.
+     * May return multiple barcodes for the same package when quantity is > 1.
+     * @return Barcode[]
+     */
+    public static function getBarcodesFromTaskAndPackageIds(int $taskId, int $packageId, int $quantity = 1, int $start = 0): array
+    {
+        return array_map(
+            fn(int $index) => self::parse(sprintf(
+                self::WITH_PACKAGE,
+                1, // TODO: Dynamic instance
+                Barcode::TYPE_TASK,
+                $taskId,
+                $packageId,
+                $index + $start + 1
+            )),
+            range(0, $quantity - 1)
+        );
+    }
 }


### PR DESCRIPTION
Fixes #4818

It's slightly better than having them at task level, but still, we only have an array of labels, and we don't know which label corresponds to which package when quantity is > 1. 