### PR TITLE
Fix crash in foodtech dashboard when an order has no customer

### DIFF
--- a/js/app/foodtech/dashboard/components/Customer.js
+++ b/js/app/foodtech/dashboard/components/Customer.js
@@ -6,7 +6,7 @@ export default ({ customer }) => {
     <>
       <i className="fa fa-user mr-1"></i>
       <span>{ customer?.username }</span>
-      { (Array.isArray(customer.tags) && customer.tags.length > 0) &&
+      { (Array.isArray(customer?.tags) && customer.tags.length > 0) &&
         <span className="ml-1">
           { customer.tags.map((tag) => (
             <i key={ tag.slug } title={ tag.slug } className="fa fa-circle mr-1" style={{ color: tag.color }}></i>


### PR DESCRIPTION
Ran into a white screen on the foodtech dashboard orders view:

```
TypeError: Cannot read properties of null (reading 'tags')
```

`Customer.js` reads `customer.tags` directly, but the username on the line above already uses optional chaining:

```jsx
<span>{ customer?.username }</span>
{ (Array.isArray(customer.tags) && customer.tags.length > 0) &&
```

It's used as `<Customer customer={order.customer} />` in OrderCard.js and ModalContent.js. Some orders don't have a customer (API-created orders, guest orders), so `order.customer` is null and `Array.isArray(customer.tags)` throws — which takes down the whole orders view, not just the card.

Just added the `?.` to the guard so it matches the username handling:

```jsx
{ (Array.isArray(customer?.tags) && customer.tags.length > 0) &&
```

If customer is null the `&&` short-circuits before the `.length`/`.map` lines, so a customer-less order renders the icon and empty username instead of crashing.

To reproduce: open the foodtech dashboard for a restaurant that has an order with no customer (e.g. created via the API).