### PR TITLE
Update optional additional options copy

### DIFF
--- a/js/app/i18n/locales/en.json
+++ b/js/app/i18n/locales/en.json
@@ -410,7 +410,7 @@
         "CART_PRODUCT_OPTIONS_INVALID": "Some selections are not available",
         "CART_PRODUCT_OPTIONS_VALUES_RANGE": "Please choose between {{min}} and {{max}} values",
         "CART_PRODUCT_OPTIONS_VALUES_RANGE_AT_LEAST": "Please choose at least {{count}} value(s)",
-        "CART_PRODUCT_OPTIONS_VALUES_RANGE_UP_TO": "Please choose up to {{count}} value(s)",
+        "CART_PRODUCT_OPTIONS_VALUES_RANGE_UP_TO": "You can choose up to {{count}} value(s)",
         "RESTAURANT_DASHBOARD_INFO_RUSH": "Use this button to activate the 'rush' mode",
         "RESTAURANT_DASHBOARD_NEW_ORDERS": "New orders",
         "RESTAURANT_DASHBOARD_ACCEPTED_ORDERS": "Accepted orders",

--- a/js/app/i18n/locales/fr.json
+++ b/js/app/i18n/locales/fr.json
@@ -326,7 +326,7 @@
         "CART_PRODUCT_OPTIONS_INVALID": "Certaines options ne sont pas disponibles",
         "CART_PRODUCT_OPTIONS_VALUES_RANGE": "Veuillez choisir entre {{min}} et {{max}} valeurs",
         "CART_PRODUCT_OPTIONS_VALUES_RANGE_AT_LEAST": "Veuillez choisir au moins {{count}} valeur(s)",
-        "CART_PRODUCT_OPTIONS_VALUES_RANGE_UP_TO": "Veuillez choisir jusqu'à {{count}} valeur(s)",
+        "CART_PRODUCT_OPTIONS_VALUES_RANGE_UP_TO": "Vous pouvez choisir jusqu'à {{count}} valeur(s)",
         "RESTAURANTS_AND_STORES": "Restaurants et magasins",
         "ADMIN_DASHBOARD_MOVE_TO_NEXT_DAY_MULTI": "Déplacer {{count}} tâches au prochain jour",
         "ADMIN_DASHBOARD_MOVE_TO_NEXT_WORKING_DAY_MULTI": "Déplacer {{count}} tâches au prochain jour ouvré ({{nextWorkingDay}})",


### PR DESCRIPTION
Fixes #3935

Summary:
-  Change EN/FR “Please/Veuillez choose up to…” to “You can/Vous pouvez choose up to…”

Tests:
- Not run (text-only change)