### PR TITLE
Fix: When a client imports a file, the tasks appeared correctly in the dashboard but are not available in the order list

### DIFF
--- a/cypress/e2e/package-delivery/import/deliveries.cy.js
+++ b/cypress/e2e/package-delivery/import/deliveries.cy.js
@@ -50,8 +50,11 @@ context('Import deliveries (role: admin)', () => {
     cy.reload()
     cy.get('i.fa-check[data-delivery-import-status]').should('exist')
 
-    // verify imported deliveries
     cy.get('[data-testid="tab:/admin/deliveries"]').click()
+
+    // Verify the import is successful
+
+    // Deliveries list
     cy.urlmatch(/\/admin\/deliveries$/)
 
     // deliveries.csv; line 2; pricing_rule_2
@@ -63,5 +66,19 @@ context('Import deliveries (role: admin)', () => {
     cy.get('[data-testid=delivery__list_item]')
       .contains(/€6.99/)
       .should('exist')
+
+    cy.visit('/admin/orders')
+
+    // Orders list
+    cy.urlmatch(/\/admin\/orders$/)
+
+    // deliveries.csv; line 2; pricing_rule_2
+    cy.get('[data-testid="order-list-item-1"]')
+      .contains(/€2.00/)
+      .should('exist')
+
+    // deliveries.csv; line 3; pricing_rule_1 + pricing_rule_2
+    cy.get('[data-testid="order-list-item-2"]')
+      .contains(/€6.99/)
   })
 })

