### PR TITLE
Use Doctrine event listeners instead of subscribers 

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -613,18 +613,13 @@ services:
     tags:
       - { name: kernel.event_subscriber }
 
-  AppBundle\EventListener\SyliusIdGeneratorSubscriber:
-    tags:
-      #FIXME: Doctrine subscriber is deprecated. Use #[AsDocumentListener] instead
-      - { name: doctrine.event_subscriber, connection: default }
+  AppBundle\EventListener\SyliusIdGeneratorSubscriber: ~
 
   AppBundle\EventListener\LogoutSubscriber: ~
 
   AppBundle\EventListener\TaggableSubscriber:
     arguments: [ '@coopcycle.tag_manager' ]
     tags:
-      #FIXME: Doctrine subscriber is deprecated. Use #[AsDocumentListener] instead
-      - { name: doctrine.event_subscriber, connection: default }
       - { name: monolog.logger, channel: coopcycle.tagging }
 
   AppBundle\Service\DeliveryManager:
@@ -848,8 +843,6 @@ services:
   AppBundle\Doctrine\EventSubscriber\TourSubscriber:
     tags:
       - { name: monolog.logger, channel: coopcycle.logistics }
-      #FIXME: Doctrine subscriber is deprecated. Use #[AsDocumentListener] instead
-      - { name: doctrine.event_subscriber, connection: default, priority: 48 }
 
   AppBundle\Doctrine\EventSubscriber\TaskSubscriber:
     tags:
@@ -858,36 +851,20 @@ services:
   AppBundle\Doctrine\EventSubscriber\TaskCollectionSubscriber:
     tags:
       - { name: monolog.logger, channel: coopcycle.logistics }
-      #FIXME: Doctrine subscriber is deprecated. Use #[AsDocumentListener] instead
-      - { name: doctrine.event_subscriber, connection: default, priority: 16 }
 
   AppBundle\Doctrine\EventSubscriber\TaskListSubscriber:
     tags:
       - { name: monolog.logger, channel: coopcycle.logistics }
-      #FIXME: Doctrine subscriber is deprecated. Use #[AsDocumentListener] instead
-      - { name: doctrine.event_subscriber, connection: default, priority: 16 }
 
-  AppBundle\Doctrine\EventSubscriber\OrganizationSubscriber:
-    tags:
-      #FIXME: Doctrine subscriber is deprecated. Use #[AsDocumentListener] instead
-      - { name: doctrine.event_subscriber }
+  AppBundle\Doctrine\EventSubscriber\OrganizationSubscriber: ~
 
   AppBundle\Doctrine\EventSubscriber\SearchDeliveriesSubscriber:
     tags:
       - { name: monolog.logger, channel: coopcycle.search }
-      #FIXME: Doctrine subscriber is deprecated. Use #[AsDocumentListener] instead
-      - { name: doctrine.event_subscriber }
 
-  AppBundle\Doctrine\EventSubscriber\DeliverySubscriber:
-    tags:
-      #FIXME: Doctrine subscriber is deprecated. Use #[AsDocumentListener] instead
-      - { name: doctrine.event_subscriber }
+  AppBundle\Doctrine\EventSubscriber\DeliverySubscriber: ~
 
-  # needs to be run last to take into account all changes
-  AppBundle\Doctrine\EventSubscriber\LoggerSubscriber:
-    tags:
-      #FIXME: Doctrine subscriber is deprecated. Use #[AsDocumentListener] instead
-      - { name: doctrine.event_subscriber, priority: -100 }
+  AppBundle\Doctrine\EventSubscriber\LoggerSubscriber: ~
 
   AppBundle\Api\EventSubscriber\DeliverySubscriber:
     tags: [ 'kernel.event_subscriber' ]
@@ -924,10 +901,7 @@ services:
       - { name: kernel.event_subscriber }
       - { name: monolog.logger, channel: urbantz }
 
