### PR TITLE
fix: incident context display

### DIFF
--- a/js/app/admin/incidents/ux-react-controllers/Incident/IncidentItem.tsx
+++ b/js/app/admin/incidents/ux-react-controllers/Incident/IncidentItem.tsx
@@ -11,8 +11,10 @@ async function _fetchTaskContect(id) {
   );
 }
 
-function ContextDetails({ delivery, order }) {
+function ContextDetails({ context }) {
   const { t } = useTranslation();
+
+  const { delivery, order } = context;
 
   if (order) {
     const orderID = order?.number


### PR DESCRIPTION
fix: display order details in the summary

<img width="1882" height="244" alt="Screenshot 2025-11-12 at 16 48 32" src="https://github.com/user-attachments/assets/c40d8d26-b8e0-490c-b98f-8620971e24eb" />
