### PR TITLE
Calculate dynamically zero waste processing fee

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -45,8 +45,6 @@ twig:
         business_account_enabled: '%env(bool:BUSINESS_ACCOUNT_ENABLED)%'
         odoo_url: '%env(ODOO_URL)%'
         invitation_link_provider: '@AppBundle\Service\InvitationLinkProviderService'
-        loopeat_processing_fee: '%env(int:LOOPEAT_PROCESSING_FEE)%'
-        loopeat_processing_fee_behavior: '%env(LOOPEAT_PROCESSING_FEE_BEHAVIOR)%'
         paygreen_environment: '%env(PAYGREEN_ENVIRONMENT)%'
 
     exception_controller: null

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -240,7 +240,7 @@ services:
 
   AppBundle\LoopEat\ContextInitializer:
     arguments:
-      $processingFee: "%env(int:LOOPEAT_PROCESSING_FEE)%"
+      $processingFee: "%env(LOOPEAT_PROCESSING_FEE)%"
       $processingFeeBehavior: "%env(LOOPEAT_PROCESSING_FEE_BEHAVIOR)%"
     tags:
       - { name: monolog.logger, channel: loopeat }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -239,9 +239,6 @@ services:
   AppBundle\LoopEat\Context: ~
 
   AppBundle\LoopEat\ContextInitializer:
-    arguments:
-      $processingFee: "%env(LOOPEAT_PROCESSING_FEE)%"
-      $processingFeeBehavior: "%env(LOOPEAT_PROCESSING_FEE_BEHAVIOR)%"
     tags:
       - { name: monolog.logger, channel: loopeat }
 

--- a/src/Entity/Sylius/LoopeatOrderDetails.php
+++ b/src/Entity/Sylius/LoopeatOrderDetails.php
@@ -116,6 +116,11 @@ class LoopeatOrderDetails
 
     public function hasReturns()
     {
-        return count($this->returns) > 0;
+        return $this->countReturns() > 0;
+    }
+
+    public function countReturns()
+    {
+        return count($this->returns);
     }
 }

--- a/src/Entity/Sylius/Order.php
+++ b/src/Entity/Sylius/Order.php
@@ -1630,6 +1630,11 @@ class Order extends BaseOrder implements OrderInterface
         return $this->getLoopeatDetails()->hasReturns();
     }
 
