### PR TITLE
[PERTE-451] Avoid task updated notification modal for admins and dispatchers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ enable-xdebug:
 	@docker compose restart php nginx
 
 start:
-	@clear && docker compose stop && docker compose up --remove-orphans
+	@clear && docker compose up --remove-orphans && docker compose stop
 
 # Once everything is restarted, you need to run in another terminal: `make setup`
 # And after setup is done, you need to stop/restart the containers again with: `make start`

--- a/src/Doctrine/EventSubscriber/TaskListSubscriber.php
+++ b/src/Doctrine/EventSubscriber/TaskListSubscriber.php
@@ -193,9 +193,9 @@ class TaskListSubscriber implements EventSubscriber
             $users = $usersByDate[$date];
             $users = array_unique($users);
 
-            // We do not send push notifications to users with role ROLE_ADMIN,
+            // We do not send push notifications to users with role ROLE_ADMIN or ROLE_DISPATCHER,
             // they have WebSockets to get live updates
-            $users = array_filter($users, fn(UserInterface $user) => !$user->hasRole('ROLE_ADMIN'));
+            $users = array_filter($users, fn(UserInterface $user) => !($user->hasRole('ROLE_ADMIN') || $user->hasRole('ROLE_DISPATCHER')));
 
             if (count($users) === 0) {
                 continue;

--- a/tests/AppBundle/MessageHandler/Delivery/DeliveryCreatedHandlerTest.php
+++ b/tests/AppBundle/MessageHandler/Delivery/DeliveryCreatedHandlerTest.php
@@ -163,7 +163,7 @@ class DeliveryCreatedHandlerTest extends TestCase
 
         $title = 'Test Store -> Test Address Name';
         $body = "PU: 01:02-02:03 | DO: 03:04-04:05
-PU: " . $pickupAddress->getStreetAddress() . "
+PU: 111 Nice Pickup St, Somewhere, Argentina
 DO: 222 Nice Dropoff St, Someplace, Argentina";
         $data = [
             'event' => 'delivery:created',


### PR DESCRIPTION
## Issue https://github.com/coopcycle/coopcycle/issues/451

Main changes were done at coopcycle-app's PR:
https://github.com/coopcycle/coopcycle-app/pull/2042

The solution was to not consider as `"selectNotificationsToDisplay"` directly in app, because we still need the notification to update the task/tasklist in the app for every subscribed user (centrifugo / websocket).

### Tasks:
- [x] Filter out `task:updated` notifications for admins and dispatchers.
- [x] Make sure all test pass!