### PR TITLE
fix(admin): show tag name instead of slug in color badge

### DIFF
--- a/templates/admin/tags.html.twig
+++ b/templates/admin/tags.html.twig
@@ -26,7 +26,7 @@
 {% for tag in tags %}
 <tr>
   <td><a href="{{ is_granted("ROLE_ADMIN") ? path('admin_tag', { slug: tag.slug }) : '#' }}">{{ tag.name }}</a></td>
-  <td><span class="label label-default" style="background-color: {{ tag.color }};">{{ tag.slug }}</span></td>
+  <td><span class="label label-default" style="background-color: {{ tag.color }};">{{ tag.name }}</span></td>
   {% if is_granted('ROLE_ADMIN') %}
   <td>
   	<form method="POST">


### PR DESCRIPTION
## What this PR does:

On the admin tags page (`/admin/tags`), the colored badge next to each tag was displaying the tag's `slug` instead of its `name`. After a tag is renamed, the badge would still show the old slug-based text, which is confusing for admins.

This PR changes the badge label from `tag.slug` to `tag.name` so the color badge always reflects the current tag name.

---

## Changes:

- `tags.html.twig:29`: replaced `{{ tag.slug }}` with `{{ tag.name }}` in the color badge `<span>`

---

## How to test:

1. Go to the admin tags page  
2. Observe that color badges now show the tag **name**  
3. Rename a tag and verify the badge updates to show the new name  

Fixes #1973