+    public function countLoopeatReturns()
+    {
+        return $this->getLoopeatDetails()->countReturns();
+    }
+
     public function getReturnsAmountForLoopeat(): int
     {
         $reusablePackagings = $this->getRestaurant()->getReusablePackagings();

--- a/src/LoopEat/ContextInitializer.php
+++ b/src/LoopEat/ContextInitializer.php
@@ -15,8 +15,6 @@ class ContextInitializer
 
     public function __construct(
         private Client $client,
-        private int $processingFee,
-        private string $processingFeeBehavior,
         LoggerInterface $logger = null)
     {
         $this->logger = $logger ?? new NullLogger();
@@ -35,8 +33,6 @@ class ContextInitializer
         $context->logoUrl = $initiative['logo_url'];
         $context->name = $initiative['name'];
         $context->customerAppUrl = $initiative['customer_app_url'];
-        $context->processingFee = $this->processingFee;
-        $context->processingFeeBehavior = $this->processingFeeBehavior;
         $context->formats = $this->client->getFormats($order->getRestaurant());
         $context->returns = $order->getLoopeatReturns();
         $context->returnsTotalAmount = $order->getReturnsAmountForLoopeat();

--- a/src/Sylius/OrderProcessing/OrderDepositRefundProcessor.php
+++ b/src/Sylius/OrderProcessing/OrderDepositRefundProcessor.php
@@ -11,6 +11,7 @@ use AppBundle\Sylius\Order\AdjustmentInterface;
 use AppBundle\Sylius\Order\OrderItemInterface;
 use Sylius\Component\Order\Factory\AdjustmentFactoryInterface;
 use Doctrine\Common\Collections\ArrayCollection;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class OrderDepositRefundProcessor implements OrderProcessorInterface
@@ -28,7 +29,7 @@ final class OrderDepositRefundProcessor implements OrderProcessorInterface
     public function __construct(
         private AdjustmentFactoryInterface $adjustmentFactory,
         private TranslatorInterface $translator,
-        private int $loopeatProcessingFee = 0,
+        private string $loopeatProcessingFee = '0',
         private string $loopeatProcessingFeeBehavior = self::LOOPEAT_PROCESSING_FEE_BEHAVIOR_ALWAYS)
     {
         $this->loopeatProcessingFee = $loopeatProcessingFee;
@@ -104,13 +105,19 @@ final class OrderDepositRefundProcessor implements OrderProcessorInterface
 
         // Collect an additional fee for LoopEat, *PER ORDER*
         // https://github.com/coopcycle/coopcycle-web/issues/2284
-        if ($restaurant->isLoopeatEnabled() && $this->loopeatProcessingFee > 0) {
+        if ($restaurant->isLoopeatEnabled() && $this->loopeatProcessingFee !== '0') {
             if (self::LOOPEAT_PROCESSING_FEE_BEHAVIOR_ALWAYS === $this->loopeatProcessingFeeBehavior
                 || (self::LOOPEAT_PROCESSING_FEE_BEHAVIOR_ON_RETURNS === $this->loopeatProcessingFeeBehavior && $order->hasLoopeatReturns())) {
+
+                $language = new ExpressionLanguage();
+                $loopeatProcessingFee = $language->evaluate($this->loopeatProcessingFee, [
+                    'returns_count' => $order->countLoopeatReturns(),
+                ]);
+
                 $order->addAdjustment($this->adjustmentFactory->createWithData(
                     AdjustmentInterface::REUSABLE_PACKAGING_ADJUSTMENT,
                     $this->translator->trans('order.adjustment_type.reusable_packaging.loopeat'),
-                    $this->loopeatProcessingFee,
+                    $loopeatProcessingFee,
                     $neutral = false
                 ));
             }

--- a/src/Twig/CoopCycleExtension.php
+++ b/src/Twig/CoopCycleExtension.php
@@ -99,6 +99,7 @@ class CoopCycleExtension extends AbstractExtension
             new TwigFunction('should_show_pre_order', array(LocalBusinessRuntime::class, 'shouldShowPreOrder')),
             new TwigFunction('loopeat_authorization_url', array(LoopeatRuntime::class, 'getAuthorizationUrl')),
             new TwigFunction('loopeat_name', array(LoopeatRuntime::class, 'getName')),
+            new TwigFunction('loopeat_returns_fee', array(LoopeatRuntime::class, 'getReturnsFee')),
             new TwigFunction('restaurant_tags', array(LocalBusinessRuntime::class, 'tags')),
             new TwigFunction('restaurant_badges', array(LocalBusinessRuntime::class, 'badges')),
             new TwigFunction('coopcycle_configtest', array(SettingResolver::class, 'configTest')),

--- a/src/Twig/LoopeatRuntime.php
+++ b/src/Twig/LoopeatRuntime.php
@@ -4,11 +4,14 @@ namespace AppBundle\Twig;
 
 use AppBundle\LoopEat\Client;
 use AppBundle\Sylius\Order\OrderInterface;
+use AppBundle\Sylius\OrderProcessing\OrderDepositRefundProcessor;
 use Twig\Extension\RuntimeExtensionInterface;
 
 class LoopeatRuntime implements RuntimeExtensionInterface
 {
-    public function __construct(private Client $client)
+    public function __construct(
+        private Client $client,
+        private OrderDepositRefundProcessor $orderDepositRefundProcessor)
     {}
 
     public function getAuthorizationUrl(OrderInterface $order, int $requiredCredits = 0, bool $showDeposit = false)
@@ -33,5 +36,10 @@ class LoopeatRuntime implements RuntimeExtensionInterface
         $initiative = $this->client->initiative();
 
         return $initiative['name'];
+    }
+
+    public function getReturnsFee(OrderInterface $order): int
+    {
+        return $this->orderDepositRefundProcessor->getLoopeatReturnsFee($order);
     }
 }

--- a/templates/emails/order/accepted.mjml.twig
+++ b/templates/emails/order/accepted.mjml.twig
@@ -21,8 +21,9 @@
   </mj-text>
   {% if order.isLoopeat() %}
   <mj-text align="left" line-height="20px">
-  {% if loopeat_context.processingFee > 0 and loopeat_context.processingFeeBehavior == 'on_returns' %}
-  {{ ('order.loopeat.accepted.with_fee')|trans({ '%name%': loopeat_context.name, '%amount%': loopeat_context.processingFee|price_format }, 'emails')|raw }}
+  {% set returns_fee = loopeat_returns_fee(order) %}
+  {% if returns_fee > 0 %}
+  {{ ('order.loopeat.accepted.with_fee')|trans({ '%name%': loopeat_context.name, '%amount%': returns_fee|price_format }, 'emails')|raw }}
   {% else %}
   {{ ('order.loopeat.accepted')|trans({ '%name%': loopeat_context.name }, 'emails')|raw }}
   {% endif %}


### PR DESCRIPTION
The `LOOPEAT_PROCESSING_FEE` env var can now contain an expression. If it contains a number, it will still work like before. 

Fixes #4971 