--- a/cypress/e2e/pricing/setup_simple_km_based_pricing_rule.cy.js
+++ b/cypress/e2e/pricing/setup_simple_km_based_pricing_rule.cy.js
@@ -1,6 +1,6 @@
 context('Setup simple km-based pricing (role: admin)', () => {
   beforeEach(() => {
-    cy.loadFixturesWithSetup('../cypress/fixtures/pricing.yml')
+    cy.loadFixturesWithSetup('ORM/user_admin.yml')
     cy.login('admin', '12345678')
   })
 
@@ -11,6 +11,7 @@ context('Setup simple km-based pricing (role: admin)', () => {
     cy.get('[data-testid="pricing_rule_sets_add"]').click()
 
     // New pricing rule set page
+    cy.urlmatch(/\/admin\/deliveries\/pricing\/new$/)
     cy.get('#pricing_rule_set_name').type('Old school')
 
     // Select strategy: All the matching rules
@@ -47,6 +48,9 @@ context('Setup simple km-based pricing (role: admin)', () => {
     cy.intercept('/admin/deliveries/pricing/*').as('submit')
     cy.get('.btn-block').click()
     cy.wait('@submit', { timeout: 10000 })
+
+    // Pricing rule page
+    cy.urlmatch(/\/admin\/deliveries\/pricing\/[0-9]+$/)
 
     cy.get('.alert-success', { timeout: 10000 })
       .should('contain', 'Changements sauvegardés')

--- a/cypress/e2e/pricing/setup_simple_matrix_pricing_rule.cy.js
+++ b/cypress/e2e/pricing/setup_simple_matrix_pricing_rule.cy.js
@@ -1,6 +1,6 @@
 context('Setup simple matrix pricing (role: admin)', () => {
   beforeEach(() => {
-    cy.loadFixturesWithSetup('../cypress/fixtures/pricing.yml')
+    cy.loadFixturesWithSetup(['ORM/user_admin.yml', 'ORM/packages.yml'])
     cy.login('admin', '12345678')
   })
 
@@ -11,6 +11,7 @@ context('Setup simple matrix pricing (role: admin)', () => {
     cy.get('[data-testid="pricing_rule_sets_add"]').click()
 
     // New pricing rule set page
+    cy.urlmatch(/\/admin\/deliveries\/pricing\/new$/)
     // Matrix:
     // columns: packages = SMALL, XL;
     // rows: diff_hours(pickup) > 4, < 4
@@ -80,6 +81,9 @@ context('Setup simple matrix pricing (role: admin)', () => {
 
     // Save button
     cy.get('.btn-block').click()
+
+    // Pricing rule page
+    cy.urlmatch(/\/admin\/deliveries\/pricing\/[0-9]+$/)
 
     cy.get('.alert-success', { timeout: 10000 })
       .should('contain', 'Changements sauvegardés')

--- a/cypress/e2e/pricing/setup_simple_multi_point_pricing_rule.cy.js
+++ b/cypress/e2e/pricing/setup_simple_multi_point_pricing_rule.cy.js
@@ -1,6 +1,6 @@
 context('Setup simple multi-point pricing (role: admin)', () => {
   beforeEach(() => {
-    cy.loadFixturesWithSetup('../cypress/fixtures/pricing.yml')
+    cy.loadFixturesWithSetup(['ORM/user_admin.yml', 'ORM/packages.yml'])
     cy.login('admin', '12345678')
   })
 
@@ -11,6 +11,7 @@ context('Setup simple multi-point pricing (role: admin)', () => {
     cy.get('[data-testid="pricing_rule_sets_add"]').click()
 
     // New pricing rule set page
+    cy.urlmatch(/\/admin\/deliveries\/pricing\/new$/)
     cy.get('#pricing_rule_set_name').type('Multi-point pricing')
 
     // Select strategy: All the matching rules
@@ -44,6 +45,9 @@ context('Setup simple multi-point pricing (role: admin)', () => {
     cy.intercept('POST', '/admin/deliveries/pricing/new').as('submit')
     cy.get('.btn-block').click()
     cy.wait('@submit', { timeout: 10000 })
+
+    // Pricing rule page
+    cy.urlmatch(/\/admin\/deliveries\/pricing\/[0-9]+$/)
 
     cy.get('.alert-success', { timeout: 10000 })
       .should('contain', 'Changements sauvegardés')

--- a/cypress/e2e/pricing/setup_time_slot_based_pricing_rule.cy.js
+++ b/cypress/e2e/pricing/setup_time_slot_based_pricing_rule.cy.js
@@ -1,0 +1,54 @@
+context('Setup pricing based on time slots (role: admin)', () => {
+  beforeEach(() => {
+    cy.loadFixturesWithSetup([
+      'ORM/user_admin.yml',
+      'ORM/time_slots_pagination.yml',
+    ])
+    cy.login('admin', '12345678')
+  })
+
+  it('creates pricing based on time slots', function () {
+    cy.visit('/admin/deliveries/pricing')
+
+    // List of all pricing rule sets
+    cy.get('[data-testid="pricing_rule_sets_add"]').click()
+
+    // New pricing rule set page
+    cy.urlmatch(/\/admin\/deliveries\/pricing\/new$/)
+
+    cy.get('#pricing_rule_set_name').type('Using time slots')
+
+    cy.get('[data-testid="pricing_rule_set_add_rule_target_task"]').click()
+    cy.get('[data-testid="pricing-rule-0"]').within(() => {
+      cy.get('[data-testid="rule-picker-add-condition"]').click()
+      cy.get(
+        '[data-testid="condition-0"] > :nth-child(1) > .form-control',
+      ).select('time_slot')
+      cy.get('[width="20%"] > .form-control').select('==')
+      cy.get('[width="25%"] > .form-control').select('/api/time_slots/20')
+      cy.get('#pricing_rule_set_rules_0_price').type('7')
+    })
+
+    cy.get('[data-testid="pricing_rule_set_add_rule_target_task"]').click()
+    cy.get('[data-testid="pricing-rule-1"]').within(() => {
+      cy.get('[data-testid="rule-picker-add-condition"]').click()
+      cy.get(
+        '[data-testid="condition-0"] > :nth-child(1) > .form-control',
+      ).select('time_slot')
+      cy.get('[width="20%"] > .form-control').select('==')
+      cy.get('[width="25%"] > .form-control').select('/api/time_slots/75')
+      cy.get('#pricing_rule_set_rules_1_price').type('15')
+    })
+
+    // Save button
+    cy.get('.btn-block').click()
+
+    // Pricing rule page
+    cy.urlmatch(/\/admin\/deliveries\/pricing\/[0-9]+$/)
+
+    cy.get('.alert-success', { timeout: 10000 }).should(
+      'contain',
+      'Changements sauvegardés',
+    )
+  })
+})

--- a/fixtures/ORM/packages.yml
+++ b/fixtures/ORM/packages.yml
@@ -1,0 +1,21 @@
+AppBundle\Entity\PackageSet:
+  package_set_1:
+    name: 'Standard'
+
+AppBundle\Entity\Package:
+  package_small:
+    name: 'SMALL'
+    maxVolumeUnits: 1.0
+    averageVolumeUnits: 1.0
+    packageSet: '@package_set_1'
+    description: ''
+    short_code: 'SM'
+    color: '#a91de0'
+  package_xl:
+    name: 'XL'
+    maxVolumeUnits: 3.0
+    averageVolumeUnits: 3.0
+    packageSet: '@package_set_1'
+    description: ''
+    short_code: 'XL'
+    color: '#a91de0'

--- a/fixtures/ORM/time_slots_pagination.yml
+++ b/fixtures/ORM/time_slots_pagination.yml
@@ -1,10 +1,6 @@
-include:
-  - user_admin.yml
-  - packages.yml
-
 AppBundle\Entity\TimeSlot:
-  time_slot_1:
-    name: 'Acme time slot'
+  time_slot_{1..120}:
+    name: 'Acme time slot <current()>'
     openingHours:
       - 'Mo-Su 00:00-11:59'
       - 'Mo-Su 12:00-23:59'

--- a/js/app/api/utils.js
+++ b/js/app/api/utils.js
@@ -1,0 +1,53 @@
+/**
+ * similar function exists in the mobile app codebase
+ */
+export async function fetchAllRecordsUsingFetchWithBQ(
+  fetchWithBQ,
+  url,
+  itemsPerPage,
+  otherParams = null,
+) {
+  const fetch = async page => {
+    const params = new URLSearchParams({
+      pagination: true,
+      page,
+      itemsPerPage,
+      ...otherParams,
+    })
+    const result = await fetchWithBQ(`${url}?${params.toString()}`)
+    return result.data
+  }
+  const firstRs = await fetch(1)
+
+  if (
+    !Object.hasOwn(firstRs, 'hydra:totalItems') ||
+    firstRs['hydra:totalItems'] <= firstRs['hydra:member'].length
+  ) {
+    // Total items were already returned in the 1st request!
+    return {
+      data: firstRs['hydra:member'],
+    }
+  }
+
+  // OK more pages are needed to be fetched to get all items..!
+  const totalItems = firstRs['hydra:totalItems']
+  const maxPage =
+    Math.trunc(totalItems / itemsPerPage) +
+    (totalItems % itemsPerPage === 0 ? 0 : 1)
+
+  return Promise.all(
+    [...Array(maxPage + 1).keys()].slice(2).map(page => fetch(page)),
+  )
+    .then(results =>
+      results.reduce(
+        (acc, rs) => acc.concat(rs['hydra:member']),
+        firstRs['hydra:member'],
+      ),
+    )
+    .then(results => {
+      return { data: results }
+    })
+    .catch(error => {
+      return { error }
+    })
+}

--- a/js/app/components/delivery-form/DeliveryForm.js
+++ b/js/app/components/delivery-form/DeliveryForm.js
@@ -129,24 +129,10 @@ export default function({
   const { data: storeData } = useGetStoreQuery(storeNodeId)
   const storeDeliveryInfos = useMemo(() => storeData ?? {}, [storeData])
 
-  const { data: tagsData } = useGetTagsQuery(undefined, {
+  const { data: tags } = useGetTagsQuery(undefined, {
     skip: !isDispatcher,
   })
-  const { data: addressesData } = useGetStoreAddressesQuery(storeNodeId)
-
-  const tags = useMemo(() => {
-    if (tagsData) {
-      return tagsData['hydra:member']
-    }
-    return []
-  }, [tagsData])
-
-  const addresses = useMemo(() => {
-    if (addressesData) {
-      return addressesData['hydra:member']
-    }
-    return []
-  }, [addressesData])
+  const { data: addresses } = useGetStoreAddressesQuery(storeNodeId)
 
   const [trackingLink, setTrackingLink] = useState('#')
   const [initialValues, setInitialValues] = useState({ tasks: [] })
@@ -230,17 +216,17 @@ export default function({
   const isDataReady = useMemo(() => {
     if (!storeData) return false
 
-    if (!addressesData) return false
+    if (!addresses) return false
 
-    if (isDispatcher && !tagsData) {
+    if (isDispatcher && !tags) {
       return false
     }
 
     return true
   }, [
     storeData,
-    addressesData,
-    tagsData,
+    addresses,
+    tags,
     isDispatcher
   ])
 

--- a/js/app/components/delivery-form/Task.js
+++ b/js/app/components/delivery-form/Task.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useState } from 'react'
 import { Field } from 'formik'
 import AddressBookNew from './AddressBook'
 import { Input, Button } from 'antd'
@@ -44,22 +44,8 @@ export default ({
     taskValues.type === 'DROPOFF' && values.tasks.length > 2,
   )
 
-  const { data: timeSlotsData } = useGetStoreTimeSlotsQuery(storeNodeId)
-  const { data: packagesData } = useGetStorePackagesQuery(storeNodeId)
-
-  const timeSlotLabels = useMemo(() => {
-    if (timeSlotsData) {
-      return timeSlotsData['hydra:member']
-    }
-    return []
-  }, [timeSlotsData])
-
-  const packages = useMemo(() => {
-    if (packagesData) {
-      return packagesData['hydra:member']
-    }
-    return null
-  }, [packagesData])
+  const { data: timeSlotLabels } = useGetStoreTimeSlotsQuery(storeNodeId)
+  const { data: packages } = useGetStorePackagesQuery(storeNodeId)
 
   return (
     <div className="task border p-4 mb-4" data-testid={`form-task-${index}`}>

--- a/js/app/delivery/pricing/components/RulePickerLine/TimeSlotPicker.js
+++ b/js/app/delivery/pricing/components/RulePickerLine/TimeSlotPicker.js
@@ -4,17 +4,11 @@ import PickerIsLoading from './PickerIsLoading'
 import PickerIsError from './PickerIsError'
 
 export default function TimeSlotPicker({ value, onChange }) {
-  const { data, isFetching } = useGetTimeSlotsQuery()
+  const { data: timeSlots, isFetching } = useGetTimeSlotsQuery()
 
   if (isFetching) {
     return <PickerIsLoading />
   }
-
-  if (!data) {
-    return <PickerIsError />
-  }
-
-  const timeSlots = data['hydra:member']
 
   if (!timeSlots) {
     return <PickerIsError />

--- a/templates/_partials/order/list.html.twig
+++ b/templates/_partials/order/list.html.twig
@@ -21,7 +21,7 @@
   </thead>
   <tbody>
   {% for order in orders %}
-  <tr>
+  <tr data-testid="order-list-item-{{ order.id }}">
     <td width="5%">
       {% if is_granted('ROLE_ADMIN') or (order.customer is not null and order.customer == app.user.customer) %}
       <a href="{{ path(routes.order, { id: order.id }) }}" class="text-monospace">

--- a/tests/AppBundle/Domain/Order/Reactor/UpdateStateTest.php
+++ b/tests/AppBundle/Domain/Order/Reactor/UpdateStateTest.php
@@ -17,6 +17,7 @@ use AppBundle\Entity\Sylius\Payment;
 use AppBundle\Entity\Task;
 use AppBundle\Sylius\Order\OrderInterface;
 use AppBundle\Utils\OrderTimeHelper;
+use Doctrine\ORM\EntityManagerInterface;
 use Prophecy\Argument;
 use Prophecy\PhpUnit\ProphecyTrait;
 use SM\Factory\FactoryInterface;
@@ -58,11 +59,14 @@ class UpdateStateTest extends KernelTestCase
             ->getShippingTimeRange(Argument::type(OrderInterface::class))
             ->willReturn($this->shippingTimeRange);
 
+        $this->entityManager = $this->prophesize(EntityManagerInterface::class);
+
         $this->updateState = new UpdateState(
             $this->stateMachineFactory,
             $this->orderProcessor->reveal(),
             $this->eventBus->reveal(),
-            $this->orderTimeHelper->reveal()
+            $this->orderTimeHelper->reveal(),
+            $this->entityManager->reveal()
         );
     }
 
@@ -107,7 +111,8 @@ class UpdateStateTest extends KernelTestCase
         $order->setState(OrderInterface::STATE_CART);
 
         $this->eventBus
-            ->dispatch(Argument::that(function (OrderStateChanged $event) {
+            ->dispatch(Argument::that(function (Envelope $message) {
+                $event = $message->getMessage();
                 $this->assertInstanceOf(OrderCreated::class, $event->getTriggeredBy());
                 return true;
             }))
@@ -136,7 +141,8 @@ class UpdateStateTest extends KernelTestCase
         $order->setState(OrderInterface::STATE_NEW);
 
         $this->eventBus
-            ->dispatch(Argument::that(function (OrderStateChanged $event) {
+            ->dispatch(Argument::that(function (Envelope $message) {
+                $event = $message->getMessage();
                 $this->assertInstanceOf(OrderAccepted::class, $event->getTriggeredBy());
                 return true;
             }))
@@ -164,7 +170,8 @@ class UpdateStateTest extends KernelTestCase
         $order->setDelivery($delivery);
 
         $this->eventBus
-            ->dispatch(Argument::that(function (OrderStateChanged $event) {
+            ->dispatch(Argument::that(function (Envelope $message) {
+                $event = $message->getMessage();
                 $this->assertInstanceOf(OrderFulfilled::class, $event->getTriggeredBy());
                 return true;
             }))
@@ -210,7 +217,8 @@ class UpdateStateTest extends KernelTestCase
         $order->addPayment($payment);
 
         $this->eventBus
-            ->dispatch(Argument::that(function (OrderStateChanged $event) {
+            ->dispatch(Argument::that(function (Envelope $message) {
+                $event = $message->getMessage();
                 $this->assertInstanceOf(OrderCancelled::class, $event->getTriggeredBy());
                 return true;
             }))


### PR DESCRIPTION
Fixes: https://github.com/coopcycle/coopcycle/issues/386

The order does not appear in the order list, because the order state is not updated, and the orders stays in the state `Cart`

Why?

We process `ImportDeliveries` message asynchronously and flush database changes at the end of the import: https://github.com/coopcycle/coopcycle-web/blob/master/src/MessageHandler/ImportDeliveriesHandler.php#L125

However, `OrderCreated` event is dispatched after the `ImportDeliveries` message is handled: https://github.com/coopcycle/coopcycle-web/blob/master/src/MessageHandler/Order/Command/OnDemandHandler.php#L30-L32 That's why, as I understand, all changes `UpdateState` makes are not written to the database.

(As I understand, in other situations `OrderCreated` and similar events are dispatched during request processing and `->with(new DispatchAfterCurrentBusStamp())` forces them to be executed after the current message, but before the request is processed and changes are flushed to the database)