-  AppBundle\Doctrine\EventSubscriber\ShopsEventsForTypesenseSubscriber:
-    tags:
-      #FIXME: Doctrine subscriber is deprecated. Use #[AsDocumentListener] instead
-      - { name: doctrine.event_subscriber }
+  AppBundle\Doctrine\EventSubscriber\ShopsEventsForTypesenseSubscriber: ~
 
   AppBundle\Action\Settings:
     public: true

--- a/config/services/doctrine_extensions.yml
+++ b/config/services/doctrine_extensions.yml
@@ -96,11 +96,7 @@ services:
             # - [ setClock, [ '@clock' ] ]
 
 
-    coopcycle.listener.post_soft_delete:
-        class: AppBundle\Doctrine\EventSubscriber\PostSoftDeleteSubscriber
-        tags:
-            #FIXME: Doctrine subscriber is deprecated. Use #[AsDocumentListener] instead
-            - { name: doctrine.event_subscriber }
+    AppBundle\Doctrine\EventSubscriber\PostSoftDeleteSubscriber: ~
 
     postgis.event_subscriber:
         class: AppBundle\Doctrine\PostGIS\ORMSchemaEventSubscriber

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -44,7 +44,7 @@ services:
           $s3Path: '%env(CUBEJS_DUCKDB_S3_PATH)%'
           $appName: '%env(COOPCYCLE_APP_NAME)%'
 
-    AppBundle\Doctrine\EventSubscriber\MockDateSubscriber:
+    AppBundle\Doctrine\EventSubscriber\MockDateSubscriber: ~
 
     app.map_center:
         class: League\Geotools\Coordinate\Coordinate

--- a/src/Doctrine/EventSubscriber/DeliverySubscriber.php
+++ b/src/Doctrine/EventSubscriber/DeliverySubscriber.php
@@ -4,14 +4,16 @@ namespace AppBundle\Doctrine\EventSubscriber;
 
 use AppBundle\Entity\Delivery;
 use AppBundle\Message\DeliveryCreated;
