### PR TITLE
[PERTE-197] Allowing 'ROLE_DISPATCHER' to call endpoints

### DIFF
--- a/cypress/fixtures/dispatch.yml
+++ b/cypress/fixtures/dispatch.yml
@@ -15,6 +15,17 @@ AppBundle\Entity\User:
     roles: [ 'ROLE_COURIER' ]
     telephone: <identity(\libphonenumber\PhoneNumberUtil::getInstance()->parse('+33612345678'))>
 
+  dispatcher_01:
+    __factory:
+      '@Nucleos\UserBundle\Util\UserManipulator::create':
+        - 'dispatcher'
+        - 'dispatcher'
+        - 'dispatcher@demo.coopcycle.org'
+        - true
+        - false
+    roles: [ 'ROLE_DISPATCHER' ]
+    telephone: <identity(\libphonenumber\PhoneNumberUtil::getInstance()->parse('+33612345678'))>
+
 AppBundle\Entity\Task:
   task_1:
     address: "@address_1"
@@ -24,3 +35,52 @@ AppBundle\Entity\Task:
     address: "@address_2"
     doneAfter: <identity(new \DateTime('today 11:30:00'))>
     doneBefore: <identity(new \DateTime('today 12:00:00'))>
+
+AppBundle\Entity\Base\GeoCoordinates:
+  geo_warehouse:
+    __construct: [ "48.8758311", "2.3675732" ]
+
+AppBundle\Entity\Delivery\PricingRuleSet:
+  pricing_rule_set_1:
+    name: Default
+    rules: [ '@pricing_rule_1' ]
+
+AppBundle\Entity\Delivery\PricingRule:
+  pricing_rule_1:
+    expression: 'distance \> 0'
+    price: 499
+    position: 1
+    ruleSet: '@pricing_rule_set_1'
+
+AppBundle\Entity\TimeSlot:
+  time_slot_1:
+    name: 'Acme time slot'
+    openingHours:
+      - 'Mo-Su 00:00-11:59'
+      - 'Mo-Su 12:00-23:59'
+
+AppBundle\Entity\Address:
+  warehouse:
+    name: 'Warehouse'
+    contactName: 'John Doe'
+    telephone: <identity(\libphonenumber\PhoneNumberUtil::getInstance()->parse('+33112121212'))>
+    addressLocality: 'Paris'
+    postalCode: '75001'
+    streetAddress: '23, Avenue Claude Vellefaux, 75010 Paris, France'
+    geo: "@geo_warehouse"
+
+AppBundle\Entity\Store:
+  store_1:
+    name: 'Acme'
+    address: "@address_1"
+    enabled: true
+    pricingRuleSet: '@pricing_rule_set_1'
+    timeSlot: '@time_slot_1'
+    __calls:
+      - addAddress: [ "@warehouse" ]
+
+AppBundle\Entity\DeliveryForm:
+  delivery_form:
+    pricingRuleSet: '@pricing_rule_set_1'
+    withVehicle: false
+    withWeight: false

--- a/features/retail_prices.feature
+++ b/features/retail_prices.feature
@@ -1,6 +1,50 @@
 Feature: Retail prices
 
