### PR TITLE
Raise 3-column menu breakpoint to 1720px

### DIFF
--- a/js/app/restaurant/menu.scss
+++ b/js/app/restaurant/menu.scss
@@ -45,7 +45,7 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
-    @media (min-width: 1600px) {
+    @media (min-width: 1720px) {
       grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }


### PR DESCRIPTION
Fixes #4148

Summary:
- Adjust restaurant menu grid to switch to 3 columns at 1720px for wider layouts

Tests:
- Not run (CSS-only change)