### PR TITLE
[PERTE-462] Add the day for push notification title

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ enable-xdebug:
 	@docker compose restart php nginx
 
 start:
-	@clear && docker compose up --remove-orphans
+	@clear && docker compose stop && docker compose up --remove-orphans
 
 # Once everything is restarted, you need to run in another terminal: `make setup`
 # And after setup is done, you need to stop/restart the containers again with: `make start`

--- a/src/MessageHandler/DeliveryCreatedHandler.php
+++ b/src/MessageHandler/DeliveryCreatedHandler.php
@@ -202,6 +202,10 @@ class DeliveryCreatedHandler
                 break;
         }
 
+        if (($day = $this->getDayForTitle($pickup->getAfter()))) {
+            $title = "(".$day.") " . $title;
+        }
+
         return [$title, $body];
     }
 
@@ -212,5 +216,17 @@ class DeliveryCreatedHandler
         $body = $taskaddr->getName() ? $taskaddr->getStreetAddress() : '';
 
         return [$title, $body];
+    }
+
+    private function getDayForTitle(\DateTime $dt): string
+    {
+        $datetime = Carbon::instance($dt);
+        $now = Carbon::now();
+
+        if ($datetime->format('Y-m-d') !== $now->format('Y-m-d')) {
+            return $datetime->locale($this->locale)->format('d M');
+        }
+
+        return "";
     }
 }


### PR DESCRIPTION
## Issue: https://github.com/coopcycle/coopcycle/issues/462

### Related PR
- https://github.com/coopcycle/coopcycle-app/pull/2037

<img width="298" height="242" alt="image" src="https://github.com/user-attachments/assets/4ffbc039-dc22-45c6-9cea-af5d325799dc" />

### Tasks:
- [x] Add the day for push notification title if the pickup date is not today.
- [x] Make sure all tests pass!