-  Scenario: Get delivery price with JWT
+  Scenario: Get delivery price with JWT for dispatcher user
+    Given the fixtures files are loaded:
+      | sylius_channels.yml |
+      | sylius_taxation.yml |
+      | stores.yml          |
+    And the setting "subject_to_vat" has value "1"
+    And the user "dispatcher" is loaded:
+      | email      | dispatcher@coopcycle.org |
+      | password   | 123456            |
+    And the user "dispatcher" has role "ROLE_DISPATCHER"
+    And the user "dispatcher" is authenticated
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "dispatcher" sends a "POST" request to "/api/retail_prices/calculate" with body:
+      """
+      {
+        "store":"/api/stores/1",
+        "pickup": {
+          "address": "24, Rue de la Paix Paris",
+          "before": "tomorrow 13:00"
+        },
+        "dropoff": {
+          "address": "48, Rue de Rivoli Paris",
+          "before": "tomorrow 15:00"
+        }
+      }
+      """
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context":"/api/contexts/RetailPrice",
+        "@id":@string@,
+        "@type":"RetailPrice",
+        "amount":499,
+        "currency":"EUR",
+        "tax":{
+          "amount":83,
+          "included": true
+        }
+      }
+      """
+
+  Scenario: Get delivery price with JWT for dispatcher user
     Given the fixtures files are loaded:
       | sylius_channels.yml |
       | sylius_taxation.yml |

--- a/features/retail_prices.feature
+++ b/features/retail_prices.feature
@@ -1,19 +1,19 @@
 Feature: Retail prices
 
-  Scenario: Get delivery price with JWT for dispatcher user
+  Scenario: Get delivery price with JWT for admin user
     Given the fixtures files are loaded:
       | sylius_channels.yml |
       | sylius_taxation.yml |
       | stores.yml          |
     And the setting "subject_to_vat" has value "1"
-    And the user "dispatcher" is loaded:
-      | email      | dispatcher@coopcycle.org |
+    And the user "admin" is loaded:
+      | email      | admin@coopcycle.org |
       | password   | 123456            |
-    And the user "dispatcher" has role "ROLE_DISPATCHER"
-    And the user "dispatcher" is authenticated
+    And the user "admin" has role "ROLE_ADMIN"
+    And the user "admin" is authenticated
     When I add "Content-Type" header equal to "application/ld+json"
     And I add "Accept" header equal to "application/ld+json"
-    And the user "dispatcher" sends a "POST" request to "/api/retail_prices/calculate" with body:
+    And the user "admin" sends a "POST" request to "/api/retail_prices/calculate" with body:
       """
       {
         "store":"/api/stores/1",
@@ -50,14 +50,14 @@ Feature: Retail prices
       | sylius_taxation.yml |
       | stores.yml          |
     And the setting "subject_to_vat" has value "1"
-    And the user "admin" is loaded:
-      | email      | admin@coopcycle.org |
+    And the user "dispatcher" is loaded:
+      | email      | dispatcher@coopcycle.org |
       | password   | 123456            |
-    And the user "admin" has role "ROLE_ADMIN"
-    And the user "admin" is authenticated
+    And the user "dispatcher" has role "ROLE_DISPATCHER"
+    And the user "dispatcher" is authenticated
     When I add "Content-Type" header equal to "application/ld+json"
     And I add "Accept" header equal to "application/ld+json"
-    And the user "admin" sends a "POST" request to "/api/retail_prices/calculate" with body:
+    And the user "dispatcher" sends a "POST" request to "/api/retail_prices/calculate" with body:
       """
       {
         "store":"/api/stores/1",

--- a/src/Api/DataTransformer/DeliveryInputDataTransformer.php
+++ b/src/Api/DataTransformer/DeliveryInputDataTransformer.php
@@ -51,7 +51,8 @@ class DeliveryInputDataTransformer implements DataTransformerInterface
 
         if ($data->store && $data->store instanceof Store) {
 
-            if (!$this->authorizationChecker->isGranted('edit', $data->store)) {
+            //FIXME: move access controls to the operations in the Entities
+            if (!$this->authorizationChecker->isGranted('ROLE_DISPATCHER') && !$this->authorizationChecker->isGranted('edit', $data->store)) {
                 throw new AccessDeniedHttpException('');
             }
 

--- a/src/Api/Resource/RetailPrice.php
+++ b/src/Api/Resource/RetailPrice.php
@@ -25,7 +25,7 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
  *       "status"=200,
  *       "write"=false,
  *       "denormalization_context"={"groups"={"pricing_deliveries"}},
- *       "access_control"="is_granted('ROLE_ADMIN') or is_granted('ROLE_STORE') or is_granted('ROLE_OAUTH2_DELIVERIES')",
+ *       "access_control"="is_granted('ROLE_ADMIN') or is_granted('ROLE_STORE') or is_granted('ROLE_OAUTH2_DELIVERIES') or is_granted('ROLE_DISPATCHER')",
  *       "openapi_context"={
  *         "summary"="Calculates price of a Delivery",
  *       }

--- a/src/Api/Resource/RetailPrice.php
+++ b/src/Api/Resource/RetailPrice.php
@@ -25,7 +25,7 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
  *       "status"=200,
  *       "write"=false,
  *       "denormalization_context"={"groups"={"pricing_deliveries"}},
- *       "access_control"="is_granted('ROLE_ADMIN') or is_granted('ROLE_STORE') or is_granted('ROLE_OAUTH2_DELIVERIES') or is_granted('ROLE_DISPATCHER')",
+ *       "access_control"="is_granted('ROLE_DISPATCHER') or is_granted('ROLE_STORE') or is_granted('ROLE_OAUTH2_DELIVERIES')",
  *       "openapi_context"={
  *         "summary"="Calculates price of a Delivery",
  *       }

--- a/src/Entity/Store.php
+++ b/src/Entity/Store.php
@@ -68,14 +68,14 @@ use AppBundle\Action\Store\Packages as Packages;
  *       "path"="/stores/{id}/time_slots",
  *       "controller"=TimeSlots::class,
  *       "normalization_context"={"groups"={"store_time_slots"}},
- *       "security"="is_granted('ROLE_DISPATCHER')"
+ *       "security"="is_granted('edit', object)"
  *     },
  *     "packages"={
  *       "method"="GET",
  *       "path"="/stores/{id}/packages",
  *       "controller"=Packages::class,
  *       "normalization_context"={"groups"={"store_packages"}},
- *       "security"="is_granted('ROLE_DISPATCHER')"
+ *       "security"="is_granted('edit', object)"
  *     },
  *     "add_address"={
  *       "method"="POST",

--- a/src/Entity/Store.php
+++ b/src/Entity/Store.php
@@ -42,7 +42,7 @@ use AppBundle\Action\Store\Packages as Packages;
  *   collectionOperations={
  *     "get"={
  *       "method"="GET",
- *       "access_control"="is_granted('ROLE_ADMIN') or is_granted('ROLE_DISPATCHER')"
+ *       "access_control"="is_granted('ROLE_DISPATCHER')"
  *     },
  *     "me_stores"={
  *       "method"="GET",
@@ -68,14 +68,14 @@ use AppBundle\Action\Store\Packages as Packages;
  *       "path"="/stores/{id}/time_slots",
  *       "controller"=TimeSlots::class,
  *       "normalization_context"={"groups"={"store_time_slots"}},
- *       "security"="is_granted('ROLE_ADMIN') or is_granted('ROLE_DISPATCHER')"
+ *       "security"="is_granted('ROLE_DISPATCHER')"
  *     },
  *     "packages"={
  *       "method"="GET",
  *       "path"="/stores/{id}/packages",
  *       "controller"=Packages::class,
  *       "normalization_context"={"groups"={"store_packages"}},
- *       "security"="is_granted('ROLE_ADMIN') or is_granted('ROLE_DISPATCHER')"
+ *       "security"="is_granted('ROLE_DISPATCHER')"
  *     },
  *     "add_address"={
  *       "method"="POST",

--- a/src/Entity/Store.php
+++ b/src/Entity/Store.php
@@ -42,7 +42,7 @@ use AppBundle\Action\Store\Packages as Packages;
  *   collectionOperations={
  *     "get"={
  *       "method"="GET",
- *       "access_control"="is_granted('ROLE_DISPATCHER')"
+ *       "access_control"="is_granted('ROLE_ADMIN') or is_granted('ROLE_DISPATCHER')"
  *     },
  *     "me_stores"={
  *       "method"="GET",
@@ -68,14 +68,14 @@ use AppBundle\Action\Store\Packages as Packages;
  *       "path"="/stores/{id}/time_slots",
  *       "controller"=TimeSlots::class,
  *       "normalization_context"={"groups"={"store_time_slots"}},
- *       "security"="is_granted('edit', object)"
+ *       "security"="is_granted('ROLE_ADMIN') or is_granted('ROLE_DISPATCHER')"
  *     },
  *     "packages"={
  *       "method"="GET",
  *       "path"="/stores/{id}/packages",
  *       "controller"=Packages::class,
  *       "normalization_context"={"groups"={"store_packages"}},
- *       "security"="is_granted('edit', object)"
+ *       "security"="is_granted('ROLE_ADMIN') or is_granted('ROLE_DISPATCHER')"
  *     },
  *     "add_address"={
  *       "method"="POST",

--- a/src/Entity/Store.php
+++ b/src/Entity/Store.php
@@ -68,14 +68,14 @@ use AppBundle\Action\Store\Packages as Packages;
  *       "path"="/stores/{id}/time_slots",
  *       "controller"=TimeSlots::class,
  *       "normalization_context"={"groups"={"store_time_slots"}},
- *       "security"="is_granted('edit', object)"
+ *       "security"="is_granted('ROLE_DISPATCHER') or is_granted('edit', object)"
  *     },
  *     "packages"={
  *       "method"="GET",
  *       "path"="/stores/{id}/packages",
  *       "controller"=Packages::class,
  *       "normalization_context"={"groups"={"store_packages"}},
- *       "security"="is_granted('edit', object)"
+ *       "security"="is_granted('ROLE_DISPATCHER') or is_granted('edit', object)"
  *     },
  *     "add_address"={
  *       "method"="POST",

--- a/src/Security/StoreVoter.php
+++ b/src/Security/StoreVoter.php
@@ -44,7 +44,7 @@ class StoreVoter extends Voter
 
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
     {
-        if ($this->authorizationChecker->isGranted('ROLE_DISPATCHER')) {
+        if ($this->authorizationChecker->isGranted('ROLE_ADMIN')) {
             return true;
         }
 
@@ -57,6 +57,13 @@ class StoreVoter extends Voter
 
         if ($this->authorizationChecker->isGranted('ROLE_STORE')
             && is_object($user) && is_callable([ $user, 'ownsStore' ]) && $user->ownsStore($subject)) {
+            return true;
+        }
+
+        if (
+            in_array($attribute, [self::VIEW, self::EDIT_DELIVERY]) &&
+            $this->authorizationChecker->isGranted('ROLE_DISPATCHER')
+        ) {
             return true;
         }
 

--- a/src/Security/StoreVoter.php
+++ b/src/Security/StoreVoter.php
@@ -60,13 +60,6 @@ class StoreVoter extends Voter
             return true;
         }
 
-        if (
-            in_array($attribute, [self::VIEW, self::EDIT_DELIVERY]) &&
-            $this->authorizationChecker->isGranted('ROLE_DISPATCHER')
-        ) {
-            return true;
-        }
-
         return false;
     }
 }

--- a/src/Security/StoreVoter.php
+++ b/src/Security/StoreVoter.php
@@ -44,7 +44,7 @@ class StoreVoter extends Voter
 
     protected function voteOnAttribute($attribute, $subject, TokenInterface $token)
     {
-        if ($this->authorizationChecker->isGranted('ROLE_ADMIN')) {
+        if ($this->authorizationChecker->isGranted('ROLE_DISPATCHER')) {
             return true;
         }
 


### PR DESCRIPTION
### Issue: [#197](https://github.com/coopcycle/coopcycle/issues/197)
Related PRs:
* https://github.com/coopcycle/coopcycle-app/pull/1949
* https://github.com/coopcycle/coopcycle-web/pull/4906

We need to allow a dispatcher to call this endpoints:

- api/stores/{id}/time_slots
- api/stores/{id}/packages
- api/retail_prices/calculate

Also, added fixture for test Dispatch->Create delivery in app mobile