### PR TITLE
Fix: invoicing page

### DIFF
--- a/cypress/e2e/invoicing/export_data_for_invoicing.cy.js
+++ b/cypress/e2e/invoicing/export_data_for_invoicing.cy.js
@@ -11,17 +11,45 @@ context('Invoicing (role: admin)', () => {
     cy.get('[data-testid="invoicing.toggleRangePicker"]').click()
 
     // Choose 2 months (this avoids an edge case when running this test in the last day of the current month)
-    const firstDayOfPreviousMonth = moment().startOf('month').subtract(1, 'months').format('YYYY-MM-DD')
+    const firstDayOfPreviousMonth = moment()
+      .startOf('month')
+      .subtract(1, 'months')
+      .format('YYYY-MM-DD')
     const lastDayOfCurrentMonth = moment().endOf('month').format('YYYY-MM-DD')
     cy.get('.ant-picker-input-active > input').click()
-    cy.get('.ant-picker-input-active > input').type(firstDayOfPreviousMonth);
-    cy.get(':nth-child(3) > input').click();
-    cy.get('.ant-picker-input-active > input').type(`${lastDayOfCurrentMonth}{enter}`);
+    cy.get('.ant-picker-input-active > input').type(firstDayOfPreviousMonth)
+    cy.get(':nth-child(3) > input').click()
+    cy.get('.ant-picker-input-active > input').type(
+      `${lastDayOfCurrentMonth}{enter}`,
+    )
 
     cy.get('[data-testid="invoicing.refresh"]').click()
 
     cy.get('[data-testid="invoicing.organizations"]')
       .contains(/Acme/)
       .should('exist')
+
+    // Expand the first row to see the orders
+    cy.get('[aria-label="Développer la ligne"]').first().click()
+
+    // Verify that only the first row is expanded
+    cy.get('[aria-label="Réduire la ligne"]').should('have.length', 1)
+
+    // Verify that the orders from A1 to A10 are displayed
+    for (let i = 1; i <= 10; i++) {
+      cy.get('.ant-table-cell').filter(`:contains("A${i}")`).should('exist')
+    }
+
+    // Verify pagination
+
+    // Go to the second page of orders
+    cy.get('[data-testid="invoicing.orders.1"]').within(() => {
+      cy.get('.ant-pagination-item-2').click()
+    })
+
+    // Verify that the orders from A11 to A20 are displayed
+    for (let i = 11; i <= 20; i++) {
+      cy.get('.ant-table-cell').filter(`:contains("A${i}")`).should('exist')
+    }
   })
 })

--- a/cypress/e2e/invoicing/export_data_for_invoicing.cy.js
+++ b/cypress/e2e/invoicing/export_data_for_invoicing.cy.js
@@ -37,7 +37,9 @@ context('Invoicing (role: admin)', () => {
 
     // Verify that the orders from A1 to A10 are displayed
     for (let i = 1; i <= 10; i++) {
-      cy.get('.ant-table-cell').filter(`:contains("A${i}")`).should('exist')
+      cy.get('.ant-table-cell')
+        .contains(new RegExp(`^A${i}$`))
+        .should('exist')
     }
 
     // Verify pagination
@@ -49,7 +51,16 @@ context('Invoicing (role: admin)', () => {
 
     // Verify that the orders from A11 to A20 are displayed
     for (let i = 11; i <= 20; i++) {
-      cy.get('.ant-table-cell').filter(`:contains("A${i}")`).should('exist')
+      cy.get('.ant-table-cell')
+        .contains(new RegExp(`^A${i}$`))
+        .should('exist')
+    }
+
+    // Verify that the first page is not displayed
+    for (let i = 1; i <= 10; i++) {
+      cy.get(`.ant-table-cell`)
+        .contains(new RegExp(`^A${i}$`))
+        .should('not.exist')
     }
   })
 })

--- a/js/app/admin/invoicing/components/ExportModalContent.js
+++ b/js/app/admin/invoicing/components/ExportModalContent.js
@@ -76,6 +76,7 @@ export default ({ dateRange, params, setModalOpen }) => {
       </main>
       <footer className="modal-footer">
         <Button
+          testID="invoicing.download.file"
           primary
           block
           icon="download"

--- a/js/app/admin/invoicing/components/OrdersTable/index.js
+++ b/js/app/admin/invoicing/components/OrdersTable/index.js
@@ -151,21 +151,23 @@ export default function OrdersTable({
   }, [reloadKey, previousReloadKey, refetch])
 
   return (
-    <Table
-      style={{ marginTop: '48px' }}
-      columns={columns}
-      loading={isFetching}
-      dataSource={dataSource}
-      rowKey="rowKey"
-      pagination={{
-        pageSize,
-        total,
-        showSizeChanger: true,
-      }}
-      onChange={pagination => {
-        setCurrentPage(pagination.current)
-        setPageSize(pagination.pageSize)
-      }}
-    />
+    <div data-testid={`invoicing.orders.${storeId}`}>
+      <Table
+        style={{ marginTop: '48px' }}
+        columns={columns}
+        loading={isFetching}
+        dataSource={dataSource}
+        rowKey="rowKey"
+        pagination={{
+          pageSize,
+          total,
+          showSizeChanger: true,
+        }}
+        onChange={pagination => {
+          setCurrentPage(pagination.current)
+          setPageSize(pagination.pageSize)
+        }}
+      />
+    </div>
   )
 }

