### PR TITLE
Fix for crash on refund when there is a failed payment attached to the order

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -334,6 +334,9 @@ class AdminController extends AbstractController
 
                 if ('refund' === $form->getClickedButton()->getName()) {
                     foreach ($form->get('payments') as $paymentForm) {
+                        if (!$paymentForm->has('refund')) {
+                            continue;
+                        }
                         /** @var \Symfony\Component\Form\ClickableInterface $refundButton */
                         $refundButton = $paymentForm->get('refund');
                         if ($refundButton->isClicked()) {


### PR DESCRIPTION
issue #4912 

Check if refund field is defined on PaymentType, otherwise refund crashes when there is a failed  payment attached to the form