-use Doctrine\Common\EventSubscriber;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Events;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-class DeliverySubscriber implements EventSubscriber
+#[AsDoctrineListener(event: Events::onFlush, connection: 'default')]
+#[AsDoctrineListener(event: Events::postFlush, connection: 'default')]
+class DeliverySubscriber
 {
     private $messageBus;
     private $deliveries = [];
@@ -20,14 +22,6 @@ class DeliverySubscriber implements EventSubscriber
     public function __construct(MessageBusInterface $messageBus)
     {
         $this->messageBus = $messageBus;
-    }
-
-    public function getSubscribedEvents()
-    {
-        return array(
-            Events::onFlush,
-            Events::postFlush,
-        );
     }
 
     public function onFlush(OnFlushEventArgs $args)

--- a/src/Doctrine/EventSubscriber/LoggerSubscriber.php
+++ b/src/Doctrine/EventSubscriber/LoggerSubscriber.php
@@ -2,7 +2,7 @@
 
 namespace AppBundle\Doctrine\EventSubscriber;
 
-use Doctrine\Common\EventSubscriber;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Events;
@@ -11,7 +11,9 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 
-class LoggerSubscriber implements EventSubscriber
+#[AsDoctrineListener(event: Events::onFlush, priority: -100, connection: 'default')]
+#[AsDoctrineListener(event: Events::postFlush, priority: -100, connection: 'default')]
+class LoggerSubscriber
 {
 
     /** @var EntityItem[] */
@@ -24,14 +26,6 @@ class LoggerSubscriber implements EventSubscriber
     public function __construct(
         private readonly LoggerInterface $databaseLogger)
     {
-    }
-
-    public function getSubscribedEvents(): array
-    {
-        return array(
-            Events::onFlush,
-            Events::postFlush,
-        );
     }
 
     public function onFlush(OnFlushEventArgs $args): void

--- a/src/Doctrine/EventSubscriber/MockDateSubscriber.php
+++ b/src/Doctrine/EventSubscriber/MockDateSubscriber.php
@@ -3,22 +3,12 @@
 namespace AppBundle\Doctrine\EventSubscriber;
 
 use Carbon\Carbon;
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Events;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Gedmo\Timestampable\Traits\Timestampable;
 
-class MockDateSubscriber implements EventSubscriber
+class MockDateSubscriber
 {
-
-    public function getSubscribedEvents()
-    {
-        return [
-            Events::prePersist,
-            Events::preUpdate,
-        ];
-    }
-
     public function prePersist(LifecycleEventArgs $args)
     {
         $entity = $args->getObject();

--- a/src/Doctrine/EventSubscriber/OrganizationSubscriber.php
+++ b/src/Doctrine/EventSubscriber/OrganizationSubscriber.php
@@ -7,11 +7,12 @@ use AppBundle\Entity\Organization;
 use AppBundle\Entity\Store;
 use AppBundle\Entity\Task;
 use AppBundle\Security\TokenStoreExtractor;
-use Doctrine\Common\EventSubscriber;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
 
-class OrganizationSubscriber implements EventSubscriber
+#[AsDoctrineListener(event: Events::prePersist, connection: 'default')]
+class OrganizationSubscriber
 {
     private $storeExtractor;
 
@@ -19,13 +20,6 @@ class OrganizationSubscriber implements EventSubscriber
         TokenStoreExtractor $storeExtractor)
     {
         $this->storeExtractor = $storeExtractor;
-    }
-
-    public function getSubscribedEvents()
-    {
-        return array(
-            Events::prePersist,
-        );
     }
 
     /**

--- a/src/Doctrine/EventSubscriber/PostSoftDeleteSubscriber.php
+++ b/src/Doctrine/EventSubscriber/PostSoftDeleteSubscriber.php
@@ -12,10 +12,12 @@ use AppBundle\Entity\Trailer;
 use AppBundle\Entity\Vehicle;
 use AppBundle\Sylius\Product\ProductInterface;
 use AppBundle\Sylius\Product\ProductOptionInterface;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Gedmo\SoftDeleteable\SoftDeleteableListener;
 
+#[AsDoctrineListener(event: SoftDeleteableListener::POST_SOFT_DELETE, connection: 'default')]
 class PostSoftDeleteSubscriber implements EventSubscriber
 {
     /**

--- a/src/Doctrine/EventSubscriber/SearchDeliveriesSubscriber.php
+++ b/src/Doctrine/EventSubscriber/SearchDeliveriesSubscriber.php
@@ -5,27 +5,21 @@ namespace AppBundle\Doctrine\EventSubscriber;
 use AppBundle\Entity\Delivery;
 use AppBundle\Entity\Task;
 use AppBundle\Message\IndexDeliveries;
-use Doctrine\Common\EventSubscriber;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Events;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-class SearchDeliveriesSubscriber implements EventSubscriber
+#[AsDoctrineListener(event: Events::onFlush, connection: 'default')]
+#[AsDoctrineListener(event: Events::postFlush, connection: 'default')]
+class SearchDeliveriesSubscriber
 {
     private $deliveries = [];
 
     public function __construct(private MessageBusInterface $messageBus)
     {}
-
-    public function getSubscribedEvents()
-    {
-        return array(
-            Events::onFlush,
-            Events::postFlush,
-        );
-    }
 
     public function onFlush(OnFlushEventArgs $args)
     {

--- a/src/Doctrine/EventSubscriber/ShopsEventsForTypesenseSubscriber.php
+++ b/src/Doctrine/EventSubscriber/ShopsEventsForTypesenseSubscriber.php
@@ -7,8 +7,8 @@ use ACSEO\TypesenseBundle\Manager\DocumentManager;
 use AppBundle\Entity\LocalBusiness;
 use AppBundle\Entity\Sylius\Product;
 use AppBundle\Enum\FoodEstablishment;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Events;
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Psr\Log\LoggerInterface;
 use Gedmo\SoftDeleteable\SoftDeleteableListener;
@@ -16,7 +16,9 @@ use Typesense\Exceptions\ObjectNotFound;
 use ACSEO\TypesenseBundle\Client\TypesenseClient;
 use AppBundle\Entity\Store;
 
-class ShopsEventsForTypesenseSubscriber implements EventSubscriber
+#[AsDoctrineListener(event: SoftDeleteableListener::POST_SOFT_DELETE, connection: 'default')]
+#[AsDoctrineListener(event: Events::postUpdate, connection: 'default')]
+class ShopsEventsForTypesenseSubscriber
 {
     private $productsCollection;
     private $maxPosts = 250;
@@ -28,14 +30,6 @@ class ShopsEventsForTypesenseSubscriber implements EventSubscriber
         private TypesenseClient $typesenseClient)
     {
         $this->productsCollection = array_search(Product::class, $this->collectionManager->getManagedClassNames(), true);
-    }
-
-    public function getSubscribedEvents()
-    {
-        return array(
-            SoftDeleteableListener::POST_SOFT_DELETE,
-            Events::postUpdate,
-        );
     }
 
     public function postSoftDelete(LifecycleEventArgs $args)

--- a/src/Doctrine/EventSubscriber/TaskCollectionSubscriber.php
+++ b/src/Doctrine/EventSubscriber/TaskCollectionSubscriber.php
@@ -6,13 +6,15 @@ use AppBundle\Entity\Task\CollectionInterface as TaskCollectionInterface;
 use AppBundle\Entity\TaskCollection;
 use AppBundle\Entity\TaskCollectionItem;
 use AppBundle\Service\RoutingInterface;
-use Doctrine\Common\EventSubscriber;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Events;
 use Psr\Log\LoggerInterface;
 
-class TaskCollectionSubscriber implements EventSubscriber
+#[AsDoctrineListener(event: Events::prePersist, priority: 16, connection: 'default')]
+#[AsDoctrineListener(event: Events::onFlush, priority: 16, connection: 'default')]
+class TaskCollectionSubscriber
 {
     private $routing;
     private $logger;
@@ -23,14 +25,6 @@ class TaskCollectionSubscriber implements EventSubscriber
     {
         $this->routing = $routing;
         $this->logger = $logger;
-    }
-
-    public function getSubscribedEvents()
-    {
-        return array(
-            Events::prePersist,
-            Events::onFlush
-        );
     }
 
     private function calculate(TaskCollectionInterface $taskCollection)

--- a/src/Doctrine/EventSubscriber/TaskListSubscriber.php
+++ b/src/Doctrine/EventSubscriber/TaskListSubscriber.php
@@ -11,7 +11,7 @@ use AppBundle\Message\PushNotification;
 use AppBundle\Service\RemotePushNotificationManager;
 use AppBundle\Service\RoutingInterface;
 use Carbon\Carbon;
-use Doctrine\Common\EventSubscriber;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
@@ -21,7 +21,10 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
-class TaskListSubscriber implements EventSubscriber
+#[AsDoctrineListener(event: Events::prePersist, priority: 16, connection: 'default')]
+#[AsDoctrineListener(event: Events::onFlush, priority: 16, connection: 'default')]
+#[AsDoctrineListener(event: Events::postFlush, priority: 16, connection: 'default')]
+class TaskListSubscriber
 {
     private $taskLists = [];
 
@@ -33,15 +36,6 @@ class TaskListSubscriber implements EventSubscriber
         private readonly LoggerInterface $logger
     )
     {
-    }
-
-    public function getSubscribedEvents()
-    {
-        return array(
-            Events::prePersist,
-            Events::onFlush,
-            Events::postFlush,
-        );
     }
 
     private function calculate(TaskList $taskList)

--- a/src/Doctrine/EventSubscriber/TourSubscriber.php
+++ b/src/Doctrine/EventSubscriber/TourSubscriber.php
@@ -6,14 +6,16 @@ use AppBundle\Domain\Tour\Event\TourCreated;
 use AppBundle\Domain\Tour\Event\TourUpdated;
 use AppBundle\Entity\TaskCollectionItem;
 use AppBundle\Entity\Tour;
-use Doctrine\Common\EventSubscriber;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Events;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-class TourSubscriber implements EventSubscriber
+#[AsDoctrineListener(event: Events::onFlush, priority: 48, connection: 'default')]
+#[AsDoctrineListener(event: Events::postFlush, priority: 48, connection: 'default')]
+class TourSubscriber
 {
 
     private $insertedTours = [];
@@ -24,14 +26,6 @@ class TourSubscriber implements EventSubscriber
         private LoggerInterface $logger,
         private MessageBusInterface $eventBus
     ) {}
-
-    public function getSubscribedEvents()
-    {
-        return array(
-            Events::onFlush,
-            Events::postFlush
-        );
-    }
 
     /**
      * Trickles down the assignment information from tour to tasks.

--- a/src/EventListener/SyliusIdGeneratorSubscriber.php
+++ b/src/EventListener/SyliusIdGeneratorSubscriber.php
@@ -2,8 +2,9 @@
 
 namespace AppBundle\EventListener;
 
-use Doctrine\Common\EventSubscriber;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\ORM\Events;
 use Doctrine\ORM\Id\IdentityGenerator;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Sylius\Component\Resource\Model\ResourceInterface;
@@ -11,15 +12,9 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 /**
  * This class is needed because Sylius uses the "AUTO" strategy, which doesn't work in PostgreSQL.
  */
-class SyliusIdGeneratorSubscriber implements EventSubscriber
+#[AsDoctrineListener(event: Events::loadClassMetadata, connection: 'default')]
+class SyliusIdGeneratorSubscriber
 {
-    public function getSubscribedEvents()
-    {
-        return array(
-            'loadClassMetadata',
-        );
-    }
-
     public function loadClassMetadata(LoadClassMetadataEventArgs $args)
     {
         $metadata = $args->getClassMetadata();

--- a/src/EventListener/TaggableSubscriber.php
+++ b/src/EventListener/TaggableSubscriber.php
@@ -4,14 +4,17 @@ namespace AppBundle\EventListener;
 
 use AppBundle\Entity\Model\TaggableInterface;
 use AppBundle\Service\TagManager;
-use Doctrine\Common\EventSubscriber;
+use Doctrine\Bundle\DoctrineBundle\Attribute\AsDoctrineListener;
 use Doctrine\ORM\Event\OnFlushEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Events;
 use Psr\Log\LoggerInterface;
 
-class TaggableSubscriber implements EventSubscriber
+#[AsDoctrineListener(event: Events::onFlush, connection: 'default')]
+#[AsDoctrineListener(event: Events::postLoad, connection: 'default')]
+#[AsDoctrineListener(event: Events::postFlush, connection: 'default')]
+class TaggableSubscriber
 {
     private TagManager $tagManager;
     private LoggerInterface $logger;
@@ -26,15 +29,6 @@ class TaggableSubscriber implements EventSubscriber
 
         $this->added   = new \SplObjectStorage();
         $this->removed = new \SplObjectStorage();
-    }
-
-    public function getSubscribedEvents()
-    {
-        return array(
-            Events::onFlush,
-            Events::postLoad,
-            Events::postFlush,
-        );
     }
 
     public function onFlush(OnFlushEventArgs $args)

--- a/tests/Behat/FeatureContext.php
+++ b/tests/Behat/FeatureContext.php
@@ -315,7 +315,8 @@ class FeatureContext implements Context, SnippetAcceptingContext
         $this->redis->set('datetime:now', Carbon::now()->toAtomString());
 
         // Mock createdAt and updatedAt fields in the database
-        $this->entityManager->getEventManager()->addEventSubscriber(
+        $this->entityManager->getEventManager()->addEventListener(
+            ['prePersist', 'preUpdate'],
             $this->mockDateSubscriber
         );
     }


### PR DESCRIPTION
https://symfony.com/doc/6.4/doctrine/events.html#doctrine-lifecycle-subscribers

We are still using `doctrine.event_subscriber` on classes from `jsor/doctrine-postgis`, because [new usage](https://github.com/jsor/doctrine-postgis/blob/main/docs/symfony.md) doesn't work. 