--- a/js/app/admin/invoicing/components/OrdersToInvoice/index.js
+++ b/js/app/admin/invoicing/components/OrdersToInvoice/index.js
@@ -79,6 +79,7 @@ export default () => {
       />
       <div className="d-flex justify-content-end" style={{ marginTop: '24px' }}>
         <Button
+          testID="invoicing.download"
           primary
           onClick={() => {
             if (!params) {

--- a/js/app/admin/invoicing/components/OrganizationsTable/index.js
+++ b/js/app/admin/invoicing/components/OrganizationsTable/index.js
@@ -47,7 +47,7 @@ export default function OrganizationsTable({
 
     return {
       dataSource: data['hydra:member'].map(item => ({
-        rowKey: item['@id'],
+        rowKey: item.storeId,
         storeId: item.storeId,
         name: `${item.organizationLegalName} (${item.ordersCount})`,
         subTotal: money(item.subTotal),

--- a/src/Api/Dto/InvoiceLineItem.php
+++ b/src/Api/Dto/InvoiceLineItem.php
@@ -12,18 +12,20 @@ use Symfony\Component\Serializer\Annotation\SerializedName;
 #[ApiResource(
     operations: [
         new Get(
-            uriTemplate: '/invoice_line_items/{invoiceId}',
+            uriTemplate: '/invoice_line_items/{id}',
+            requirements: ['id' => '^(?!.*grouped_by_organization|.*export).*$'],
             controller: NotFoundAction::class,
-            read: false,
             output: false,
             // Make sure to add requirements for operations like "/invoice_line_items/grouped_by_organization" to work
-            requirements: ['invoiceId' => '^(?!.*grouped_by_organization|.*export).*$']
+            read: false
         )
     ]
 )]
 class InvoiceLineItem
 {
     #[ApiProperty(identifier: true)]
+    public string $id;
+
     public string $invoiceId;
 
     public readonly \DateTime $invoiceDate;
@@ -62,6 +64,7 @@ class InvoiceLineItem
     public readonly array $exports;
 
     public function __construct(
+        string $id,
         string $invoiceId,
         \DateTime $invoiceDate,
         ?int $storeId,
@@ -78,6 +81,7 @@ class InvoiceLineItem
         array $exports,
     )
     {
+        $this->id = $id;
         $this->invoiceId = $invoiceId;
         $this->invoiceDate = $invoiceDate;
         $this->storeId = $storeId;

--- a/src/Api/State/InvoiceLineItemsProvider.php
+++ b/src/Api/State/InvoiceLineItemsProvider.php
@@ -194,6 +194,7 @@ final class InvoiceLineItemsProvider implements ProviderInterface
         $exports = $order->getExports()->map(fn($export) => $export->getExportCommand())->toArray();
 
         return new InvoiceLineItem(
+            sprintf('%s-%d', $invoiceId, $order->getId()),
             $invoiceId,
             $invoiceDate,
             $store?->getId(),

--- a/src/Api/State/InvoiceLineItemsProvider.php
+++ b/src/Api/State/InvoiceLineItemsProvider.php
@@ -6,7 +6,6 @@ use ApiPlatform\Metadata\Operation;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\State\Pagination\PaginatorInterface;
 use ApiPlatform\State\Pagination\TraversablePaginator;
-use ApiPlatform\Doctrine\Orm\Extension\QueryCollectionExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Extension\QueryResultCollectionExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGenerator;
 use AppBundle\Api\Dto\InvoiceLineItem;
@@ -30,7 +29,7 @@ final class InvoiceLineItemsProvider implements ProviderInterface
         private readonly SettingsManager $settingsManager,
         private readonly TranslatorInterface $translator,
         private readonly string $locale,
-        private readonly iterable $collectionExtensions
+        private readonly iterable $collectionExtensions,
     )
     {
     }
@@ -110,7 +109,7 @@ final class InvoiceLineItemsProvider implements ProviderInterface
             );
         }
 
-        return $data;
+        return $invoiceLineItems;
     }
 
     private function preloadEntities(array $orders): void


### PR DESCRIPTION
Fixed:

- clicking one shop or expanding one shop clicks or expands all of them
- the orders could be duplicated within an unfolded organisation (due to pagination issues)
- export file is empty
