### PR TITLE
Fix #3839: Sort recurrence rules by rule name instead of store name

### DIFF
--- a/js/app/dashboard/__tests__/selectors.js
+++ b/js/app/dashboard/__tests__/selectors.js
@@ -48,6 +48,19 @@ const th2359 = {
   }
 }
 
+const th = {
+  rule: 'FREQ=WEEKLY;BYDAY=TH',
+  template: {
+    '@type': 'hydra:Collection',
+    'hydra:member': [
+      {
+        after: '10:00',
+        before: '11:00'
+      }
+    ]
+  }
+}
+
 describe('Selectors', () => {
 
   describe('selectRecurrenceRules', () => {
@@ -86,6 +99,86 @@ describe('Selectors', () => {
           ]
         ),
       })).toEqual([ th2359 ])
+    })
+
+    it('sorts matching rules by name, then orgName for unnamed rules', () => {
+      const alpha = {
+        ...th,
+        '@id': '/api/recurrence_rules/11',
+        name: 'Alpha',
+        orgName: 'Zulu'
+      }
+      const zeta = {
+        ...th,
+        '@id': '/api/recurrence_rules/12',
+        name: 'zeta',
+        orgName: 'Alpha'
+      }
+      const unnamedAcme = {
+        ...th,
+        '@id': '/api/recurrence_rules/13',
+        orgName: 'Acme'
+      }
+      const unnamedBeta = {
+        ...th,
+        '@id': '/api/recurrence_rules/14',
+        orgName: 'Beta'
+      }
+
+      const result = selectRecurrenceRules({
+        logistics: {
+          date: "2021-03-04T23:00:00.000Z",
+        },
+        rrules: recurrenceRulesAdapter.upsertMany(
+          recurrenceRulesAdapter.getInitialState(),
+          [
+            unnamedBeta,
+            zeta,
+            unnamedAcme,
+            alpha
+          ]
+        ),
+      })
+
+      expect(result.map(rule => rule['@id'])).toEqual([
+        '/api/recurrence_rules/11',
+        '/api/recurrence_rules/12',
+        '/api/recurrence_rules/13',
+        '/api/recurrence_rules/14',
+      ])
+    })
+
+    it('uses @id as deterministic tie-breaker', () => {
+      const first = {
+        ...th,
+        '@id': '/api/recurrence_rules/20',
+        name: 'Same Name',
+        orgName: 'Same Org'
+      }
+      const second = {
+        ...th,
+        '@id': '/api/recurrence_rules/21',
+        name: 'Same Name',
+        orgName: 'Same Org'
+      }
+
+      const result = selectRecurrenceRules({
+        logistics: {
+          date: "2021-03-04T23:00:00.000Z",
+        },
+        rrules: recurrenceRulesAdapter.upsertMany(
+          recurrenceRulesAdapter.getInitialState(),
+          [
+            second,
+            first
+          ]
+        ),
+      })
+
+      expect(result.map(rule => rule['@id'])).toEqual([
+        '/api/recurrence_rules/20',
+        '/api/recurrence_rules/21',
+      ])
     })
   })
 })

--- a/js/app/dashboard/redux/selectors.js
+++ b/js/app/dashboard/redux/selectors.js
@@ -17,9 +17,44 @@ const taskListSelectors = taskListAdapter.getSelectors((state) => state.logistic
 export const taskSelectors = taskAdapter.getSelectors((state) => state.logistics.entities.tasks)
 export const tourSelectors = tourAdapter.getSelectors((state) => state.logistics.entities.tours)
 
+const normalizeRecurrenceRuleText = value =>
+  typeof value === 'string' ? value.trim() : ''
+
+const compareCaseInsensitive = (a, b) =>
+  a.localeCompare(b, undefined, { sensitivity: 'base' })
+
+const compareRecurrenceRules = (a, b) => {
+  const nameA = normalizeRecurrenceRuleText(a.name)
+  const nameB = normalizeRecurrenceRuleText(b.name)
+  const hasNameA = nameA.length > 0
+  const hasNameB = nameB.length > 0
+
+  if (hasNameA && hasNameB) {
+    const byName = compareCaseInsensitive(nameA, nameB)
+    if (byName !== 0) {
+      return byName
+    }
+  } else if (hasNameA !== hasNameB) {
+    return hasNameA ? -1 : 1
+  }
+
+  const byOrgName = compareCaseInsensitive(
+    normalizeRecurrenceRuleText(a.orgName),
+    normalizeRecurrenceRuleText(b.orgName)
+  )
+  if (byOrgName !== 0) {
+    return byOrgName
+  }
+
+  return compareCaseInsensitive(
+    normalizeRecurrenceRuleText(a['@id']),
+    normalizeRecurrenceRuleText(b['@id'])
+  )
+}
+
 export const recurrenceRulesAdapter = createEntityAdapter({
   selectId: (o) => o['@id'],
-  sortComparer: (a, b) => a.orgName.localeCompare(b.orgName),
+  sortComparer: compareRecurrenceRules,
 })
 
 // UI selectors


### PR DESCRIPTION
 Fixes #3839

  Recurrence rules in the Dispatch dashboard were sorted by `orgName` (store/organization name), ignoring the
  rule `name`. This meant that even after naming rules, the list order didn't reflect those names.

  ## What changed

  The `sortComparer` on `recurrenceRulesAdapter` in `js/app/dashboard/redux/selectors.js` has been replaced with
  a multi-level comparator that sorts by:

  - Rule name (case-insensitive): named rules appear first, sorted alphabetically
  - `orgName` (case-insensitive): fallback for unnamed rules or when names are equal
  - `@id`: deterministic tie-breaker when both `name` and `orgName` are identical

  Rules with no `name` (or a whitespace-only/empty name) are treated as unnamed and appear after all named
  rules, sorted among themselves by `orgName`.

  No backend/API changes. Date/time filtering logic is untouched.

  ## Tests

  - Named rules sort alphabetically by name (case-insensitive), regardless of `orgName`
  - Named rules appear before unnamed rules
  - Unnamed rules fall back to `orgName` ordering
  - `@id` tie-breaker ensures deterministic ordering when `name` and `orgName` are equal
  - `docker compose exec -T -e APP_ENV=test -e NODE_ENV=test webpack npm run jest -- --testMatch "**/dashboard/
  __tests__/selectors.js"` (PASS)