### PR TITLE
Fix tag color badge text after tag rename

### DIFF
--- a/templates/admin/tags.html.twig
+++ b/templates/admin/tags.html.twig
@@ -26,7 +26,7 @@
 {% for tag in tags %}
 <tr>
   <td><a href="{{ is_granted("ROLE_ADMIN") ? path('admin_tag', { slug: tag.slug }) : '#' }}">{{ tag.name }}</a></td>
-  <td><span class="label label-default" style="background-color: {{ tag.color }};">{{ tag.slug }}</span></td>
+  <td><span class="label label-default" style="background-color: {{ tag.color }};">{{ tag.name }}</span></td>
   {% if is_granted('ROLE_ADMIN') %}
   <td>
   	<form method="POST">


### PR DESCRIPTION
## Summary
Show tag name (not slug) in the admin tags color badge so renamed tags display consistently.

## Root cause
The template rendered 	ag.slug in the color badge, while slug is immutable.

Closes #1973