### PR TITLE
fix: make pawapay init optional

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1158,7 +1158,7 @@ services:
 
   AppBundle\Service\PawapayManager:
     arguments:
-      $countryCode: '%env(PAWAPAY_COUNTRY_CODE)%'
+      $countryCode: '%env(default::PAWAPAY_COUNTRY_CODE)%'
 
   AppBundle\Sylius\Order\ReceiptGenerator:
     arguments:

--- a/src/Service/PawapayManager.php
+++ b/src/Service/PawapayManager.php
@@ -19,12 +19,17 @@ class PawapayManager
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly LoggerInterface $logger,
         private string $locale,
-        private string $countryCode
+        private ?string $countryCode = null
     )
     {}
 
     public function createPaymentPage(PaymentInterface $payment, array $context = [])
     {
+        if (null === $this->countryCode) {
+            $this->logger->info('Order #%d | PawapayManager::createPaymentPage | Pawapay country code is not set', $payment->getOrder()->getId());
+            return;
+        }
+
         $order = $payment->getOrder();
         $customer = $order->getCustomer();
 


### PR DESCRIPTION
fix: make pawapay init optional, otherwise we have to configure pawapay env vars on all instances

```
err Environment variable not found: "PAWAPAY_COUNTRY_CODE".
```