### PR TITLE
Try to optimize endpoint.

### DIFF
--- a/src/Api/State/MyOrdersProvider.php
+++ b/src/Api/State/MyOrdersProvider.php
@@ -3,6 +3,8 @@
 namespace AppBundle\Api\State;
 
 use ApiPlatform\Metadata\Operation;
+use ApiPlatform\State\Pagination\PaginatorInterface;
+use ApiPlatform\State\Pagination\TraversablePaginator;
 use ApiPlatform\State\ProviderInterface;
 use ApiPlatform\Doctrine\Orm\Extension\QueryResultCollectionExtensionInterface;
 use ApiPlatform\Doctrine\Orm\Util\QueryNameGenerator;
@@ -11,6 +13,8 @@ use AppBundle\Entity\Sylius\Customer;
 use AppBundle\Entity\Sylius\Order;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query\Expr\Join;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+use ShipMonk\DoctrineEntityPreloader\EntityPreloader;
 use Symfony\Component\Security\Core\Security;
 
 final class MyOrdersProvider implements ProviderInterface
@@ -27,26 +31,66 @@ final class MyOrdersProvider implements ProviderInterface
     {
         $entityClass = $operation->getClass();
 
-        $queryBuilder = $this->entityManager->getRepository($entityClass)
-            ->createQueryBuilder('o')
-            ->orderBy('o.createdAt', 'DESC')
-            ->innerJoin(Customer::class, 'c', Join::WITH, 'o.customer = c.id')
+        $qb = $this->entityManager->getRepository(Customer::class)
+            ->createQueryBuilder('c')
             ->innerJoin(User::class, 'u', Join::WITH, 'u.customer = c.id')
             ->where('u.id = :user')
+            ->setParameter('user', $this->security->getUser());
+
+        $customer = $qb->getQuery()->getOneOrNullResult();
+
+        $queryBuilder = $this->entityManager->getRepository($entityClass)
+            ->createQueryBuilder('o')
+            ->andWhere('o.customer = :customer')
             ->andWhere('o.state != :state_cart')
-            ->setParameter('user', $this->security->getUser())
+            ->orderBy('o.createdAt', 'DESC')
+            ->setParameter('customer', $customer)
             ->setParameter('state_cart', Order::STATE_CART)
             ;
 
+        // https://github.com/coopcycle/coopcycle-web/issues/5188
+        // FIXME Doesn't work
+        // $queryBuilder->getQuery()->setHint(Paginator::HINT_ENABLE_DISTINCT, false);
+
         $queryNameGenerator = new QueryNameGenerator();
         foreach ($this->collectionExtensions as $extension) {
+
             $extension->applyToCollection($queryBuilder, $queryNameGenerator, $entityClass, $operation, $context);
 
             if ($extension instanceof QueryResultCollectionExtensionInterface && $extension->supportsResult($entityClass, $operation, $context)) {
-                return $extension->getResult($queryBuilder, $entityClass, $operation, $context);
+                return $this->preload($extension->getResult($queryBuilder, $entityClass, $operation, $context));
             }
         }
 
-        return $queryBuilder->getQuery()->getResult();
+        // FIXME
+        // Serialize only what is needed for the app.
+
+        $orders = $queryBuilder->getQuery()->getResult();
+
+        return $this->preload($orders);
+    }
+
+    private function preload(iterable $result): iterable
+    {
+        $orders = \iterator_to_array($result);
+
+        $preloader = new EntityPreloader($this->entityManager);
+        $preloader->preload($orders, 'adjustments');
+        $preloader->preload($orders, 'payments');
+
+        $items = $preloader->preload($orders, 'items');
+        $variant = $preloader->preload($items, 'variant');
+        $product = $preloader->preload($variant, 'product');
+
+        if ($result instanceof PaginatorInterface) {
+            return new TraversablePaginator(
+                new \ArrayIterator($orders),
+                $result->getCurrentPage(),
+                $result->getItemsPerPage(),
+                $result->getTotalItems()
+            );
+        }
+
+        return $orders;
     }
 }

--- a/src/Entity/Sylius/Order.php
+++ b/src/Entity/Sylius/Order.php
@@ -376,7 +376,13 @@ use Webmozart\Assert\Assert as WMAssert;
             denormalizationContext: ['groups' => ['order_create', 'address_create']],
             write: false
         ),
-        new GetCollection(uriTemplate: '/me/orders', provider: MyOrdersProvider::class),
+        new GetCollection(
+            uriTemplate: '/me/orders',
+            provider: MyOrdersProvider::class,
+            // Optimize performance
+            // https://api-platform.com/docs/v3.4/core/pagination/#controlling-the-behavior-of-the-doctrine-orm-paginator
+            paginationFetchJoinCollection: false
+        ),
         new GetCollection(
             // FIXME Maybe it shouldn't be a path param
             // It should be like /invoice_line_items?grouped_by_organization=1


### PR DESCRIPTION
See #5188

I actually used the `paginationFetchJoinCollection` attribute on the operation to modify the underlying Doctrine mechanism

> This behavior is only necessary if you actually fetch join a to-many collection. You can disable this behavior by setting the fetchJoinCollection argument to false; in that case only 2 instead of the 3 queries described are executed. We hope to automate the detection for this in the future.

Before 

<img width="1220" height="317" alt="Capture d’écran 2026-02-06 à 10 21 39" src="https://github.com/user-attachments/assets/97be70a7-a54f-425b-9d12-4238d198c45a" />

After

<img width="1215" height="317" alt="Capture d’écran 2026-02-06 à 10 22 21" src="https://github.com/user-attachments/assets/723a8435-3762-42b3-902f-6d47eb795cd1" />

---

However, one DISTINCT query is still there, this is why I don't close the issue. 