### PR TITLE
Upgrade Picqer barcode generator to v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -160,7 +160,7 @@
         "paygreen/paygreen-php": "*",
         "flow-php/parquet": "^0.16",
         "flow-php/filesystem": "^0.16",
-        "picqer/php-barcode-generator": "^2.4",
+        "picqer/php-barcode-generator": "^3.2",
         "shipmonk/doctrine-entity-preloader": "^1.0",
         "z4kn4fein/php-semver": "^3.0",
         "invenso/rector": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29678742ad6a00a23f0c2d06aac0212d",
+    "content-hash": "157d41558c12d8f24821aa6c3f4b1d5e",
     "packages": [
         {
             "name": "acseo/typesense-bundle",
@@ -13473,21 +13473,20 @@
         },
         {
             "name": "picqer/php-barcode-generator",
-            "version": "v2.4.2",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/picqer/php-barcode-generator.git",
-                "reference": "e9d39681f617705492b609fc3fc58465ef88e8fd"
+                "reference": "6beada2a30623832ff41b8c7d307c169736b8552"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/picqer/php-barcode-generator/zipball/e9d39681f617705492b609fc3fc58465ef88e8fd",
-                "reference": "e9d39681f617705492b609fc3fc58465ef88e8fd",
+                "url": "https://api.github.com/repos/picqer/php-barcode-generator/zipball/6beada2a30623832ff41b8c7d307c169736b8552",
+                "reference": "6beada2a30623832ff41b8c7d307c169736b8552",
                 "shasum": ""
             },
             "require": {
-                "ext-mbstring": "*",
-                "php": "^8.1"
+                "php": "^8.2"
             },
             "require-dev": {
                 "phpstan/phpstan": "^1.10",
@@ -13510,14 +13509,14 @@
             ],
             "authors": [
                 {
-                    "name": "Nicola Asuni",
-                    "email": "info@tecnick.com",
-                    "homepage": "http://nicolaasuni.tecnick.com"
-                },
-                {
                     "name": "Casper Bakker",
                     "email": "info@picqer.com",
                     "homepage": "https://picqer.com"
+                },
+                {
+                    "name": "Nicola Asuni",
+                    "email": "info@tecnick.com",
+                    "homepage": "http://nicolaasuni.tecnick.com"
                 }
             ],
             "description": "An easy to use, non-bloated, barcode generator in PHP. Creates SVG, PNG, JPG and HTML images from the most used 1D barcode standards.",
@@ -13548,15 +13547,9 @@
             ],
             "support": {
                 "issues": "https://github.com/picqer/php-barcode-generator/issues",
-                "source": "https://github.com/picqer/php-barcode-generator/tree/v2.4.2"
+                "source": "https://github.com/picqer/php-barcode-generator/tree/v3.3.0"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/casperbakker",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-09-18T08:09:33+00:00"
+            "time": "2026-08-22T09:50:32+00:00"
         },
         {
             "name": "ppshobi/psonic",


### PR DESCRIPTION
## Summary

- upgrade `picqer/php-barcode-generator` from `^2.4` to `^3.2`
- update the lockfile from v2.4.2 to v3.3.0

CoopCycle requires PHP 8.2 or newer, which satisfies the v3 PHP requirement. The existing `BarcodeGeneratorSVG::getBarcode()` API remains supported.

## Validation

- `composer validate --strict` (passes with existing manifest warnings)
- exercised the SVG generation and barcode-width parsing path against v3.3.0 successfully
- `git diff --check`