### PR TITLE
Fix: "products" column (products outside a section) is empty in menu sections form

### DIFF
--- a/src/Utils/MenuEditor.php
+++ b/src/Utils/MenuEditor.php
@@ -11,7 +11,7 @@ class MenuEditor
     /**
      * @var \Doctrine\Common\Collections\Collection
      */
-    public $products;
+    private $products;
     private $restaurant;
     private $menu;
 
@@ -19,7 +19,6 @@ class MenuEditor
     {
         $this->restaurant = $restaurant;
         $this->menu = $menu;
-        $this->products = $this->getProducts();
     }
 
     public function getName()

--- a/src/Utils/MenuEditor.php
+++ b/src/Utils/MenuEditor.php
@@ -19,6 +19,7 @@ class MenuEditor
     {
         $this->restaurant = $restaurant;
         $this->menu = $menu;
+        $this->products = $this->getProducts();
     }
 
     public function getName()

--- a/src/Utils/MenuEditor.php
+++ b/src/Utils/MenuEditor.php
@@ -4,14 +4,9 @@ namespace AppBundle\Utils;
 
 use AppBundle\Entity\LocalBusiness;
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
 
 class MenuEditor
 {
-    /**
-     * @var \Doctrine\Common\Collections\Collection
-     */
-    private $products;
     private $restaurant;
     private $menu;
 
@@ -49,10 +44,5 @@ class MenuEditor
         }
 
         return $products;
-    }
-
-    public function setProducts(Collection $products)
-    {
-        $this->products = $products;
     }
 }


### PR DESCRIPTION
The bug : the "products" column in the menu editor form is empty

Why? I am not PHP wizard but when we added the annotation with rector, the value of "products" in the twig template is now NULL (here https://github.com/coopcycle/coopcycle-web/commit/534bc0a395bbc31f60ae857446f6cc828f6756c5#diff-cb098e0335fc596eab9af092879d3298620efb6a6ae84441078dd5976738ca8eR12 )