### PR TITLE
[PERTE-275] Do not list/display deleted stores by default for `/api/stores` endpoint

### DIFF
--- a/cypress/e2e/invoicing/export_data_for_invoicing.cy.js
+++ b/cypress/e2e/invoicing/export_data_for_invoicing.cy.js
@@ -1,3 +1,5 @@
+import moment from 'moment'
+
 context('Invoicing (role: admin)', () => {
   beforeEach(() => {
     const prefix = Cypress.env('COMMAND_PREFIX')
@@ -20,13 +22,12 @@ context('Invoicing (role: admin)', () => {
     cy.get('[data-testid="invoicing.toggleRangePicker"]').click()
 
     // Choose 1 month
+    const firstDayOfMonth = moment().startOf('month').format('YYYY-MM-DD')
+    const lastDayOfMonth = moment().endOf('month').format('YYYY-MM-DD')
     cy.get('.ant-picker-input-active > input').click()
-    cy.get(
-      ':nth-child(1) > .ant-picker-date-panel > .ant-picker-body > .ant-picker-content > tbody > :nth-child(1) > .ant-picker-cell-start > .ant-picker-cell-inner',
-    ).click()
-    cy.get(
-      ':nth-child(1) > .ant-picker-date-panel > .ant-picker-body > .ant-picker-content > tbody > :nth-child(5) > .ant-picker-cell-end > .ant-picker-cell-inner',
-    ).click()
+    cy.get('.ant-picker-input-active > input').type(firstDayOfMonth);
+    cy.get(':nth-child(3) > input').click();
+    cy.get('.ant-picker-input-active > input').type(`${lastDayOfMonth}{enter}`);
 
     cy.get('[data-testid="invoicing.refresh"]').click()
 

--- a/cypress/e2e/local-commerce/@admin/recurrence_rules/create_delivery_with_recurrence_rule_as_admin.cy.js
+++ b/cypress/e2e/local-commerce/@admin/recurrence_rules/create_delivery_with_recurrence_rule_as_admin.cy.js
@@ -104,12 +104,12 @@ describe('Delivery with recurrence rule (role: admin)', () => {
         '#delivery_tasks_0_doneBefore_widget > .ant-picker > .ant-picker-input-active > input')
         .click()
       cy.get(
-        '.ant-picker-content:visible > :nth-child(2) > :nth-child(13) > .ant-picker-time-panel-cell-inner')
-        .click()
+        '#delivery_tasks_0_doneBefore_widget > .ant-picker > .ant-picker-input-active > input')
+        .type('{backspace}{backspace}12')
       cy.get('.ant-picker-ok:visible > .ant-btn').click()
       cy.get(
-        '.ant-picker-content:visible > :nth-child(2) > :nth-child(28) > .ant-picker-time-panel-cell-inner')
-        .click()
+        '#delivery_tasks_0_doneBefore_widget > .ant-picker > .ant-picker-input-active > input')
+        .type('{backspace}{backspace}27')
       cy.get('.ant-picker-ok:visible > .ant-btn').click()
 
       cy.get('#delivery_tasks_0_comments').type('Pickup comments')
@@ -122,12 +122,12 @@ describe('Delivery with recurrence rule (role: admin)', () => {
         '#delivery_tasks_1_doneBefore_widget > .ant-picker > .ant-picker-input-active > input')
         .click()
       cy.get(
-        '.ant-picker-content:visible > :nth-child(2) > :nth-child(25) > .ant-picker-time-panel-cell-inner')
-        .click()
+        '#delivery_tasks_1_doneBefore_widget > .ant-picker > .ant-picker-input-active > input')
+        .type('{backspace}{backspace}24')
       cy.get('.ant-picker-ok:visible > .ant-btn').click()
       cy.get(
-        '.ant-picker-content:visible > :nth-child(2) > :nth-child(59) > .ant-picker-time-panel-cell-inner')
-        .click()
+        '#delivery_tasks_1_doneBefore_widget > .ant-picker > .ant-picker-input-active > input')
+        .type('{backspace}{backspace}58')
       cy.get('.ant-picker-ok:visible > .ant-btn').click()
 
       cy.get('#delivery_tasks_1_weight').clear()

--- a/features/fixtures/ORM/stores.yml
+++ b/features/fixtures/ORM/stores.yml
@@ -203,3 +203,12 @@ AppBundle\Entity\Store:
     timeSlots: ['@time_slot_1', '@time_slot_2']
     __calls:
       - addAddress: ['@address_1']
+  store_10:
+    name: 'Deleted store'
+    deletedAt: <identity(new \DateTime('yesterday'))>
+    address: '@address_1'
+    enabled: true
+    pricingRuleSet: '@pricing_rule_set_1'
+    timeSlot: '@time_slot_1'
+    __calls:
+      - addAddress: ['@address_1']

--- a/features/stores.feature
+++ b/features/stores.feature
@@ -93,6 +93,47 @@ Feature: Stores
       }
       """
 
+  Scenario: List stores
+    Given the fixtures files are loaded:
+      | sylius_channels.yml |
+      | stores.yml          |
+    And the user "bob" is loaded:
+      | email      | bob@coopcycle.org |
+      | password   | 123456            |
+    And the user "bob" has role "ROLE_ADMIN"
+    And the user "bob" is authenticated
+    When I add "Content-Type" header equal to "application/ld+json"
+    And I add "Accept" header equal to "application/ld+json"
+    And the user "bob" sends a "GET" request to "/api/stores"
+    Then the response status code should be 200
+    And the response should be in JSON
+    And the JSON should match:
+      """
+      {
+        "@context": "/api/contexts/Store",
+        "@id": "/api/stores",
+        "@type": "hydra:Collection",
+        "hydra:member": [
+          {
+            "@id": "/api/stores/@string@",
+            "id": "@integer@.greaterThan(0)",
+            "@type": "http://schema.org/Store",
+            "name": "@string@",
+            "enabled": true,
+            "address": {"@*@":"@*@"},
+            "timeSlot": "/api/time_slots/1",
+            "timeSlots": @array@,
+            "prefillPickupAddress": @boolean@,
+            "weightRequired": @boolean@,
+            "packagesRequired": @boolean@,
+            "multiDropEnabled": @boolean@
+          },
+          @...@
+        ],
+        "hydra:totalItems": 9
+      }
+      """
+
   Scenario: Retrieve store
     Given the fixtures files are loaded:
       | sylius_channels.yml |

--- a/src/Api/EventSubscriber/SoftDeletedSubscriber.php
+++ b/src/Api/EventSubscriber/SoftDeletedSubscriber.php
@@ -20,6 +20,7 @@ final class SoftDeletedSubscriber implements EventSubscriberInterface
         'api_organizations_get_collection',
         'admin_restaurants_search',
         'admin_stores_search',
+        'api_stores_get_collection',
         'api_warehouses_get_collection',
         'api_vehicles_get_collection',
         'api_trailers_get_collection'

--- a/src/Controller/Utils/StoreTrait.php
+++ b/src/Controller/Utils/StoreTrait.php
@@ -66,10 +66,6 @@ trait StoreTrait
      */
     public function storeListAction(Request $request, PaginatorInterface $paginator, JWTManagerInterface $jwtManager)
     {
-        if (!$request->query->getBoolean('deleted', false)) {
-            $this->entityManager->getFilters()->enable('soft_deleteable');
-        }
-
         $qb = $this->getDoctrine()
         ->getRepository(Store::class)
         ->createQueryBuilder('c')

--- a/src/Controller/Utils/StoreTrait.php
+++ b/src/Controller/Utils/StoreTrait.php
@@ -66,6 +66,10 @@ trait StoreTrait
      */
     public function storeListAction(Request $request, PaginatorInterface $paginator, JWTManagerInterface $jwtManager)
     {
+        if (!$request->query->getBoolean('deleted', false)) {
+            $this->entityManager->getFilters()->enable('soft_deleteable');
+        }
+
         $qb = $this->getDoctrine()
         ->getRepository(Store::class)
         ->createQueryBuilder('c')


### PR DESCRIPTION
### Issue: [#275](https://github.com/coopcycle/coopcycle/issues/275)

- [x] Filter out by default deleted stores from `/api/stores` response
- [x] Create a behat test