### PR TITLE
[PERTE-197] Allowing 'ROLE_DISPATCHER' to call 'GET /api/stores' endpoint

### DIFF
--- a/src/Entity/Store.php
+++ b/src/Entity/Store.php
@@ -42,7 +42,7 @@ use AppBundle\Action\Store\Packages as Packages;
  *   collectionOperations={
  *     "get"={
  *       "method"="GET",
- *       "access_control"="is_granted('ROLE_ADMIN')"
+ *       "access_control"="is_granted('ROLE_DISPATCHER')"
  *     },
  *     "me_stores"={
  *       "method"="GET",


### PR DESCRIPTION
### Issue: [#197](https://github.com/coopcycle/coopcycle/issues/197)
Related PR: https://github.com/coopcycle/coopcycle-app/pull/1949

We need to allow a dispatcher to call the endpoint to list all the stores.