### PR TITLE
fix(deps): migrate remaining files from react-beautiful-dnd to @hello-pangea/dnd

### DIFF
--- a/assets/react/controllers/Store/TimeSlot.jsx
+++ b/assets/react/controllers/Store/TimeSlot.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Select, Radio, Spin, notification } from "antd";
-import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
+import { DragDropContext, Draggable, Droppable } from "@hello-pangea/dnd";
 import _ from 'lodash';
 import { useTranslation } from 'react-i18next';
 

--- a/js/app/components/OpeningHours.js
+++ b/js/app/components/OpeningHours.js
@@ -9,7 +9,7 @@ import { withTranslation } from 'react-i18next'
 import openingHourIntervalToReadable from '../restaurant/parseOpeningHours'
 import TimeRange from '../utils/TimeRange'
 import { AntdConfigProvider, timePickerProps } from '../utils/antd'
-import { DragDropContext, Draggable, Droppable } from 'react-beautiful-dnd'
+import { DragDropContext, Draggable, Droppable } from '@hello-pangea/dnd'
 
 const minutes = []
 for (let i = 0; i <= 60; i++) {


### PR DESCRIPTION
Closes #4991

   ## Changes

   Migrates the last 2 files still importing from `react-beautiful-dnd`:

   - `js/app/components/OpeningHours.js`
   - `assets/react/controllers/Store/TimeSlot.jsx`

   Both now use `@hello-pangea/dnd` which is already used throughout the codebase (dashboard, pricing rules, etc.).

   ## Notes

   - `@hello-pangea/dnd` has an identical API, so this is a pure import change
   - No version upgrade included - staying on 16.6.0 to minimize risk
   - `react-beautiful-dnd` still appears in package-lock.json as a transitive dependency of `@cubejs-client/playground` (dev only, outside our control)

   ## Future consideration

   If the `defaultProps` warning persists, upgrading `@hello-pangea/dnd` to 18.x may help - happy to do that in a follow-up if desired.